### PR TITLE
V0.3 dev

### DIFF
--- a/src/acvp_lcl.h
+++ b/src/acvp_lcl.h
@@ -96,7 +96,7 @@
 #define ACVP_DRBG_PER_SO_MAX     256
 #define ACVP_DRBG_ADDI_IN_MAX    256
 
-#define ACVP_HASH_MSG_MAX       1024
+#define ACVP_HASH_MSG_MAX       12800
 #define ACVP_HASH_MD_MAX        64
 
 #define ACVP_KAT_BUF_MAX        1024*1024


### PR DESCRIPTION
When implementing SHA AFT tests - the "long message" tests from the former SHAVS can be up to 51200 bits long (6400 Bytes).  To accommodate the size of the "msg" coming in we need this value to be twice the max size - therefore we need to bump this up to 12800 bytes.