### PR TITLE
Add log levels, prereq for AEAD ciphers and SHA parms set

### DIFF
--- a/src/acvp.h
+++ b/src/acvp.h
@@ -35,6 +35,14 @@ extern "C"
 {
 #endif
 
+typedef enum acvp_log_lvl {
+    ACVP_LOG_LVL_NONE = 0,
+    ACVP_LOG_LVL_ERR,
+    ACVP_LOG_LVL_WARN,
+    ACVP_LOG_LVL_STATUS,
+    ACVP_LOG_LVL_INFO,
+} ACVP_LOG_LVL;
+
 /*! @struct ACVP_CTX
  *  @brief This opaque structure is used to maintain the state of a test session
  *         with an ACVP server.  A single instance of this context
@@ -117,6 +125,13 @@ typedef enum acvp_sym_cipher {
     ACVP_CIPHER_END,
 } ACVP_CIPHER;
 
+#define ACVP_SYM_PREREQ_AES_STR      "AES"
+#define ACVP_SYM_PREREQ_DRBG_STR     "DRBG"
+typedef enum acvp_sym_pre_req {
+    ACVP_SYM_PREREQ_AES = 1,
+    ACVP_SYM_PREREQ_DRBG
+} ACVP_SYM_PRE_REQ;
+
 /*
  * Used to help manage capability structures
  */
@@ -165,6 +180,11 @@ typedef enum acvp_sym_cipher_direction {
     ACVP_DIR_DECRYPT,
     ACVP_DIR_BOTH
 } ACVP_SYM_CIPH_DIR;
+
+typedef enum acvp_hash_param {
+    ACVP_HASH_IN_BIT = 0,
+    ACVP_HASH_IN_EMPTY
+} ACVP_HASH_PARM;
 
 /*
  * These are the available DRBG algorithms that libacvp supports.  The application
@@ -488,6 +508,10 @@ ACVP_RESULT acvp_enable_sym_cipher_cap_parm(
 	ACVP_SYM_CIPH_PARM parm,
 	int length);
 
+ACVP_RESULT acvp_enable_sym_prereq_cap(ACVP_CTX *ctx,
+                                       ACVP_CIPHER      cipher,
+                              	       ACVP_SYM_PRE_REQ pre_req_cap,
+                              	       char              *value);
 
 /*! @brief acvp_enable_hash_cap() allows an application to specify a
        hash capability to be tested by the ACVP server.
@@ -513,6 +537,14 @@ ACVP_RESULT acvp_enable_hash_cap(
 	ACVP_CTX *ctx,
 	ACVP_CIPHER cipher,
         ACVP_RESULT (*crypto_handler)(ACVP_TEST_CASE *test_case));
+
+ACVP_RESULT acvp_enable_hash_cap_parm (
+		   ACVP_CTX *ctx,
+		   ACVP_CIPHER cipher,
+                   ACVP_HASH_PARM       param,
+                   int                  value);
+
+
 
         /*! @brief acvp_enable_drbg_cap() allows an application to specify a
                hash capability to be tested by the ACVP server.
@@ -618,7 +650,8 @@ ACVP_RESULT acvp_enable_hmac_prereq_cap(
 
     @return ACVP_RESULT
  */
-ACVP_RESULT acvp_create_test_session(ACVP_CTX **ctx, ACVP_RESULT (*progress_cb)(char *msg));
+ACVP_RESULT acvp_create_test_session(ACVP_CTX **ctx, ACVP_RESULT (*progress_cb)(char *msg),
+	                             ACVP_LOG_LVL level);
 
 /*! @brief acvp_free_test_session() releases the memory associated with
        an ACVP_CTX.
@@ -630,6 +663,7 @@ ACVP_RESULT acvp_create_test_session(ACVP_CTX **ctx, ACVP_RESULT (*progress_cb)(
 
     @param ctx Pointer to ACVP_CTX that was previously created by
         calling acvp_create_test_session.
+    @param level Select the debug level, see ACVP_LOG_LVL
 
     @return ACVP_RESULT
  */

--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -153,14 +153,14 @@ static ACVP_RESULT acvp_aes_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
 
     tmp = calloc(1, ACVP_SYM_CT_MAX);
     if (!tmp) {
-        acvp_log_msg(ctx, "Unable to malloc in acvp_aes_output_tc");
+        ACVP_LOG_ERR("Unable to malloc in acvp_aes_output_tc");
         return ACVP_MALLOC_FAIL;
     }
 
     memset(tmp, 0x0, ACVP_SYM_CT_MAX);
     rv = acvp_bin_to_hexstr(stc->key, stc->key_len/8, (unsigned char*)tmp);
     if (rv != ACVP_SUCCESS) {
-	acvp_log_msg(ctx, "hex conversion failure (key)");
+	ACVP_LOG_ERR("hex conversion failure (key)");
 	return rv;
     }
     json_object_set_string(r_tobj, "key", tmp);
@@ -169,7 +169,7 @@ static ACVP_RESULT acvp_aes_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
         memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	rv = acvp_bin_to_hexstr(stc->iv, stc->iv_len, (unsigned char*)tmp);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "hex conversion failure (iv)");
+	    ACVP_LOG_ERR("hex conversion failure (iv)");
 	    return rv;
         }
         json_object_set_string(r_tobj, "iv", tmp);
@@ -179,7 +179,7 @@ static ACVP_RESULT acvp_aes_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
 	memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, (unsigned char*)tmp);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "hex conversion failure (pt)");
+	    ACVP_LOG_ERR("hex conversion failure (pt)");
 	    return rv;
 	}
 	json_object_set_string(r_tobj, "pt", tmp);
@@ -188,7 +188,7 @@ static ACVP_RESULT acvp_aes_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
 	memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, (unsigned char*)tmp);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "hex conversion failure (ct)");
+	    ACVP_LOG_ERR("hex conversion failure (ct)");
 	    return rv;
 	}
 	json_object_set_string(r_tobj, "ct", tmp);
@@ -219,7 +219,7 @@ static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
 
     tmp = calloc(1, ACVP_SYM_CT_MAX);
     if (!tmp) {
-        acvp_log_msg(ctx, "Unable to malloc in acvp_aes_output_tc");
+        ACVP_LOG_ERR("Unable to malloc in acvp_aes_output_tc");
         return ACVP_MALLOC_FAIL;
     }
 
@@ -237,7 +237,7 @@ static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
          */
         rv = acvp_aes_output_mct_tc(ctx, stc, r_tobj);
 	if (rv != ACVP_SUCCESS) {
-            acvp_log_msg(ctx, "ERROR: JSON output failure in AES module");
+            ACVP_LOG_ERR("JSON output failure in AES module");
             return rv;
         }
 
@@ -247,7 +247,7 @@ static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
             /* Process the current AES encrypt test vector... */
             rv = (cap->crypto_handler)(tc);
             if (rv != ACVP_SUCCESS) {
-                acvp_log_msg(ctx, "ERROR: crypto module failed the operation");
+                ACVP_LOG_ERR("crypto module failed the operation");
                 return ACVP_CRYPTO_MODULE_FAIL;
             }
 
@@ -256,7 +256,7 @@ static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
 	     */
 	    rv = acvp_aes_mct_iterate_tc(ctx, stc, i);
 	    if (rv != ACVP_SUCCESS) {
-                acvp_log_msg(ctx, "ERROR: Failed the MCT iteration changes");
+                ACVP_LOG_ERR("Failed the MCT iteration changes");
                 return rv;
 	    }
         }
@@ -267,7 +267,7 @@ static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
 	    memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	    rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, (unsigned char*)tmp);
 	    if (rv != ACVP_SUCCESS) {
-	        acvp_log_msg(ctx, "hex conversion failure (ct)");
+	        ACVP_LOG_ERR("hex conversion failure (ct)");
 		return rv;
 	    }
 	    json_object_set_string(r_tobj, "ct", tmp);
@@ -303,7 +303,7 @@ static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
 	    memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	    rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, (unsigned char*)tmp);
 	    if (rv != ACVP_SUCCESS) {
-	        acvp_log_msg(ctx, "hex conversion failure (pt)");
+	        ACVP_LOG_ERR("hex conversion failure (pt)");
 		return rv;
 	    }
 	    json_object_set_string(r_tobj, "pt", tmp);
@@ -393,7 +393,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     ACVP_SYM_CIPH_TESTTYPE test_type;
 
     if (!alg_str) {
-        acvp_log_msg(ctx, "ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
 	return (ACVP_MALFORMED_JSON);
     }
 
@@ -406,7 +406,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
         } else if (!strncmp(dir_str, "decrypt", 7)) {
 	    dir = ACVP_DIR_DECRYPT;
         } else {
-            acvp_log_msg(ctx, "ERROR: unsupported direction requested from server (%s)", dir_str);
+            ACVP_LOG_ERR("unsupported direction requested from server (%s)", dir_str);
             //return (ACVP_UNSUPPORTED_OP);
         }
     }
@@ -420,12 +420,12 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
      */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id < ACVP_CIPHER_START) {
-        acvp_log_msg(ctx, "ERROR: unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
         return (ACVP_UNSUPPORTED_OP);
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        acvp_log_msg(ctx, "ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return (ACVP_UNSUPPORTED_OP);
     }
 
@@ -434,7 +434,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        acvp_log_msg(ctx, "ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
         return(rv);
     }
 
@@ -472,7 +472,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     	    } else if (!strncmp(dir_str2, "decrypt", 7)) {
 	        dir = ACVP_DIR_DECRYPT;
     	    } else {
-                acvp_log_msg(ctx, "ERROR: unsupported direction requested from server (%s)", dir_str2);
+                ACVP_LOG_ERR("unsupported direction requested from server (%s)", dir_str2);
                 return (ACVP_UNSUPPORTED_OP);
             }
         }
@@ -486,21 +486,21 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
         taglen = (unsigned int)json_object_get_number(groupobj, "tagLen");
         test_type = (unsigned int)json_object_get_number(groupobj, "testType");
 
-        acvp_log_msg(ctx, "    Test group: %d", i);
-        acvp_log_msg(ctx, "        keylen: %d", keylen);
-        acvp_log_msg(ctx, "         ivlen: %d", ivlen);
-        acvp_log_msg(ctx, "         ptlen: %d", ptlen);
-        acvp_log_msg(ctx, "        aadlen: %d", aadlen);
-        acvp_log_msg(ctx, "        taglen: %d", taglen);
-        acvp_log_msg(ctx, "         dir:   %s", dir_str);
-        acvp_log_msg(ctx, "      testtype: %d", test_type);
+        ACVP_LOG_INFO("    Test group: %d", i);
+        ACVP_LOG_INFO("        keylen: %d", keylen);
+        ACVP_LOG_INFO("         ivlen: %d", ivlen);
+        ACVP_LOG_INFO("         ptlen: %d", ptlen);
+        ACVP_LOG_INFO("        aadlen: %d", aadlen);
+        ACVP_LOG_INFO("        taglen: %d", taglen);
+        ACVP_LOG_INFO("         dir:   %s", dir_str);
+        ACVP_LOG_INFO("      testtype: %d", test_type);
 
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
 
         for (j = 0; j < t_cnt; j++) {
-            acvp_log_msg(ctx, "Found new AES test vector...");
+            ACVP_LOG_INFO("Found new AES test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -516,14 +516,14 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
             }
             aad = (unsigned char *)json_object_get_string(testobj, "aad");
 
-            acvp_log_msg(ctx, "        Test case: %d", j);
-            acvp_log_msg(ctx, "            tcId: %d", tc_id);
-            acvp_log_msg(ctx, "              key: %s", key);
-            acvp_log_msg(ctx, "               pt: %s", pt);
-            acvp_log_msg(ctx, "               ct: %s", ct);
-            acvp_log_msg(ctx, "               iv: %s", iv);
-            acvp_log_msg(ctx, "              tag: %s", tag);
-            acvp_log_msg(ctx, "              aad: %s", aad);
+            ACVP_LOG_INFO("        Test case: %d", j);
+            ACVP_LOG_INFO("            tcId: %d", tc_id);
+            ACVP_LOG_INFO("              key: %s", key);
+            ACVP_LOG_INFO("               pt: %s", pt);
+            ACVP_LOG_INFO("               ct: %s", ct);
+            ACVP_LOG_INFO("               iv: %s", iv);
+            ACVP_LOG_INFO("              tag: %s", tag);
+            ACVP_LOG_INFO("              aad: %s", aad);
 
             /*
              * Create a new test case in the response
@@ -548,7 +548,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 		res_tarr = json_object_get_array(r_tobj, "resultsArray");
 	        rv = acvp_aes_mct_tc(ctx, cap, &tc, &stc, res_tarr);
 		if (rv != ACVP_SUCCESS) {
-		    acvp_log_msg(ctx, "ERROR: crypto module failed the MCT operation");
+		    ACVP_LOG_ERR("crypto module failed the MCT operation");
 		    return ACVP_CRYPTO_MODULE_FAIL;
                 }
 
@@ -557,7 +557,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
                 /* Process the current AES KAT test vector... */
 		rv = (cap->crypto_handler)(&tc);
 		if (rv != ACVP_SUCCESS) {
-		    acvp_log_msg(ctx, "ERROR: crypto module failed the operation");
+		    ACVP_LOG_ERR("crypto module failed the operation");
 		    return ACVP_CRYPTO_MODULE_FAIL;
                 }
 
@@ -566,7 +566,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 		 */
 		rv = acvp_aes_output_tc(ctx, &stc, r_tobj);
 		if (rv != ACVP_SUCCESS) {
-                    acvp_log_msg(ctx, "ERROR: JSON output failure in AES module");
+                    ACVP_LOG_ERR("JSON output failure in AES module");
                     return rv;
                 }
 	    }
@@ -582,8 +582,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     }
     json_array_append_value(reg_arry, r_vs_val);
 
-    //FIXME
-    printf("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+    ACVP_LOG_INFO("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
 
     return ACVP_SUCCESS;
 }
@@ -601,7 +600,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, JS
 
     tmp = calloc(1, ACVP_SYM_CT_MAX);
     if (!tmp) {
-        acvp_log_msg(ctx, "Unable to malloc in acvp_aes_output_tc");
+        ACVP_LOG_ERR("Unable to malloc in acvp_aes_output_tc");
         return ACVP_MALLOC_FAIL;
     }
 
@@ -612,7 +611,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, JS
 	if (stc->cipher != ACVP_AES_KW) {
 	    rv = acvp_bin_to_hexstr(stc->iv, stc->iv_len, (unsigned char*)tmp);
 	    if (rv != ACVP_SUCCESS) {
-		acvp_log_msg(ctx, "hex conversion failure (iv)");
+		ACVP_LOG_ERR("hex conversion failure (iv)");
 		return rv;
 	    }
 	    json_object_set_string(tc_rsp, "iv", tmp);
@@ -621,7 +620,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, JS
 	memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, (unsigned char*)tmp);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "hex conversion failure (ct)");
+	    ACVP_LOG_ERR("hex conversion failure (ct)");
 	    return rv;
 	}
 	json_object_set_string(tc_rsp, "ct", tmp);
@@ -633,7 +632,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, JS
 	    memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	    rv = acvp_bin_to_hexstr(stc->tag, stc->tag_len, (unsigned char*)tmp);
 	    if (rv != ACVP_SUCCESS) {
-		acvp_log_msg(ctx, "hex conversion failure (tag)");
+		ACVP_LOG_ERR("hex conversion failure (tag)");
 		return rv;
 	    }
 	    json_object_set_string(tc_rsp, "tag", tmp);
@@ -641,7 +640,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, JS
     } else {
 	rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, (unsigned char*)tmp);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "hex conversion failure (pt)");
+	    ACVP_LOG_ERR("hex conversion failure (pt)");
 	    return rv;
 	}
 	json_object_set_string(tc_rsp, "pt", tmp);
@@ -701,14 +700,14 @@ static ACVP_RESULT acvp_aes_init_tc(ACVP_CTX *ctx,
 
     rv = acvp_hexstr_to_bin((const unsigned char *)j_key, stc->key, ACVP_SYM_KEY_MAX);
     if (rv != ACVP_SUCCESS) {
-        acvp_log_msg(ctx, "Hex conversion failure (key)");
+        ACVP_LOG_ERR("Hex conversion failure (key)");
         return rv;
     }
 
     if (j_pt) {
 	rv = acvp_hexstr_to_bin((const unsigned char *)j_pt, stc->pt, ACVP_SYM_PT_MAX);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "Hex conversion failure (pt)");
+	    ACVP_LOG_ERR("Hex conversion failure (pt)");
 	    return rv;
 	}
     }
@@ -716,7 +715,7 @@ static ACVP_RESULT acvp_aes_init_tc(ACVP_CTX *ctx,
     if (j_ct) {
 	rv = acvp_hexstr_to_bin((const unsigned char *)j_ct, stc->ct, ACVP_SYM_CT_MAX);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "Hex conversion failure (ct)");
+	    ACVP_LOG_ERR("Hex conversion failure (ct)");
 	    return rv;
 	}
     }
@@ -724,7 +723,7 @@ static ACVP_RESULT acvp_aes_init_tc(ACVP_CTX *ctx,
     if (j_iv) {
 	rv = acvp_hexstr_to_bin((const unsigned char *)j_iv, stc->iv, ACVP_SYM_IV_MAX);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "Hex conversion failure (iv)");
+	    ACVP_LOG_ERR("Hex conversion failure (iv)");
 	    return rv;
 	}
     }
@@ -732,7 +731,7 @@ static ACVP_RESULT acvp_aes_init_tc(ACVP_CTX *ctx,
     if (j_tag) {
 	rv = acvp_hexstr_to_bin((const unsigned char *)j_tag, stc->tag, ACVP_SYM_TAG_MAX);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "Hex conversion failure (tag)");
+	    ACVP_LOG_ERR("Hex conversion failure (tag)");
 	    return rv;
 	}
     }
@@ -740,7 +739,7 @@ static ACVP_RESULT acvp_aes_init_tc(ACVP_CTX *ctx,
     if (j_aad) {
 	rv = acvp_hexstr_to_bin((const unsigned char *)j_aad, stc->aad, ACVP_SYM_AAD_MAX);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "Hex conversion failure (aad)");
+	    ACVP_LOG_ERR("Hex conversion failure (aad)");
 	    return rv;
 	}
     }

--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -149,14 +149,14 @@ static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
 
     tmp = calloc(1, ACVP_SYM_CT_MAX);
     if (!tmp) {
-        acvp_log_msg(ctx, "Unable to malloc in acvp_des_output_tc");
+        ACVP_LOG_ERR("Unable to malloc in acvp_des_output_tc");
         return ACVP_MALLOC_FAIL;
     }
 
     memset(tmp, 0x0, ACVP_SYM_CT_MAX);
     rv = acvp_bin_to_hexstr(stc->key, stc->key_len/8, (unsigned char*)tmp);
     if (rv != ACVP_SUCCESS) {
-	acvp_log_msg(ctx, "hex conversion failure (key)");
+	ACVP_LOG_ERR("hex conversion failure (key)");
 	return rv;
     }
     json_object_set_string(r_tobj, "key", tmp);
@@ -165,7 +165,7 @@ static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
         memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	rv = acvp_bin_to_hexstr(stc->iv, stc->iv_len, (unsigned char*)tmp);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "hex conversion failure (iv)");
+	    ACVP_LOG_ERR("hex conversion failure (iv)");
 	    return rv;
         }
         json_object_set_string(r_tobj, "iv", tmp);
@@ -175,7 +175,7 @@ static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
 	memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, (unsigned char*)tmp);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "hex conversion failure (pt)");
+	    ACVP_LOG_ERR("hex conversion failure (pt)");
 	    return rv;
 	}
 	json_object_set_string(r_tobj, "pt", tmp);
@@ -183,7 +183,7 @@ static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
 	memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, (unsigned char*)tmp);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "hex conversion failure (ct)");
+	    ACVP_LOG_ERR("hex conversion failure (ct)");
 	    return rv;
 	}
 	json_object_set_string(r_tobj, "ct", tmp);
@@ -240,7 +240,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
 
     tmp = calloc(1, ACVP_SYM_CT_MAX);
     if (!tmp) {
-        acvp_log_msg(ctx, "Unable to malloc in acvp_des_output_tc");
+        ACVP_LOG_ERR("Unable to malloc in acvp_des_output_tc");
         return ACVP_MALLOC_FAIL;
     }
 
@@ -258,7 +258,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
          */
         rv = acvp_des_output_mct_tc(ctx, stc, r_tobj);
 	if (rv != ACVP_SUCCESS) {
-            acvp_log_msg(ctx, "ERROR: JSON output failure in DES module");
+            ACVP_LOG_ERR("JSON output failure in DES module");
             return rv;
         }
 
@@ -271,7 +271,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
             /* Process the current DES encrypt test vector... */
             rv = (cap->crypto_handler)(tc);
             if (rv != ACVP_SUCCESS) {
-                acvp_log_msg(ctx, "ERROR: crypto module failed the operation");
+                ACVP_LOG_ERR("crypto module failed the operation");
                 return ACVP_CRYPTO_MODULE_FAIL;
             }
             /*
@@ -279,7 +279,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
 	     */
 	    rv = acvp_des_mct_iterate_tc(ctx, stc, i, r_tobj);
 	    if (rv != ACVP_SUCCESS) {
-                acvp_log_msg(ctx, "ERROR: Failed the MCT iteration changes");
+                ACVP_LOG_ERR("Failed the MCT iteration changes");
                 return rv;
 	    }
         }
@@ -322,7 +322,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
 	    memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	    rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, (unsigned char*)tmp);
 	    if (rv != ACVP_SUCCESS) {
-	        acvp_log_msg(ctx, "hex conversion failure (ct)");
+	        ACVP_LOG_ERR("hex conversion failure (ct)");
 		return rv;
 	    }
 	    json_object_set_string(r_tobj, "ct", tmp);
@@ -333,7 +333,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
 	    memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	    rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, (unsigned char*)tmp);
 	    if (rv != ACVP_SUCCESS) {
-	        acvp_log_msg(ctx, "hex conversion failure (pt)");
+	        ACVP_LOG_ERR("hex conversion failure (pt)");
 		return rv;
 	    }
 	    json_object_set_string(r_tobj, "pt", tmp);
@@ -390,7 +390,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     ACVP_SYM_CIPH_TESTTYPE test_type;
 
     if (!alg_str) {
-        acvp_log_msg(ctx, "ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
 	return (ACVP_MALFORMED_JSON);
     }
 
@@ -402,7 +402,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     } else if (!strncmp(dir_str, "decrypt", 7)) {
 	dir = ACVP_DIR_DECRYPT;
     } else {
-        acvp_log_msg(ctx, "ERROR: unsupported direction requested from server (%s)", dir_str);
+        ACVP_LOG_ERR("unsupported direction requested from server (%s)", dir_str);
         //return (ACVP_UNSUPPORTED_OP);
     }
 
@@ -416,12 +416,12 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
      */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id < ACVP_CIPHER_START) {
-        acvp_log_msg(ctx, "ERROR: unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
         return (ACVP_UNSUPPORTED_OP);
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        acvp_log_msg(ctx, "ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return (ACVP_UNSUPPORTED_OP);
     }
 
@@ -430,7 +430,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        acvp_log_msg(ctx, "ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
         return(rv);
     }
 
@@ -469,7 +469,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     	    } else if (!strncmp(dir_str, "decrypt", 7)) {
 	        dir = ACVP_DIR_DECRYPT;
     	    } else {
-                acvp_log_msg(ctx, "ERROR: unsupported direction requested from server (%s)", dir_str);
+                ACVP_LOG_ERR("unsupported direction requested from server (%s)", dir_str);
                 return (ACVP_UNSUPPORTED_OP);
             }
         }
@@ -479,17 +479,17 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
         ptlen = (unsigned int)json_object_get_number(groupobj, "ptLen");
         test_type = (unsigned int)json_object_get_number(groupobj, "testType");
 
-        acvp_log_msg(ctx, "    Test group: %d", i);
-        acvp_log_msg(ctx, "        keylen: %d", keylen);
-        acvp_log_msg(ctx, "         ivlen: %d", ivlen);
-        acvp_log_msg(ctx, "         ptlen: %d", ptlen);
-        acvp_log_msg(ctx, "         dir:   %s", dir_str);
-        acvp_log_msg(ctx, "      testtype: %d", test_type);
+        ACVP_LOG_INFO("    Test group: %d", i);
+        ACVP_LOG_INFO("        keylen: %d", keylen);
+        ACVP_LOG_INFO("         ivlen: %d", ivlen);
+        ACVP_LOG_INFO("         ptlen: %d", ptlen);
+        ACVP_LOG_INFO("         dir:   %s", dir_str);
+        ACVP_LOG_INFO("      testtype: %d", test_type);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
         for (j = 0; j < t_cnt; j++) {
-            acvp_log_msg(ctx, "Found new 3DES test vector...");
+            ACVP_LOG_INFO("Found new 3DES test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -503,12 +503,12 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 		iv = (unsigned char *)json_object_get_string(testobj, "iv");
             }
 
-            acvp_log_msg(ctx, "        Test case: %d", j);
-            acvp_log_msg(ctx, "            tcId: %d", tc_id);
-            acvp_log_msg(ctx, "              key: %s", key);
-            acvp_log_msg(ctx, "               pt: %s", pt);
-            acvp_log_msg(ctx, "               ct: %s", ct);
-            acvp_log_msg(ctx, "               iv: %s", iv);
+            ACVP_LOG_INFO("        Test case: %d", j);
+            ACVP_LOG_INFO("            tcId: %d", tc_id);
+            ACVP_LOG_INFO("              key: %s", key);
+            ACVP_LOG_INFO("               pt: %s", pt);
+            ACVP_LOG_INFO("               ct: %s", ct);
+            ACVP_LOG_INFO("               iv: %s", iv);
 
             /*
              * Create a new test case in the response
@@ -533,7 +533,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 		res_tarr = json_object_get_array(r_tobj, "resultsArray");
 	        rv = acvp_des_mct_tc(ctx, cap, &tc, &stc, res_tarr);
 		if (rv != ACVP_SUCCESS) {
-		    acvp_log_msg(ctx, "ERROR: crypto module failed the DES MCT operation");
+		    ACVP_LOG_ERR("crypto module failed the DES MCT operation");
 		    return ACVP_CRYPTO_MODULE_FAIL;
                 }
 
@@ -542,7 +542,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
             /* Process the current DES encrypt test vector... */
             rv = (cap->crypto_handler)(&tc);
             if (rv != ACVP_SUCCESS) {
-                acvp_log_msg(ctx, "ERROR: crypto module failed the operation");
+                ACVP_LOG_ERR("crypto module failed the operation");
                 return ACVP_CRYPTO_MODULE_FAIL;
             }
 
@@ -551,7 +551,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
              */
             rv = acvp_des_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                acvp_log_msg(ctx, "ERROR: JSON output failure in 3DES module");
+                ACVP_LOG_ERR("JSON output failure in 3DES module");
                 return rv;
             }
 	}
@@ -566,8 +566,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
         }
     }
 
-    //FIXME
-    printf("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+    ACVP_LOG_INFO("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
 
     return ACVP_SUCCESS;
 }
@@ -585,14 +584,14 @@ static ACVP_RESULT acvp_des_output_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, JS
 
     tmp = calloc(1, ACVP_SYM_CT_MAX);
     if (!tmp) {
-        acvp_log_msg(ctx, "Unable to malloc in acvp_des_output_tc");
+        ACVP_LOG_ERR("Unable to malloc in acvp_des_output_tc");
         return ACVP_MALLOC_FAIL;
     }
 
     if (stc->direction == ACVP_DIR_ENCRYPT) {
 	rv = acvp_bin_to_hexstr(stc->iv, stc->iv_len, (unsigned char*)tmp);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "hex conversion failure (iv)");
+	    ACVP_LOG_ERR("hex conversion failure (iv)");
 	    return rv;
 	}
 	json_object_set_string(tc_rsp, "iv", tmp);
@@ -600,14 +599,14 @@ static ACVP_RESULT acvp_des_output_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, JS
 	memset(tmp, 0x0, ACVP_SYM_CT_MAX);
 	rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, (unsigned char*)tmp);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "hex conversion failure (ct)");
+	    ACVP_LOG_ERR("hex conversion failure (ct)");
 	    return rv;
 	}
 	json_object_set_string(tc_rsp, "ct", tmp);
     } else {
 	rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, (unsigned char*)tmp);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "hex conversion failure (pt)");
+	    ACVP_LOG_ERR("hex conversion failure (pt)");
 	    return rv;
 	}
 	json_object_set_string(tc_rsp, "pt", tmp);
@@ -658,14 +657,14 @@ static ACVP_RESULT acvp_des_init_tc(ACVP_CTX *ctx,
 
     rv = acvp_hexstr_to_bin((const unsigned char *)j_key, stc->key, ACVP_SYM_KEY_MAX);
     if (rv != ACVP_SUCCESS) {
-        acvp_log_msg(ctx, "Hex converstion failure (key)");
+        ACVP_LOG_ERR("Hex converstion failure (key)");
         return rv;
     }
 
     if (j_pt) {
 	rv = acvp_hexstr_to_bin((const unsigned char *)j_pt, stc->pt, ACVP_SYM_PT_MAX);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "Hex converstion failure (pt)");
+	    ACVP_LOG_ERR("Hex converstion failure (pt)");
 	    return rv;
 	}
     }
@@ -673,7 +672,7 @@ static ACVP_RESULT acvp_des_init_tc(ACVP_CTX *ctx,
     if (j_ct) {
 	rv = acvp_hexstr_to_bin((const unsigned char *)j_ct, stc->ct, ACVP_SYM_CT_MAX);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "Hex converstion failure (ct)");
+	    ACVP_LOG_ERR("Hex converstion failure (ct)");
 	    return rv;
 	}
     }
@@ -681,7 +680,7 @@ static ACVP_RESULT acvp_des_init_tc(ACVP_CTX *ctx,
     if (j_iv) {
 	rv = acvp_hexstr_to_bin((const unsigned char *)j_iv, stc->iv, ACVP_SYM_IV_MAX);
 	if (rv != ACVP_SUCCESS) {
-	    acvp_log_msg(ctx, "Hex converstion failure (iv)");
+	    ACVP_LOG_ERR("Hex converstion failure (iv)");
 	    return rv;
 	}
     }

--- a/src/acvp_drbg.c
+++ b/src/acvp_drbg.c
@@ -107,16 +107,16 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     ACVP_DRBG_MODE      mode_id;
 
     if (!alg_str) {
-        acvp_log_msg(ctx, "ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return (ACVP_MALFORMED_JSON);
     }
 
     if (!mode_str) {
-        acvp_log_msg(ctx, "ERROR: unable to parse DRBG 'mode' from JSON");
+        ACVP_LOG_ERR("unable to parse DRBG 'mode' from JSON");
         return (ACVP_MALFORMED_JSON);
     }
 
-    acvp_log_msg(ctx, "    DRBG alg: %s", alg_str);
+    ACVP_LOG_INFO("    DRBG alg: %s", alg_str);
 
     /*
      * Get a reference to the abstracted test case
@@ -128,7 +128,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
      */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if ((alg_id < ACVP_HASHDRBG) || (alg_id > ACVP_CTRDRBG)) {
-        acvp_log_msg(ctx, "ERROR: unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
         return (ACVP_UNSUPPORTED_OP);
     }
     /*
@@ -136,13 +136,13 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
      */
     mode_id = acvp_lookup_drbg_mode_index(mode_str);
     if (mode_id == ACVP_DRBG_MODE_END) {
-        acvp_log_msg(ctx, "ERROR: unsupported DRBG mode (%s)", mode_str);
+        ACVP_LOG_ERR("unsupported DRBG mode (%s)", mode_str);
         return (ACVP_UNSUPPORTED_OP);
     }
 
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        acvp_log_msg(ctx, "ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return (ACVP_UNSUPPORTED_OP);
     }
 
@@ -153,7 +153,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        acvp_log_msg(ctx, "ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
         return(rv);
     }
 
@@ -176,13 +176,13 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 
     groups = json_object_get_array(obj, "testGroups");
     g_cnt = json_array_get_count(groups);
-    acvp_log_msg(ctx, "Number of TestGroups: %d", g_cnt);
+    ACVP_LOG_INFO("Number of TestGroups: %d", g_cnt);
     for (i = 0; i < g_cnt; i++) {
         groupval = json_array_get_value(groups, i);
         groupobj = json_value_get_object(groupval);
 
         char *reg = json_serialize_to_string_pretty(groupval);
-        printf("json groupval count: %d\n %s\n", i, reg);
+        ACVP_LOG_INFO("json groupval count: %d\n %s\n", i, reg);
 
         /*
          * Handle Group Params
@@ -196,7 +196,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 
         if ((!der_func_str) || (!pred_resist_str))
         {
-            acvp_log_msg(ctx, "ERROR: ACVP server requesting unsupported PR or DF capability");
+            ACVP_LOG_ERR("ACVP server requesting unsupported PR or DF capability");
             return (ACVP_UNSUPPORTED_OP);
         }
 
@@ -208,15 +208,15 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
             additional_input_len  = json_object_get_number(groupobj, "additionalInputLen");
         }
 
-        acvp_log_msg(ctx, "    Test group:");
-        acvp_log_msg(ctx, "    DRBG mode: %s", mode_str);
-        acvp_log_msg(ctx, "    derFunc: %s", der_func_str);
-        acvp_log_msg(ctx, "    predResistance: %s", pred_resist_str);
-        acvp_log_msg(ctx, "    entropyInputLen: %d", entropy_len);
-        acvp_log_msg(ctx, "    additionalInputLen: %d", additional_input_len);
-        acvp_log_msg(ctx, "    persoStringLen: %d", perso_string_len);
-        acvp_log_msg(ctx, "    nonceLen: %d", nonce_len);
-        acvp_log_msg(ctx, "    returnedBitsLen: %d", drb_len);
+        ACVP_LOG_INFO("    Test group:");
+        ACVP_LOG_INFO("    DRBG mode: %s", mode_str);
+        ACVP_LOG_INFO("    derFunc: %s", der_func_str);
+        ACVP_LOG_INFO("    predResistance: %s", pred_resist_str);
+        ACVP_LOG_INFO("    entropyInputLen: %d", entropy_len);
+        ACVP_LOG_INFO("    additionalInputLen: %d", additional_input_len);
+        ACVP_LOG_INFO("    persoStringLen: %d", perso_string_len);
+        ACVP_LOG_INFO("    nonceLen: %d", nonce_len);
+        ACVP_LOG_INFO("    returnedBitsLen: %d", drb_len);
         //TODO: Sanity check alg/mode mismatch
 
         /*
@@ -224,9 +224,9 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
          */
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
-        acvp_log_msg(ctx, "Number of Tests: %d", g_cnt);
+        ACVP_LOG_INFO("Number of Tests: %d", g_cnt);
         for (j = 0; j < t_cnt; j++) {
-            acvp_log_msg(ctx, "Found new DRBG test vector...");
+            ACVP_LOG_INFO("Found new DRBG test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -238,11 +238,11 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
             entropy = (unsigned char *)json_object_get_string(testobj, "entropyInput");
             nonce = (unsigned char *)json_object_get_string(testobj, "nonce");
 
-            acvp_log_msg(ctx, "        Test case: %d", j);
-            acvp_log_msg(ctx, "             tcId: %d", tc_id);
-            acvp_log_msg(ctx, "             entropyInput: %s", entropy);
-            acvp_log_msg(ctx, "             perso_string: %s", perso_string);
-            acvp_log_msg(ctx, "             nonce: %s", nonce);
+            ACVP_LOG_INFO("        Test case: %d", j);
+            ACVP_LOG_INFO("             tcId: %d", tc_id);
+            ACVP_LOG_INFO("             entropyInput: %s", entropy);
+            ACVP_LOG_INFO("             perso_string: %s", perso_string);
+            ACVP_LOG_INFO("             nonce: %s", nonce);
 
             /*
              * Handle pred_resist_input array. Has at most 2 elements
@@ -253,7 +253,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
             JSON_Object  *pr_input_obj;
 
             int pr_i = 0;
-            acvp_log_msg(ctx, "Found new DRBG Prediction Input...");
+            ACVP_LOG_INFO("Found new DRBG Prediction Input...");
             pr_input_val = json_array_get_value(pred_resist_input, pr_i);
             pr_input_obj = json_value_get_object(pr_input_val);
 
@@ -305,7 +305,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
             /* Process the current test vector... */
             rv = (cap->crypto_handler)(&tc);
             if (rv != ACVP_SUCCESS) {
-                acvp_log_msg(ctx, "ERROR: crypto module failed the operation");
+                ACVP_LOG_ERR("crypto module failed the operation");
                 return ACVP_CRYPTO_MODULE_FAIL;
             }
 
@@ -314,7 +314,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
              */
             rv = acvp_drbg_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                acvp_log_msg(ctx, "ERROR: JSON output failure in DRBG module");
+                ACVP_LOG_ERR("JSON output failure in DRBG module");
                 return rv;
             }
 
@@ -330,8 +330,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     }
     json_array_append_value(reg_arry, r_vs_val);
 
-    //FIXME
-    printf("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+    ACVP_LOG_INFO("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
 
     return ACVP_SUCCESS;
 }
@@ -349,13 +348,13 @@ static ACVP_RESULT acvp_drbg_output_tc(ACVP_CTX *ctx, ACVP_DRBG_TC *stc, JSON_Ob
 
     tmp = calloc(1, 2*ACVP_DRB_MAX);
     if (!tmp) {
-        acvp_log_msg(ctx, "Unable to malloc in acvp_drbg_output_tc");
+        ACVP_LOG_ERR("Unable to malloc in acvp_drbg_output_tc");
         return ACVP_MALLOC_FAIL;
     }
 
     rv = acvp_bin_to_hexstr(stc->drb, stc->drb_len, (unsigned char*)tmp);
     if (rv != ACVP_SUCCESS) {
-        acvp_log_msg(ctx, "hex conversion failure (returnedBits)");
+        ACVP_LOG_ERR("hex conversion failure (returnedBits)");
         return rv;
     }
     json_object_set_string(tc_rsp, "returnedBits", tmp);
@@ -412,7 +411,7 @@ static ACVP_RESULT acvp_drbg_init_tc(ACVP_CTX *ctx,
         rv = acvp_hexstr_to_bin((const unsigned char *)additional_input,
                 stc->additional_input, ACVP_DRBG_ADDI_IN_MAX);
         if (rv != ACVP_SUCCESS) {
-            acvp_log_msg(ctx, "Hex conversion failure (additional_input)");
+            ACVP_LOG_ERR("Hex conversion failure (additional_input)");
             return rv;
         }
     }
@@ -421,7 +420,7 @@ static ACVP_RESULT acvp_drbg_init_tc(ACVP_CTX *ctx,
         rv = acvp_hexstr_to_bin((const unsigned char *)entropy_input_pr,
                 stc->entropy_input_pr, ACVP_DRBG_ENTPY_IN_MAX);
         if (rv != ACVP_SUCCESS) {
-            acvp_log_msg(ctx, "Hex conversion failure (entropy_input_pr)");
+            ACVP_LOG_ERR("Hex conversion failure (entropy_input_pr)");
             return rv;
         }
     }
@@ -430,7 +429,7 @@ static ACVP_RESULT acvp_drbg_init_tc(ACVP_CTX *ctx,
         rv = acvp_hexstr_to_bin((const unsigned char *)additional_input_1,
                 stc->additional_input_1, ACVP_DRBG_ADDI_IN_MAX);
         if (rv != ACVP_SUCCESS) {
-            acvp_log_msg(ctx, "Hex conversion failure (2nd additional_input)");
+            ACVP_LOG_ERR("Hex conversion failure (2nd additional_input)");
             return rv;
         }
     }
@@ -439,7 +438,7 @@ static ACVP_RESULT acvp_drbg_init_tc(ACVP_CTX *ctx,
         rv = acvp_hexstr_to_bin((const unsigned char *)entropy_input_pr_1,
                 stc->entropy_input_pr_1, ACVP_DRBG_ENTPY_IN_MAX);
         if (rv != ACVP_SUCCESS) {
-            acvp_log_msg(ctx, "Hex conversion failure (2nd entropy_input_pr)");
+            ACVP_LOG_ERR("Hex conversion failure (2nd entropy_input_pr)");
             return rv;
         }
     }
@@ -448,7 +447,7 @@ static ACVP_RESULT acvp_drbg_init_tc(ACVP_CTX *ctx,
         rv = acvp_hexstr_to_bin((const unsigned char *)entropy,
                 stc->entropy, ACVP_DRBG_ENTPY_IN_MAX);
         if (rv != ACVP_SUCCESS) {
-            acvp_log_msg(ctx, "Hex conversion failure (entropy)");
+            ACVP_LOG_ERR("Hex conversion failure (entropy)");
             return rv;
         }
     }
@@ -457,7 +456,7 @@ static ACVP_RESULT acvp_drbg_init_tc(ACVP_CTX *ctx,
         rv = acvp_hexstr_to_bin((const unsigned char *)perso_string,
                 stc->perso_string, ACVP_DRBG_PER_SO_MAX);
         if (rv != ACVP_SUCCESS) {
-            acvp_log_msg(ctx, "Hex conversion failure (perso_string)");
+            ACVP_LOG_ERR("Hex conversion failure (perso_string)");
             return rv;
         }
     }
@@ -466,7 +465,7 @@ static ACVP_RESULT acvp_drbg_init_tc(ACVP_CTX *ctx,
         rv = acvp_hexstr_to_bin((const unsigned char *)nonce,
                 stc->nonce, ACVP_DRBG_NONCE_MAX);
         if (rv != ACVP_SUCCESS) {
-            acvp_log_msg(ctx, "Hex conversion failure (nonce)");
+            ACVP_LOG_ERR("Hex conversion failure (nonce)");
             return rv;
         }
     }

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -49,13 +49,13 @@ static ACVP_RESULT acvp_hash_output_mct_tc(ACVP_CTX *ctx, ACVP_HASH_TC *stc, JSO
 
     tmp = calloc(1, ACVP_HASH_MSG_MAX);
     if (!tmp) {
-        acvp_log_msg(ctx, "Unable to malloc in acvp_hash_output_tc");
+        ACVP_LOG_ERR("Unable to malloc in acvp_hash_output_tc");
         return ACVP_MALLOC_FAIL;
     }
 
     rv = acvp_bin_to_hexstr(stc->md, stc->md_len, (unsigned char*)tmp);
     if (rv != ACVP_SUCCESS) {
-        acvp_log_msg(ctx, "hex conversion failure (msg)");
+        ACVP_LOG_ERR("hex conversion failure (msg)");
         return rv;
     }
     json_object_set_string(r_tobj, "md", tmp);
@@ -83,7 +83,7 @@ static ACVP_RESULT acvp_hash_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
 
     tmp = calloc(1, ACVP_SYM_CT_MAX);
     if (!tmp) {
-        acvp_log_msg(ctx, "Unable to malloc in acvp_des_output_tc");
+        ACVP_LOG_ERR("Unable to malloc in acvp_des_output_tc");
         return ACVP_MALLOC_FAIL;
     }
 
@@ -104,7 +104,7 @@ static ACVP_RESULT acvp_hash_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
             /* Process the current SHA test vector... */
             rv = (cap->crypto_handler)(tc);
             if (rv != ACVP_SUCCESS) {
-                acvp_log_msg(ctx, "ERROR: crypto module failed the operation");
+                ACVP_LOG_ERR("crypto module failed the operation");
                 return ACVP_CRYPTO_MODULE_FAIL;
             }
 
@@ -113,7 +113,7 @@ static ACVP_RESULT acvp_hash_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
 	     */
 	    rv = acvp_hash_mct_iterate_tc(ctx, stc, i, r_tobj);
 	    if (rv != ACVP_SUCCESS) {
-                acvp_log_msg(ctx, "ERROR: Failed the MCT iteration changes");
+                ACVP_LOG_ERR("Failed the MCT iteration changes");
                 return rv;
 	    }
         }
@@ -122,7 +122,7 @@ static ACVP_RESULT acvp_hash_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
          */
         rv = acvp_hash_output_mct_tc(ctx, stc, r_tobj);
 	if (rv != ACVP_SUCCESS) {
-            acvp_log_msg(ctx, "ERROR: JSON output failure in HASH module");
+            ACVP_LOG_ERR("JSON output failure in HASH module");
             return rv;
         }
 
@@ -171,7 +171,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     ACVP_CIPHER	        alg_id;
 
     if (!alg_str) {
-        acvp_log_msg(ctx, "ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
 	return (ACVP_MALFORMED_JSON);
     }
 
@@ -185,12 +185,12 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
      */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id < ACVP_CIPHER_START) {
-        acvp_log_msg(ctx, "ERROR: unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
         return (ACVP_UNSUPPORTED_OP);
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        acvp_log_msg(ctx, "ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return (ACVP_UNSUPPORTED_OP);
     }
 
@@ -199,7 +199,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        acvp_log_msg(ctx, "ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
         return(rv);
     }
 
@@ -226,13 +226,13 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
         groupobj = json_value_get_object(groupval);
 
 
-        acvp_log_msg(ctx, "    Test group: %d", i);
-        acvp_log_msg(ctx, "        msglen: %d", msglen);
+        ACVP_LOG_INFO("    Test group: %d", i);
+        ACVP_LOG_INFO("        msglen: %d", msglen);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
         for (j = 0; j < t_cnt; j++) {
-            acvp_log_msg(ctx, "Found new hash test vector...");
+            ACVP_LOG_INFO("Found new hash test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -241,11 +241,11 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 	    msg = (unsigned char *)json_object_get_string(testobj, "msg");
 	    test_type = (unsigned int)json_object_get_number(groupobj, "testType");
 
-            acvp_log_msg(ctx, "        Test case: %d", j);
-            acvp_log_msg(ctx, "             tcId: %d", tc_id);
-            acvp_log_msg(ctx, "              len: %d", msglen);
-            acvp_log_msg(ctx, "              msg: %s", msg);
-	    acvp_log_msg(ctx, "      testtype: %d", test_type);
+            ACVP_LOG_INFO("        Test case: %d", j);
+            ACVP_LOG_INFO("             tcId: %d", tc_id);
+            ACVP_LOG_INFO("              len: %d", msglen);
+            ACVP_LOG_INFO("              msg: %s", msg);
+	    ACVP_LOG_INFO("      testtype: %d", test_type);
 
             /*
              * Create a new test case in the response
@@ -269,14 +269,14 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 		res_tarr = json_object_get_array(r_tobj, "resultsArray");
 	        rv = acvp_hash_mct_tc(ctx, cap, &tc, &stc, res_tarr);
 		if (rv != ACVP_SUCCESS) {
-		    acvp_log_msg(ctx, "ERROR: crypto module failed the HASH MCT operation");
+		    ACVP_LOG_ERR("crypto module failed the HASH MCT operation");
 		    return ACVP_CRYPTO_MODULE_FAIL;
                 }
 	    } else {
                 /* Process the current test vector... */
 		rv = (cap->crypto_handler)(&tc);
 		if (rv != ACVP_SUCCESS) {
-                    acvp_log_msg(ctx, "ERROR: crypto module failed the operation");
+                    ACVP_LOG_ERR("crypto module failed the operation");
                     return ACVP_CRYPTO_MODULE_FAIL;
                 }
 
@@ -285,7 +285,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 		 */
 		rv = acvp_hash_output_tc(ctx, &stc, r_tobj);
 		if (rv != ACVP_SUCCESS) {
-                    acvp_log_msg(ctx, "ERROR: JSON output failure in hash module");
+                    ACVP_LOG_ERR("JSON output failure in hash module");
                     return rv;
                 }
             }
@@ -300,8 +300,8 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     }
 
     json_array_append_value(reg_arry, r_vs_val);
-    //FIXME
-    printf("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+
+    ACVP_LOG_INFO("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
 
     return ACVP_SUCCESS;
 }
@@ -319,13 +319,13 @@ static ACVP_RESULT acvp_hash_output_tc(ACVP_CTX *ctx, ACVP_HASH_TC *stc, JSON_Ob
 
     tmp = calloc(1, ACVP_HASH_MSG_MAX);
     if (!tmp) {
-        acvp_log_msg(ctx, "Unable to malloc in acvp_hash_output_tc");
+        ACVP_LOG_ERR("Unable to malloc in acvp_hash_output_tc");
         return ACVP_MALLOC_FAIL;
     }
 
     rv = acvp_bin_to_hexstr(stc->md, stc->md_len, (unsigned char*)tmp);
     if (rv != ACVP_SUCCESS) {
-        acvp_log_msg(ctx, "hex conversion failure (msg)");
+        ACVP_LOG_ERR("hex conversion failure (msg)");
         return rv;
     }
     json_object_set_string(tc_rsp, "md", tmp);
@@ -359,7 +359,7 @@ static ACVP_RESULT acvp_hash_init_tc(ACVP_CTX *ctx,
 
     rv = acvp_hexstr_to_bin((const unsigned char *)msg, stc->msg, ACVP_HASH_MSG_MAX);
     if (rv != ACVP_SUCCESS) {
-        acvp_log_msg(ctx, "Hex converstion failure (msg)");
+        ACVP_LOG_ERR("Hex converstion failure (msg)");
         return rv;
     }
 

--- a/src/acvp_lcl.h
+++ b/src/acvp_lcl.h
@@ -30,6 +30,34 @@
 
 #define ACVP_VERSION    "0.3"
 
+#ifndef ACVP_LOG_INFO
+#define ACVP_LOG_INFO(format, args ...) do { \
+        acvp_log_msg(ctx, ACVP_LOG_LVL_INFO, "***ACVP [INFO][%s:%d]--> " format "\n", \
+                __func__, __LINE__, ##args); \
+} while (0)
+#endif
+
+#ifndef ACVP_LOG_ERR
+#define ACVP_LOG_ERR(format, args ...) do { \
+        acvp_log_msg(ctx, ACVP_LOG_LVL_ERR, "***ACVP [ERR][%s:%d]--> " format "\n", \
+                __func__, __LINE__, ##args); \
+} while (0)
+#endif
+
+#ifndef ACVP_LOG_STATUS
+#define ACVP_LOG_STATUS(format, args ...) do { \
+        acvp_log_msg(ctx, ACVP_LOG_LVL_STATUS, "***ACVP [STATUS][%s:%d]--> " format "\n", \
+                __func__, __LINE__, ##args); \
+} while (0)
+#endif
+
+#ifndef ACVP_LOG_WARN
+#define ACVP_LOG_WARN(format, args ...) do { \
+        acvp_log_msg(ctx, ACVP_LOG_LVL_WARN, "***ACVP [WARN][%s:%d]--> " format "\n", \
+                __func__, __LINE__, ##args); \
+} while (0)
+#endif
+
 #define ACVP_ALG_MAX 44  /* Used by alg_tbl[] */
 
 #define ACVP_ALG_AES_ECB             "AES-ECB"
@@ -142,7 +170,18 @@ typedef struct acvp_sl_list_t {
     struct acvp_sl_list_t *next;
 } ACVP_SL_LIST;
 
+typedef struct acvp_sym_prereq_alg_val {
+    ACVP_SYM_PRE_REQ alg;
+    char *val;
+} ACVP_SYM_PREREQ_ALG_VAL;
+
+typedef struct acvp_sym_prereq_vals {
+    ACVP_SYM_PREREQ_ALG_VAL prereq_alg_val;
+    struct acvp_sym_prereq_vals *next;
+} ACVP_SYM_PREREQ_VALS;
+
 typedef struct acvp_sym_cipher_capability {
+    ACVP_SYM_PREREQ_VALS *prereq_vals;
     ACVP_SYM_CIPH_DIR direction;
     ACVP_SYM_CIPH_KO keying_option;
     ACVP_SYM_CIPH_IVGEN_SRC ivgen_source;
@@ -249,6 +288,7 @@ typedef struct acvp_caps_list_t {
  */
 struct acvp_ctx_t {
     /* Global config values for the session */
+    ACVP_LOG_LVL debug;
     char        *server_name;
     char        *path_segment;
     int server_port;
@@ -288,7 +328,7 @@ ACVP_RESULT acvp_send_register(ACVP_CTX *ctx, char *reg);
 ACVP_RESULT acvp_retrieve_vector_set(ACVP_CTX *ctx, int vs_id);
 ACVP_RESULT acvp_retrieve_vector_set_result(ACVP_CTX *ctx, int vs_id);
 ACVP_RESULT acvp_submit_vector_responses(ACVP_CTX *ctx);
-void acvp_log_msg (ACVP_CTX *ctx, const char *format, ...);
+void acvp_log_msg (ACVP_CTX *ctx, ACVP_LOG_LVL level, const char *format, ...);
 ACVP_RESULT acvp_hexstr_to_bin(const unsigned char *src, unsigned char *dest, int dest_max);
 ACVP_RESULT acvp_bin_to_hexstr(const unsigned char *src, unsigned int src_len, unsigned char *dest);
 

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -49,7 +49,7 @@ static struct curl_slist* acvp_add_auth_hdr (ACVP_CTX *ctx, struct curl_slist *s
     	bearer_size = strnlen(ctx->jwt_token, MAX_TOKEN_LEN) + 23;
     	bearer = calloc(1, bearer_size);
 	if (!bearer) {
-	    acvp_log_msg(ctx, "ERROR: unable to allocate memory.");
+	    ACVP_LOG_ERR("unable to allocate memory.");
 	    return slist;
 	}
         snprintf(bearer, bearer_size + 1, "Authorization: Bearer %s", ctx->jwt_token);
@@ -79,10 +79,10 @@ static void acvp_curl_log_peer_cert (ACVP_CTX *ctx, CURL *hnd)
     rv = curl_easy_getinfo(hnd, CURLINFO_CERTINFO, &ptr.to_info);
  
     if(!rv && ptr.to_info) {
-	acvp_log_msg(ctx, "TLS peer presented the following %d certificates...", ptr.to_certinfo->num_of_certs);
+	ACVP_LOG_INFO("TLS peer presented the following %d certificates...", ptr.to_certinfo->num_of_certs);
         for(i = 0; i < ptr.to_certinfo->num_of_certs; i++) {
             for(slist = ptr.to_certinfo->certinfo[i]; slist; slist = slist->next) {
-		acvp_log_msg(ctx, "%s", slist->data);
+		ACVP_LOG_INFO("%s", slist->data);
 	    }
         }
     }
@@ -132,7 +132,7 @@ static long acvp_curl_http_get (ACVP_CTX *ctx, char *url, void *writefunc)
 	curl_easy_setopt(hnd, CURLOPT_CERTINFO, 1L);
     } else {
         curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
-        acvp_log_msg(ctx, "WARNING: TLS peer verification has not been enabled.");
+        ACVP_LOG_WARN("TLS peer verification has not been enabled.\n");
     }
     curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
     if (ctx->tls_cert && ctx->tls_key) {
@@ -168,7 +168,7 @@ static long acvp_curl_http_get (ACVP_CTX *ctx, char *url, void *writefunc)
     curl_easy_getinfo (hnd, CURLINFO_RESPONSE_CODE, &http_code);
 
     if (http_code != HTTP_OK) {
-	acvp_log_msg(ctx, "HTTP response: %d\n", (int)http_code);
+	ACVP_LOG_ERR("HTTP response: %d\n", (int)http_code);
     } 
 
     curl_easy_cleanup(hnd);
@@ -237,7 +237,7 @@ static long acvp_curl_http_post (ACVP_CTX *ctx, char *url, char *data, void *wri
 	curl_easy_setopt(hnd, CURLOPT_CERTINFO, 1L);
     } else {
         curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
-        acvp_log_msg(ctx, "WARNING: TLS peer verification has not been enabled.");
+        ACVP_LOG_WARN("TLS peer verification has not been enabled.");
     }
     curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
     if (ctx->tls_cert && ctx->tls_key) {
@@ -261,7 +261,7 @@ static long acvp_curl_http_post (ACVP_CTX *ctx, char *url, char *data, void *wri
      */
     crv = curl_easy_perform(hnd);
     if (crv != CURLE_OK) {
-        acvp_log_msg(ctx, "Curl failed with code %d (%s)\n", crv, curl_easy_strerror(crv));
+        ACVP_LOG_ERR("Curl failed with code %d (%s)\n", crv, curl_easy_strerror(crv));
     }
 
     /*
@@ -277,7 +277,7 @@ static long acvp_curl_http_post (ACVP_CTX *ctx, char *url, char *data, void *wri
     curl_easy_getinfo (hnd, CURLINFO_RESPONSE_CODE, &http_code);
 
     if (http_code != HTTP_OK) {
-	acvp_log_msg(ctx, "HTTP response: %d\n", (int)http_code);
+	ACVP_LOG_ERR("HTTP response: %d\n", (int)http_code);
     }
 
     curl_easy_cleanup(hnd);
@@ -415,15 +415,15 @@ ACVP_RESULT acvp_send_register(ACVP_CTX *ctx, char *reg)
 
     rv = acvp_curl_http_post(ctx, url, reg, &acvp_curl_write_register_func);
     if (rv != HTTP_OK) {
-        acvp_log_msg(ctx, "Unable to register with ACVP server. curl rv=%d\n", rv);
-	acvp_log_msg(ctx, "%s\n", ctx->reg_buf);
+        ACVP_LOG_ERR("Unable to register with ACVP server. curl rv=%d\n", rv);
+	ACVP_LOG_ERR("%s\n", ctx->reg_buf);
         return ACVP_TRANSPORT_FAIL;
     }
 
     /*
      * Update user with status
-     */
-    acvp_log_msg(ctx,"Successfully received registration response from ACVP server");
+     */ 
+    ACVP_LOG_STATUS("Successfully received registration response from ACVP server");
 
     return ACVP_SUCCESS;
 }
@@ -445,15 +445,15 @@ ACVP_RESULT acvp_retrieve_vector_set(ACVP_CTX *ctx, int vs_id)
     }
     rv = acvp_curl_http_get(ctx, url, &acvp_curl_write_kat_func);
     if (rv != HTTP_OK) {
-        acvp_log_msg(ctx, "Unable to get vectors from server. curl rv=%d\n", rv);
-	acvp_log_msg(ctx, "%s\n", ctx->kat_buf);
+        ACVP_LOG_ERR("Unable to get vectors from server. curl rv=%d\n", rv);
+	ACVP_LOG_ERR("%s\n", ctx->kat_buf);
         return ACVP_TRANSPORT_FAIL;
     }
 
     /*
      * Update user with status
      */
-    acvp_log_msg(ctx,"Successfully retrieved KAT vector set");
+    ACVP_LOG_STATUS("Successfully retrieved KAT vector set");
 
     return ACVP_SUCCESS;
 }
@@ -478,12 +478,12 @@ ACVP_RESULT acvp_submit_vector_responses(ACVP_CTX *ctx)
     ctx->kat_resp = NULL;
     json_free_serialized_string(resp);
     if (rv != HTTP_OK) {
-        acvp_log_msg(ctx, "Unable to upload vector set to ACVP server. curl rv=%d\n", rv);
-	acvp_log_msg(ctx, "%s\n", ctx->upld_buf);
+        ACVP_LOG_ERR("Unable to upload vector set to ACVP server. curl rv=%d\n", rv);
+	ACVP_LOG_ERR("%s\n", ctx->upld_buf);
         return ACVP_TRANSPORT_FAIL;
     }
 
-    acvp_log_msg(ctx, "Successfully submitted KAT vector responses");
+    ACVP_LOG_STATUS("Successfully submitted KAT vector responses");
     return ACVP_SUCCESS;
 }
 
@@ -504,15 +504,15 @@ ACVP_RESULT acvp_retrieve_vector_set_result(ACVP_CTX *ctx, int vs_id)
     }
     rv = acvp_curl_http_get(ctx, url, &acvp_curl_write_kat_func);
     if (rv != HTTP_OK) {
-        acvp_log_msg(ctx, "Unable to get vector result from server. curl rv=%d\n", rv);
-	acvp_log_msg(ctx, "%s\n", ctx->kat_buf);
+        ACVP_LOG_ERR("Unable to get vector result from server. curl rv=%d\n", rv);
+	ACVP_LOG_ERR("%s\n", ctx->kat_buf);
         return ACVP_TRANSPORT_FAIL;
     }
 
     /*
      * Update user with status
      */
-    acvp_log_msg(ctx,"Successfully retrieved KAT vector set response");
+    ACVP_LOG_STATUS("Successfully retrieved KAT vector set response");
 
     return ACVP_SUCCESS;
 }

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -41,18 +41,18 @@ static int acvp_char_to_int(char ch);
  * This is a rudimentary logging facility for libacvp.
  * We will need more when moving beyond the PoC phase.
  */
-void acvp_log_msg (ACVP_CTX *ctx, const char *format, ...)
+void acvp_log_msg (ACVP_CTX *ctx, ACVP_LOG_LVL level, const char *format, ...)
 {
     va_list arguments;
-    char tmp[1024];
+    char tmp[16384];
 
-    if (ctx && ctx->test_progress_cb) {
+    if (ctx && ctx->test_progress_cb && (ctx->debug >= level)) {
         /*
          * Pull the arguments from the stack and invoke
          * the logger function
          */
         va_start(arguments, format);
-        vsnprintf(tmp, 1023, format, arguments);
+        vsnprintf(tmp, 16383, format, arguments);
         ctx->test_progress_cb(tmp);
         va_end(arguments);
         fflush(stdout);
@@ -300,7 +300,7 @@ unsigned int yes_or_no(ACVP_CTX *ctx, const char *text)
     } else if (!strncmp(text, "no", 2)) {
         result = 0;
     } else {
-        acvp_log_msg(ctx, "ERROR: unsupported yes/no value from server treated as 'no': (%s)", text);
+        ACVP_LOG_ERR("ERROR: unsupported yes/no value from server treated as 'no': (%s)", text);
         result = 0;
     }
     return result;


### PR DESCRIPTION
This PR has 3 functional changes. Changed the logging so it can be level controlled via command line argument.  Added prerequisites for AES-GCM and AES-CCM.  Added parameter capabilities for SHA.
