### PR TITLE
Fixes memory resulting from json library method call

### DIFF
--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -2,23 +2,23 @@
 * Copyright (c) 2016, Cisco Systems, Inc.
 * All rights reserved.
 
-* Redistribution and use in source and binary forms, with or without modification, 
+* Redistribution and use in source and binary forms, with or without modification,
 * are permitted provided that the following conditions are met:
 *
-* 1. Redistributions of source code must retain the above copyright notice, 
+* 1. Redistributions of source code must retain the above copyright notice,
 *    this list of conditions and the following disclaimer.
 *
 * 2. Redistributions in binary form must reproduce the above copyright notice,
-*    this list of conditions and the following disclaimer in the documentation 
+*    this list of conditions and the following disclaimer in the documentation
 *    and/or other materials provided with the distribution.
 *
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -60,7 +60,7 @@ static unsigned char key[101][32];
 static unsigned char iv[101][16];
 static unsigned char ptext[1001][32];
 static unsigned char ctext[1001][32];
- 
+
 #define gb(a,b) (((a)[(b)/8] >> (7-(b)%8))&1)
 #define sb(a,b,v) ((a)[(b)/8]=((a)[(b)/8]&~(1 << (7-(b)%8)))|(!!(v) << (7-(b)%8)))
 
@@ -135,7 +135,7 @@ static ACVP_RESULT acvp_aes_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *st
 	break;
     default:
         break;
-    }    
+    }
 
     return ACVP_SUCCESS;
 }
@@ -207,8 +207,8 @@ static ACVP_RESULT acvp_aes_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
  * parsed, processed, and a response is generated to be sent
  * back to the ACV server by the transport layer.
  */
-static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, 
-		                   ACVP_TEST_CASE *tc, ACVP_SYM_CIPHER_TC *stc, 
+static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
+		                   ACVP_TEST_CASE *tc, ACVP_SYM_CIPHER_TC *stc,
 				   JSON_Array *res_array)
 {
     int i, j, n, n1, n2;
@@ -387,15 +387,15 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     ACVP_TEST_CASE tc;
     ACVP_RESULT rv;
     const char		*dir_str2 = NULL;
-    const char		*dir_str = json_object_get_string(obj, "direction"); 
-    const char		*alg_str = json_object_get_string(obj, "algorithm"); 
+    const char		*dir_str = json_object_get_string(obj, "direction");
+    const char		*alg_str = json_object_get_string(obj, "algorithm");
     ACVP_SYM_CIPH_DIR	dir;
     ACVP_CIPHER	alg_id;
-    char  *test_type;
+    char  *test_type, *json_result;
 
     if (!alg_str) {
         ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
-	return (ACVP_MALFORMED_JSON);
+        return (ACVP_MALFORMED_JSON);
     }
 
     /*
@@ -403,9 +403,9 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
      */
     if (dir_str != NULL) {
         if (!strncmp(dir_str, "encrypt", 7)) {
-	    dir = ACVP_DIR_ENCRYPT;
+            dir = ACVP_DIR_ENCRYPT;
         } else if (!strncmp(dir_str, "decrypt", 7)) {
-	    dir = ACVP_DIR_DECRYPT;
+            dir = ACVP_DIR_DECRYPT;
         } else {
             ACVP_LOG_ERR("unsupported direction requested from server (%s)", dir_str);
             //return (ACVP_UNSUPPORTED_OP);
@@ -452,7 +452,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     json_object_set_number(r_vs, "vsId", ctx->vs_id);
     json_object_set_string(r_vs, "algorithm", alg_str);
     if (dir_str != NULL)
-        json_object_set_string(r_vs, "direction", dir_str); 
+        json_object_set_string(r_vs, "direction", dir_str);
     json_object_set_value(r_vs, "testResults", json_value_init_array());
     r_tarr = json_object_get_array(r_vs, "testResults");
 
@@ -463,16 +463,16 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
         groupobj = json_value_get_object(groupval);
         dir_str2 = json_object_get_string(groupobj, "direction");
 
-	/* version 0.3 direction will override 0.2 if there */
-	if (dir_str2 != NULL) {
-    	    /*
-    	     * verify the direction is valid 
-     	     */
-    	    if (!strncmp(dir_str2, "encrypt", 7)) {
-	        dir = ACVP_DIR_ENCRYPT;
-    	    } else if (!strncmp(dir_str2, "decrypt", 7)) {
-	        dir = ACVP_DIR_DECRYPT;
-    	    } else {
+        /* version 0.3 direction will override 0.2 if there */
+        if (dir_str2 != NULL) {
+        /*
+         * verify the direction is valid
+           */
+            if (!strncmp(dir_str2, "encrypt", 7)) {
+                dir = ACVP_DIR_ENCRYPT;
+            } else if (!strncmp(dir_str2, "decrypt", 7)) {
+                dir = ACVP_DIR_DECRYPT;
+            } else {
                 ACVP_LOG_ERR("unsupported direction requested from server (%s)", dir_str2);
                 return (ACVP_UNSUPPORTED_OP);
             }
@@ -510,7 +510,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 
             tc_id = (unsigned int)json_object_get_number(testobj, "tcId");
             key = (unsigned char *)json_object_get_string(testobj, "key");
-	    if (dir == ACVP_DIR_ENCRYPT) { 
+	    if (dir == ACVP_DIR_ENCRYPT) {
 		pt = (unsigned char *)json_object_get_string(testobj, "pt");
 		iv = (unsigned char *)json_object_get_string(testobj, "iv");
 	    	if (alg_id != ACVP_AES_GCM && alg_id != ACVP_AES_CCM) {
@@ -550,7 +550,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
              * TODO: this does mallocs, we can probably do the mallocs once for
              *       the entire vector set to be more efficient
              */
-            acvp_aes_init_tc(ctx, &stc, tc_id, test_type, key, pt, ct, iv, tag, aad, 
+            acvp_aes_init_tc(ctx, &stc, tc_id, test_type, key, pt, ct, iv, tag, aad,
 		             keylen, ivlen, ptlen, aadlen, taglen, alg_id, dir);
 
 	    /* If Monte Carlo start that here */
@@ -596,11 +596,14 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     }
     json_array_append_value(reg_arry, r_vs_val);
 
+    json_result = json_serialize_to_string_pretty(ctx->kat_resp);
     if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+        printf("\n\n%s\n\n", json_result);
     } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
     }
+    json_free_serialized_string(json_result);
+
     return ACVP_SUCCESS;
 }
 
@@ -610,7 +613,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
  * file that will be uploaded to the server.  This routine handles
  * the JSON processing for a single test case.
  */
-static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, 
+static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc,
        		                      JSON_Object *tc_rsp, ACVP_RESULT tag_rv)
 {
     ACVP_RESULT rv;
@@ -644,7 +647,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc,
 	json_object_set_string(tc_rsp, "ct", tmp);
 
 	/*
-	 * AEAD ciphers need to include the tag 
+	 * AEAD ciphers need to include the tag
 	 */
 	if (stc->cipher == ACVP_AES_GCM || stc->cipher == ACVP_AES_CCM) {
 	    memset(tmp, 0x0, ACVP_SYM_CT_MAX);
@@ -656,7 +659,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc,
 	    json_object_set_string(tc_rsp, "tag", tmp);
 	}
     } else {
-	if ((stc->cipher == ACVP_AES_GCM || stc->cipher == ACVP_AES_CCM) && 
+	if ((stc->cipher == ACVP_AES_GCM || stc->cipher == ACVP_AES_CCM) &&
 	    (tag_rv == ACVP_CRYPTO_TAG_FAIL)) {
 	    	json_object_set_boolean(tc_rsp, "decryptFail", 1);
 		return ACVP_SUCCESS;
@@ -783,7 +786,7 @@ static ACVP_RESULT acvp_aes_init_tc(ACVP_CTX *ctx,
     stc->key_len = key_len;
     stc->iv_len = iv_len/8;
     stc->pt_len = pt_len/8;
-    stc->ct_len = pt_len/8; 
+    stc->ct_len = pt_len/8;
     stc->tag_len = tag_len/8;
     stc->aad_len = aad_len/8;
 

--- a/src/acvp_cmac.c
+++ b/src/acvp_cmac.c
@@ -135,6 +135,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     ACVP_RESULT rv;
     const char		*alg_str = json_object_get_string(obj, "algorithm");
     ACVP_CIPHER	        alg_id;
+    char *json_result;
 
     if (!alg_str) {
         ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
@@ -261,8 +262,14 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     }
 
     json_array_append_value(reg_arry, r_vs_val);
-    //FIXME
-    printf("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+
+    json_result = json_serialize_to_string_pretty(ctx->kat_resp);
+    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        printf("\n\n%s\n\n", json_result);
+    } else {
+        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
+    }
+    json_free_serialized_string(json_result);
 
     return ACVP_SUCCESS;
 }

--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -2,23 +2,23 @@
 * Copyright (c) 2016, Cisco Systems, Inc.
 * All rights reserved.
 
-* Redistribution and use in source and binary forms, with or without modification, 
+* Redistribution and use in source and binary forms, with or without modification,
 * are permitted provided that the following conditions are met:
 *
-* 1. Redistributions of source code must retain the above copyright notice, 
+* 1. Redistributions of source code must retain the above copyright notice,
 *    this list of conditions and the following disclaimer.
 *
 * 2. Redistributions in binary form must reproduce the above copyright notice,
-*    this list of conditions and the following disclaimer in the documentation 
+*    this list of conditions and the following disclaimer in the documentation
 *    and/or other materials provided with the distribution.
 *
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -61,7 +61,7 @@ static unsigned char ctext[10001][8];
  * and/or pt/ct information may need to be modified.  This function
  * performs the iteration depdedent upon the cipher type and direction.
  */
-static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, 
+static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc,
                                            int i, JSON_Object *r_tobj)
 {
     int j = stc->mct_index;
@@ -118,7 +118,7 @@ static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *st
             for(n=0 ; n < 8 ; ++n) {
                 stc->iv[n] = stc->pt[n] ^ stc->ct[n];
 	    }
-        } 
+        }
         break;
     case ACVP_TDES_ECB:
         if (stc->direction == ACVP_DIR_ENCRYPT) {
@@ -129,7 +129,7 @@ static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *st
 	break;
     default:
         break;
-    }    
+    }
 
     return ACVP_SUCCESS;
 }
@@ -141,7 +141,7 @@ static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *st
  * file that will be uploaded to the server.  This routine handles
  * the JSON processing for a single test case for MCT.
  */
-static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, 
+static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc,
                                           JSON_Object *r_tobj)
 {
     ACVP_RESULT rv;
@@ -228,8 +228,8 @@ void acvp_des_set_odd_parity(unsigned char *key)
  * parsed, processed, and a response is generated to be sent
  * back to the ACV server by the transport layer.
  */
-static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, 
-		                   ACVP_TEST_CASE *tc, ACVP_SYM_CIPHER_TC *stc, 
+static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
+		                   ACVP_TEST_CASE *tc, ACVP_SYM_CIPHER_TC *stc,
 				   JSON_Array *res_array)
 {
     int i, j, n;
@@ -384,11 +384,12 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     ACVP_TEST_CASE tc;
     ACVP_RESULT rv;
     const char		*dir_str2 = NULL;
-    const char		*dir_str = json_object_get_string(obj, "direction"); 
-    const char		*alg_str = json_object_get_string(obj, "algorithm"); 
+    const char		*dir_str = json_object_get_string(obj, "direction");
+    const char		*alg_str = json_object_get_string(obj, "algorithm");
     ACVP_SYM_CIPH_DIR	dir;
     ACVP_CIPHER	alg_id;
     ACVP_SYM_CIPH_TESTTYPE test_type;
+    char *json_result;
 
     if (!alg_str) {
         ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
@@ -451,7 +452,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     json_object_set_number(r_vs, "vsId", ctx->vs_id);
     json_object_set_string(r_vs, "algorithm", alg_str);
     if (dir_str != NULL)
-        json_object_set_string(r_vs, "direction", dir_str); 
+        json_object_set_string(r_vs, "direction", dir_str);
     json_object_set_value(r_vs, "testResults", json_value_init_array());
     r_tarr = json_object_get_array(r_vs, "testResults");
 
@@ -465,7 +466,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 	/* version 0.3 direction */
 	if (dir_str2 != NULL) {
     	    /*
-    	     * verify the direction is valid 
+    	     * verify the direction is valid
      	     */
     	    if (!strncmp(dir_str2, "encrypt", 7)) {
 	        dir = ACVP_DIR_ENCRYPT;
@@ -498,7 +499,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 
             tc_id = (unsigned int)json_object_get_number(testobj, "tcId");
             key = (unsigned char *)json_object_get_string(testobj, "key");
-	    if (dir == ACVP_DIR_ENCRYPT) { 
+	    if (dir == ACVP_DIR_ENCRYPT) {
 		pt = (unsigned char *)json_object_get_string(testobj, "pt");
 		iv = (unsigned char *)json_object_get_string(testobj, "iv");
             } else {
@@ -527,7 +528,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
              * TODO: this does mallocs, we can probably do the mallocs once for
              *       the entire vector set to be more efficient
              */
-            acvp_des_init_tc(ctx, &stc, tc_id, key, pt, ct, iv,  
+            acvp_des_init_tc(ctx, &stc, tc_id, key, pt, ct, iv,
 		             keylen, ivlen, ptlen, alg_id, dir);
 
 	    /* If Monte Carlo start that here */
@@ -571,11 +572,14 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 
     json_array_append_value(reg_arry, r_vs_val);
 
+    json_result = json_serialize_to_string_pretty(ctx->kat_resp);
     if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+        printf("\n\n%s\n\n", json_result);
     } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
     }
+    json_free_serialized_string(json_result);
+
     return ACVP_SUCCESS;
 }
 
@@ -702,7 +706,7 @@ static ACVP_RESULT acvp_des_init_tc(ACVP_CTX *ctx,
     stc->key_len = key_len;
     stc->iv_len = iv_len/8;
     stc->pt_len = pt_len/8;
-    stc->ct_len = pt_len/8; 
+    stc->ct_len = pt_len/8;
 
     stc->cipher = alg_id;
     stc->direction = dir;

--- a/src/acvp_drbg.c
+++ b/src/acvp_drbg.c
@@ -78,6 +78,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 
     char            *der_func_str;
     char            *pred_resist_str;
+    char            *json_result;
 
     JSON_Value          *reg_arry_val  = NULL;
     JSON_Object         *reg_obj       = NULL;
@@ -181,8 +182,8 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
         groupval = json_array_get_value(groups, i);
         groupobj = json_value_get_object(groupval);
 
-        char *reg = json_serialize_to_string_pretty(groupval);
-        ACVP_LOG_INFO("json groupval count: %d\n %s\n", i, reg);
+        json_result = json_serialize_to_string_pretty(groupval);
+        ACVP_LOG_INFO("json groupval count: %d\n %s\n", i, json_result);
 
         /*
          * Handle Group Params
@@ -230,7 +231,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
-            reg = json_serialize_to_string_pretty(testval);
+            json_result = json_serialize_to_string_pretty(testval);
 
             tc_id = (unsigned int)json_object_get_number(testobj, "tcId");
 
@@ -330,11 +331,14 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     }
     json_array_append_value(reg_arry, r_vs_val);
 
+    json_result = json_serialize_to_string_pretty(ctx->kat_resp);
     if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+        printf("\n\n%s\n\n", json_result);
     } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
     }
+    json_free_serialized_string(json_result);
+
     return ACVP_SUCCESS;
 }
 

--- a/src/acvp_drbg.c
+++ b/src/acvp_drbg.c
@@ -184,6 +184,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 
         json_result = json_serialize_to_string_pretty(groupval);
         ACVP_LOG_INFO("json groupval count: %d\n %s\n", i, json_result);
+        json_free_serialized_string(json_result);
 
         /*
          * Handle Group Params
@@ -232,6 +233,8 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
             testobj = json_value_get_object(testval);
 
             json_result = json_serialize_to_string_pretty(testval);
+            ACVP_LOG_INFO("json testval count: %d\n %s\n", i, json_result);
+            json_free_serialized_string(json_result);
 
             tc_id = (unsigned int)json_object_get_number(testobj, "tcId");
 

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -22,10 +22,10 @@ static ACVP_RESULT acvp_hash_release_tc(ACVP_HASH_TC *stc);
 /*
  * After each hash for a Monte Carlo input
  * information may need to be modified.  This function
- * performs the iteration depdedent upon the hash type 
+ * performs the iteration depdedent upon the hash type
  * and direction.
  */
-static ACVP_RESULT acvp_hash_mct_iterate_tc(ACVP_CTX *ctx, ACVP_HASH_TC *stc, int i, 
+static ACVP_RESULT acvp_hash_mct_iterate_tc(ACVP_CTX *ctx, ACVP_HASH_TC *stc, int i,
                                             JSON_Object *r_tobj)
 {
     /* feed hash into the next message for MCT */
@@ -71,8 +71,8 @@ static ACVP_RESULT acvp_hash_output_mct_tc(ACVP_CTX *ctx, ACVP_HASH_TC *stc, JSO
  * parsed, processed, and a response is generated to be sent
  * back to the ACV server by the transport layer.
  */
-static ACVP_RESULT acvp_hash_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, 
-		                   ACVP_TEST_CASE *tc, ACVP_HASH_TC *stc, 
+static ACVP_RESULT acvp_hash_mct_tc(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap,
+		                   ACVP_TEST_CASE *tc, ACVP_HASH_TC *stc,
 				   JSON_Array *res_array)
 {
     int i, j;
@@ -167,8 +167,9 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     ACVP_HASH_TESTTYPE test_type;
     JSON_Array          *res_tarr = NULL; /* Response resultsArray */
     ACVP_RESULT rv;
-    const char		*alg_str = json_object_get_string(obj, "algorithm"); 
+    const char		*alg_str = json_object_get_string(obj, "algorithm");
     ACVP_CIPHER	        alg_id;
+    char *json_result;
 
     if (!alg_str) {
         ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
@@ -301,11 +302,14 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 
     json_array_append_value(reg_arry, r_vs_val);
 
+    json_result = json_serialize_to_string_pretty(ctx->kat_resp);
     if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+        printf("\n\n%s\n\n", json_result);
     } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
     }
+    json_free_serialized_string(json_result);
+
     return ACVP_SUCCESS;
 }
 

--- a/src/acvp_hmac.c
+++ b/src/acvp_hmac.c
@@ -117,6 +117,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
     ACVP_RESULT rv;
     const char		*alg_str = json_object_get_string(obj, "algorithm");
     ACVP_CIPHER	        alg_id;
+    char *json_result;
 
     if (!alg_str) {
         ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
@@ -240,10 +241,13 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
 
     json_array_append_value(reg_arry, r_vs_val);
 
+    json_result = json_serialize_to_string_pretty(ctx->kat_resp);
     if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+        printf("\n\n%s\n\n", json_result);
     } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_serialize_to_string_pretty(ctx->kat_resp));
+        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
     }
+    json_free_serialized_string(json_result);
+
     return ACVP_SUCCESS;
 }


### PR DESCRIPTION
Sorry for the noise, my editor converts tabs to spaces... maybe there is an ignore whitespace option on github like there is on bitbucket?

The actual fix is around the call to json_serialize_to_string_pretty in each acvp_*.c file