### PR TITLE
Hmac msglen fix

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1542,7 +1542,7 @@ static ACVP_RESULT app_sha_handler(ACVP_TEST_CASE *test_case)
 static ACVP_RESULT app_hmac_handler(ACVP_TEST_CASE *test_case)
 {
     ACVP_HMAC_TC	*tc;
-    const EVP_MD	*md;
+    const EVP_MD	*mac;
     HMAC_CTX       hmac_ctx;
     int msg_len;
 
@@ -1554,19 +1554,19 @@ static ACVP_RESULT app_hmac_handler(ACVP_TEST_CASE *test_case)
 
     switch (tc->cipher) {
     case ACVP_HMAC_SHA1:
-      md = EVP_sha1();
+      mac = EVP_sha1();
       break;
     case ACVP_HMAC_SHA2_224:
-      md = EVP_sha224();
+      mac = EVP_sha224();
       break;
     case ACVP_HMAC_SHA2_256:
-      md = EVP_sha256();
+      mac = EVP_sha256();
       break;
     case ACVP_HMAC_SHA2_384:
-      md = EVP_sha384();
+      mac = EVP_sha384();
       break;
     case ACVP_HMAC_SHA2_512:
-      md = EVP_sha512();
+      mac = EVP_sha512();
       break;
     default:
     	printf("Error: Unsupported hash algorithm requested by ACVP server\n");
@@ -1577,7 +1577,7 @@ static ACVP_RESULT app_hmac_handler(ACVP_TEST_CASE *test_case)
     HMAC_CTX_init(&hmac_ctx);
     msg_len = tc->msg_len;
 
-    if (!HMAC_Init_ex(&hmac_ctx, tc->key, tc->key_len, md, NULL)) {
+    if (!HMAC_Init_ex(&hmac_ctx, tc->key, tc->key_len, mac, NULL)) {
         printf("\nCrypto module error, HMAC_Init_ex failed\n");
         return ACVP_CRYPTO_MODULE_FAIL;
     }
@@ -1587,7 +1587,7 @@ static ACVP_RESULT app_hmac_handler(ACVP_TEST_CASE *test_case)
         return ACVP_CRYPTO_MODULE_FAIL;
     }
 
-    if (!HMAC_Final(&hmac_ctx, tc->md, &tc->md_len)) {
+    if (!HMAC_Final(&hmac_ctx, tc->mac, &tc->mac_len)) {
         printf("\nCrypto module error, HMAC_Final failed\n");
         return ACVP_CRYPTO_MODULE_FAIL;
     }

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1542,7 +1542,7 @@ static ACVP_RESULT app_sha_handler(ACVP_TEST_CASE *test_case)
 static ACVP_RESULT app_hmac_handler(ACVP_TEST_CASE *test_case)
 {
     ACVP_HMAC_TC	*tc;
-    const EVP_MD	*mac;
+    const EVP_MD	*md;
     HMAC_CTX       hmac_ctx;
     int msg_len;
 
@@ -1554,19 +1554,19 @@ static ACVP_RESULT app_hmac_handler(ACVP_TEST_CASE *test_case)
 
     switch (tc->cipher) {
     case ACVP_HMAC_SHA1:
-      mac = EVP_sha1();
+      md = EVP_sha1();
       break;
     case ACVP_HMAC_SHA2_224:
-      mac = EVP_sha224();
+      md = EVP_sha224();
       break;
     case ACVP_HMAC_SHA2_256:
-      mac = EVP_sha256();
+      md = EVP_sha256();
       break;
     case ACVP_HMAC_SHA2_384:
-      mac = EVP_sha384();
+      md = EVP_sha384();
       break;
     case ACVP_HMAC_SHA2_512:
-      mac = EVP_sha512();
+      md = EVP_sha512();
       break;
     default:
     	printf("Error: Unsupported hash algorithm requested by ACVP server\n");
@@ -1577,7 +1577,7 @@ static ACVP_RESULT app_hmac_handler(ACVP_TEST_CASE *test_case)
     HMAC_CTX_init(&hmac_ctx);
     msg_len = tc->msg_len;
 
-    if (!HMAC_Init_ex(&hmac_ctx, tc->key, tc->key_len, mac, NULL)) {
+    if (!HMAC_Init_ex(&hmac_ctx, tc->key, tc->key_len, md, NULL)) {
         printf("\nCrypto module error, HMAC_Init_ex failed\n");
         return ACVP_CRYPTO_MODULE_FAIL;
     }

--- a/src/acvp.h
+++ b/src/acvp.h
@@ -399,8 +399,8 @@ typedef struct acvp_hmac_tc_t {
     unsigned int  tc_id;    /* Test case id */
     unsigned char *msg;
     unsigned int  msg_len;
-    unsigned char *md; /* The resulting digest calculated for the test case */
-    unsigned int  md_len;
+    unsigned char *mac; /* The resulting digest calculated for the test case */
+    unsigned int  mac_len;
     unsigned int  key_len;
     unsigned char *key;
 } ACVP_HMAC_TC;

--- a/src/acvp_hmac.c
+++ b/src/acvp_hmac.c
@@ -212,7 +212,9 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
              * TODO: this does mallocs, we can probably do the mallocs once for
              *       the entire vector set to be more efficient
              */
-            msglen = strnlen((const char *)msg, ACVP_HMAC_MSG_MAX) / 2;
+            if (msglen == 0) {
+                msglen = strnlen((const char *)msg, ACVP_HMAC_MSG_MAX) / 2;
+            }
             acvp_hmac_init_tc(ctx, &stc, tc_id, msglen, msg, keyLen, key, alg_id);
 
             /* Process the current test vector... */

--- a/src/acvp_hmac.c
+++ b/src/acvp_hmac.c
@@ -21,8 +21,8 @@ static ACVP_RESULT acvp_hmac_init_tc(ACVP_CTX *ctx,
 
     stc->msg = calloc(1, ACVP_HMAC_MSG_MAX);
     if (!stc->msg) return ACVP_MALLOC_FAIL;
-    stc->md = calloc(1, ACVP_HMAC_MD_MAX);
-    if (!stc->md) return ACVP_MALLOC_FAIL;
+    stc->mac = calloc(1, ACVP_HMAC_MAC_MAX);
+    if (!stc->mac) return ACVP_MALLOC_FAIL;
     stc->key = calloc(1, ACVP_HMAC_KEY_MAX);
     if (!stc->key) return ACVP_MALLOC_FAIL;
 
@@ -62,12 +62,12 @@ static ACVP_RESULT acvp_hmac_output_tc(ACVP_CTX *ctx, ACVP_HMAC_TC *stc, JSON_Ob
         return ACVP_MALLOC_FAIL;
     }
 
-    rv = acvp_bin_to_hexstr(stc->md, stc->md_len, (unsigned char*)tmp);
+    rv = acvp_bin_to_hexstr(stc->mac, stc->mac_len, (unsigned char*)tmp);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (md)");
+        ACVP_LOG_ERR("hex conversion failure (mac)");
         return rv;
     }
-    json_object_set_string(tc_rsp, "md", tmp);
+    json_object_set_string(tc_rsp, "mac", tmp);
 
     free(tmp);
 
@@ -81,7 +81,7 @@ static ACVP_RESULT acvp_hmac_output_tc(ACVP_CTX *ctx, ACVP_HMAC_TC *stc, JSON_Ob
 static ACVP_RESULT acvp_hmac_release_tc(ACVP_HMAC_TC *stc)
 {
     free(stc->msg);
-    free(stc->md);
+    free(stc->mac);
     free(stc->key);
     memset(stc, 0x0, sizeof(ACVP_HMAC_TC));
 
@@ -212,6 +212,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj)
              * TODO: this does mallocs, we can probably do the mallocs once for
              *       the entire vector set to be more efficient
              */
+            msglen = strnlen((const char *)msg, ACVP_HMAC_MSG_MAX) / 2;
             acvp_hmac_init_tc(ctx, &stc, tc_id, msglen, msg, keyLen, key, alg_id);
 
             /* Process the current test vector... */

--- a/src/acvp_lcl.h
+++ b/src/acvp_lcl.h
@@ -144,7 +144,7 @@
 #define ACVP_HASH_MD_MAX        64
 
 #define ACVP_HMAC_MSG_MAX       1024
-#define ACVP_HMAC_MD_MAX        64
+#define ACVP_HMAC_MAC_MAX       64
 #define ACVP_HMAC_KEY_MAX       256
 
 #define ACVP_CMAC_MSG_MAX       1024


### PR DESCRIPTION
If msglen isn't included in the server response, the msglen will be set in the kat handler.

This PR also renames a few variables to be consistent with HMAC.