### PR TITLE
Common prereq

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -297,9 +297,9 @@ int main(int argc, char **argv)
      */
    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_GCM, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_INT, ACVP_IVGEN_MODE_821, &app_aes_handler_aead);
    CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_prereq_cap(ctx, ACVP_AES_GCM, ACVP_SYM_PREREQ_AES, value);
+   rv = acvp_enable_prereq_cap(ctx, ACVP_AES_GCM, ACVP_SYM_PREREQ_AES, value);
    CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_prereq_cap(ctx, ACVP_AES_GCM, ACVP_SYM_PREREQ_DRBG, value);
+   rv = acvp_enable_prereq_cap(ctx, ACVP_AES_GCM, ACVP_SYM_PREREQ_DRBG, value);
    CHECK_ENABLE_CAP_RV(rv);
    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_KEYLEN, 128);
    CHECK_ENABLE_CAP_RV(rv);
@@ -401,7 +401,7 @@ int main(int argc, char **argv)
     */
    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CCM, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler_aead);
    CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_prereq_cap(ctx, ACVP_AES_CCM, ACVP_SYM_PREREQ_AES, value);
+   rv = acvp_enable_prereq_cap(ctx, ACVP_AES_CCM, ACVP_SYM_PREREQ_AES, value);
    CHECK_ENABLE_CAP_RV(rv);
    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 128);
    CHECK_ENABLE_CAP_RV(rv);
@@ -603,7 +603,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_cmac_cap_parm(ctx, ACVP_CMAC_AES_128, ACVP_CMAC_MACLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_hmac_prereq_cap(ctx, ACVP_CMAC_AES_128, CMAC_AES, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_CMAC_AES_128, CMAC_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
 
     /*
@@ -625,7 +625,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_hmac_cap_parm(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_MACLEN, 20);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_hmac_prereq_cap(ctx, ACVP_HMAC_SHA1, HMAC_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA1, HMAC_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_enable_hmac_cap(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
@@ -644,7 +644,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_hmac_cap_parm(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_MACLEN, 28);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_hmac_prereq_cap(ctx, ACVP_HMAC_SHA2_224, HMAC_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_224, HMAC_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_enable_hmac_cap(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
@@ -663,7 +663,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_hmac_cap_parm(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_MACLEN, 32);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_hmac_prereq_cap(ctx, ACVP_HMAC_SHA2_256, HMAC_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_256, HMAC_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_enable_hmac_cap(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
@@ -682,7 +682,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_hmac_cap_parm(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_MACLEN, 48);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_hmac_prereq_cap(ctx, ACVP_HMAC_SHA2_384, HMAC_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_384, HMAC_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_enable_hmac_cap(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
@@ -701,10 +701,9 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_hmac_cap_parm(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_MACLEN, 64);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_hmac_prereq_cap(ctx, ACVP_HMAC_SHA2_512, HMAC_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_512, HMAC_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 #endif
-
 
 #if 0 /* until supported on the server */
    /*
@@ -735,7 +734,7 @@ int main(int argc, char **argv)
      */
     rv = acvp_enable_rsa_cap(ctx, ACVP_RSA, &app_rsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_prereq_cap(ctx, ACVP_RSA, RSA_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_RSA, RSA_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_rsa_cap_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_KEYGEN, ACVP_PUB_EXP, RSA_PUB_EXP_FIXED);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1988,8 +1987,7 @@ static ACVP_RESULT app_rsa_handler(ACVP_TEST_CASE *test_case)
 }
 
 
-// #ifdef ACVP_NO_RUNTIME
-#if 0
+#ifdef ACVP_NO_RUNTIME
 typedef struct
 {
     unsigned char *ent;

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -297,9 +297,9 @@ int main(int argc, char **argv)
      */
    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_GCM, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_INT, ACVP_IVGEN_MODE_821, &app_aes_handler_aead);
    CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_prereq_cap(ctx, ACVP_AES_GCM, ACVP_SYM_PREREQ_AES, value);
+   rv = acvp_enable_prereq_cap(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, value);
    CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_prereq_cap(ctx, ACVP_AES_GCM, ACVP_SYM_PREREQ_DRBG, value);
+   rv = acvp_enable_prereq_cap(ctx, ACVP_AES_GCM, ACVP_PREREQ_DRBG, value);
    CHECK_ENABLE_CAP_RV(rv);
    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_KEYLEN, 128);
    CHECK_ENABLE_CAP_RV(rv);
@@ -401,7 +401,7 @@ int main(int argc, char **argv)
     */
    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CCM, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler_aead);
    CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_prereq_cap(ctx, ACVP_AES_CCM, ACVP_SYM_PREREQ_AES, value);
+   rv = acvp_enable_prereq_cap(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, value);
    CHECK_ENABLE_CAP_RV(rv);
    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 128);
    CHECK_ENABLE_CAP_RV(rv);
@@ -603,7 +603,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_cmac_cap_parm(ctx, ACVP_CMAC_AES_128, ACVP_CMAC_MACLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_prereq_cap(ctx, ACVP_CMAC_AES_128, CMAC_AES, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_CMAC_AES_128, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
 
     /*
@@ -625,7 +625,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_hmac_cap_parm(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_MACLEN, 20);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA1, HMAC_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA1, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_enable_hmac_cap(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
@@ -644,7 +644,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_hmac_cap_parm(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_MACLEN, 28);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_224, HMAC_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_enable_hmac_cap(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
@@ -663,7 +663,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_hmac_cap_parm(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_MACLEN, 32);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_256, HMAC_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_enable_hmac_cap(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
@@ -682,7 +682,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_hmac_cap_parm(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_MACLEN, 48);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_384, HMAC_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_384, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_enable_hmac_cap(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
@@ -701,7 +701,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_hmac_cap_parm(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_MACLEN, 64);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_512, HMAC_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_HMAC_SHA2_512, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
@@ -734,7 +734,7 @@ int main(int argc, char **argv)
      */
     rv = acvp_enable_rsa_cap(ctx, ACVP_RSA, &app_rsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_prereq_cap(ctx, ACVP_RSA, RSA_SHA, value);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_RSA, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_rsa_cap_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_KEYGEN, ACVP_PUB_EXP, RSA_PUB_EXP_FIXED);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1848,7 +1848,7 @@ static ACVP_RESULT app_kdf135_snmp_handler(ACVP_TEST_CASE *test_case)
         return ACVP_CRYPTO_MODULE_FAIL;
     }
 
-    tc->skey_len = strnlen(s_key, ACVP_KDF135_SNMP_SKEY_MAX);
+    tc->skey_len = strnlen((const char *)s_key, ACVP_KDF135_SNMP_SKEY_MAX);
 
     return ACVP_SUCCESS;
 }

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -77,6 +77,9 @@ static ACVP_RESULT acvp_append_kdf135_tls_caps_entry(
     ACVP_RESULT (*crypto_handler)(ACVP_TEST_CASE *test_case));
 static void acvp_cap_free_sl(ACVP_SL_LIST *list);
 static ACVP_RESULT acvp_get_result_vsid(ACVP_CTX *ctx, int vs_id);
+static ACVP_RESULT acvp_add_prereq_val(ACVP_CIPHER cipher,
+                    ACVP_CAPS_LIST *caps_list,
+                    ACVP_PREREQ_ALG pre_req, char *value);
 
 
 /*
@@ -143,6 +146,14 @@ ACVP_ALG_HANDLER alg_tbl[ACVP_ALG_MAX] = {
     {ACVP_KDF135_SNMP,     &acvp_kdf135_snmp_kat_handler, ACVP_ALG_KDF135_SNMP}
 };
 
+#define ACVP_NUM_PREREQS 5
+struct acvp_prereqs_mode_name_t acvp_prereqs_tbl[ACVP_NUM_PREREQS] = {
+    {ACVP_PREREQ_AES, "AES"},
+    {ACVP_PREREQ_DRBG, "DRBG"},
+    {ACVP_PREREQ_HMAC, "HMAC"},
+    {ACVP_PREREQ_SHA, "SHA"},
+    {ACVP_PREREQ_TDES, "TDES"}
+};
 
 
 /*
@@ -178,8 +189,8 @@ static void acvp_free_drbg_struct(ACVP_CAPS_LIST* cap_list)
     if (drbg_cap) {
         ACVP_DRBG_CAP_MODE_LIST *mode_list = drbg_cap->drbg_cap_mode_list;
         ACVP_DRBG_CAP_MODE_LIST *next_mode_list;
-        ACVP_DRBG_PREREQ_VALS   *current_pre_req_vals;
-        ACVP_DRBG_PREREQ_VALS   *next_pre_req_vals;
+        ACVP_PREREQ_LIST   *current_pre_req_vals;
+        ACVP_PREREQ_LIST   *next_pre_req_vals;
 
         if (mode_list) {
             do {
@@ -208,50 +219,12 @@ static void acvp_free_drbg_struct(ACVP_CAPS_LIST* cap_list)
 }
 
 static void acvp_free_prereqs(ACVP_CAPS_LIST* cap_list) {
-    switch (cap_list->cap_type) {
-        case ACVP_SYM_TYPE:
-            while (cap_list->cap.sym_cap->prereq_vals) {
-                ACVP_SYM_PREREQ_VALS *temp_ptr;
-                temp_ptr = cap_list->cap.sym_cap->prereq_vals;
-                cap_list->cap.sym_cap->prereq_vals = cap_list->cap.sym_cap->prereq_vals->next;
-                free(temp_ptr);
-            }
-            break;
-        case ACVP_HMAC_TYPE:
-            while (cap_list->cap.hmac_cap->prereq_vals) {
-                ACVP_HMAC_PREREQ_VALS *temp_ptr;
-                temp_ptr = cap_list->cap.hmac_cap->prereq_vals;
-                cap_list->cap.hmac_cap->prereq_vals = cap_list->cap.hmac_cap->prereq_vals->next;
-                free(temp_ptr);
-            }
-            break;
-        case ACVP_CMAC_TYPE:
-            while (cap_list->cap.cmac_cap->prereq_vals) {
-                ACVP_CMAC_PREREQ_VALS *temp_ptr;
-                temp_ptr = cap_list->cap.cmac_cap->prereq_vals;
-                cap_list->cap.cmac_cap->prereq_vals = cap_list->cap.cmac_cap->prereq_vals->next;
-                free(temp_ptr);
-            }
-            break;
-        case ACVP_KDF135_TLS_TYPE:
-            while (cap_list->cap.kdf135_tls_cap->prereq_vals) {
-                ACVP_KDF135_TLS_PREREQ_VALS *temp_ptr;
-                temp_ptr = cap_list->cap.kdf135_tls_cap->prereq_vals;
-                cap_list->cap.kdf135_tls_cap->prereq_vals = cap_list->cap.kdf135_tls_cap->prereq_vals->next;
-                free(temp_ptr);
-            }
-        case ACVP_KDF135_SNMP_TYPE:
-            while (cap_list->cap.kdf135_snmp_cap->prereq_vals) {
-                ACVP_KDF135_SNMP_PREREQ_VALS *temp_ptr;
-                temp_ptr = cap_list->cap.kdf135_snmp_cap->prereq_vals;
-                cap_list->cap.kdf135_snmp_cap->prereq_vals = cap_list->cap.kdf135_snmp_cap->prereq_vals->next;
-                free(temp_ptr);
-            }
-        case ACVP_DRBG_TYPE:
-        case ACVP_HASH_TYPE:
-        default:
-            break;
-    }
+      while (cap_list->prereq_vals) {
+          ACVP_PREREQ_LIST *temp_ptr;
+          temp_ptr = cap_list->prereq_vals;
+          cap_list->prereq_vals = cap_list->prereq_vals->next;
+          free(temp_ptr);
+      }
 }
 
 /*
@@ -293,50 +266,44 @@ ACVP_RESULT acvp_free_test_session(ACVP_CTX *ctx)
             cap_entry = ctx->caps_list;
             while (cap_entry) {
                 cap_e2 = cap_entry->next;
+                if (cap_entry->prereq_vals) {
+                    acvp_free_prereqs(cap_entry);
+                }
                 switch (cap_entry->cap_type) {
-                        case ACVP_SYM_TYPE:
-                            if (cap_entry->cap.sym_cap->prereq_vals) {
-                                acvp_free_prereqs(cap_entry);
-                            }
-                            acvp_cap_free_sl(cap_entry->cap.sym_cap->keylen);
-                            acvp_cap_free_sl(cap_entry->cap.sym_cap->ptlen);
-                            acvp_cap_free_sl(cap_entry->cap.sym_cap->ivlen);
-                            acvp_cap_free_sl(cap_entry->cap.sym_cap->aadlen);
-                            acvp_cap_free_sl(cap_entry->cap.sym_cap->taglen);
-                            free(cap_entry->cap.sym_cap);
-                            free(cap_entry);
-                            cap_entry = cap_e2;
-                            break;
-                        case ACVP_HASH_TYPE:
-                            free(cap_entry->cap.hash_cap);
-                            free(cap_entry);
-                            cap_entry = cap_e2;
-                            break;
-                        case ACVP_DRBG_TYPE:
-                            acvp_free_drbg_struct(cap_entry);
-                            free(cap_entry);
-                            cap_entry = cap_e2;
-                            break;
-                        case ACVP_HMAC_TYPE:
-                            if (cap_entry->cap.hmac_cap->prereq_vals) {
-                                acvp_free_prereqs(cap_entry);
-                            }
-                            acvp_cap_free_sl(cap_entry->cap.hmac_cap->mac_len);
-                            free(cap_entry->cap.hmac_cap);
-                            free(cap_entry);
-                            cap_entry = cap_e2;
-                            break;
-                        case ACVP_CMAC_TYPE:
-                            if (cap_entry->cap.cmac_cap->prereq_vals) {
-                                acvp_free_prereqs(cap_entry);
-                            }
-                            acvp_cap_free_sl(cap_entry->cap.cmac_cap->mac_len);
-                            free(cap_entry->cap.cmac_cap);
-                            free(cap_entry);
-                            cap_entry = cap_e2;
-                            break;
-                        default:
-                            break;
+                case ACVP_SYM_TYPE:
+                    acvp_cap_free_sl(cap_entry->cap.sym_cap->keylen);
+                    acvp_cap_free_sl(cap_entry->cap.sym_cap->ptlen);
+                    acvp_cap_free_sl(cap_entry->cap.sym_cap->ivlen);
+                    acvp_cap_free_sl(cap_entry->cap.sym_cap->aadlen);
+                    acvp_cap_free_sl(cap_entry->cap.sym_cap->taglen);
+                    free(cap_entry->cap.sym_cap);
+                    free(cap_entry);
+                    cap_entry = cap_e2;
+                    break;
+                case ACVP_HASH_TYPE:
+                    free(cap_entry->cap.hash_cap);
+                    free(cap_entry);
+                    cap_entry = cap_e2;
+                    break;
+                case ACVP_DRBG_TYPE:
+                    acvp_free_drbg_struct(cap_entry);
+                    free(cap_entry);
+                    cap_entry = cap_e2;
+                    break;
+                case ACVP_HMAC_TYPE:
+                    acvp_cap_free_sl(cap_entry->cap.hmac_cap->mac_len);
+                    free(cap_entry->cap.hmac_cap);
+                    free(cap_entry);
+                    cap_entry = cap_e2;
+                    break;
+                case ACVP_CMAC_TYPE:
+                    acvp_cap_free_sl(cap_entry->cap.cmac_cap->mac_len);
+                    free(cap_entry->cap.cmac_cap);
+                    free(cap_entry);
+                    cap_entry = cap_e2;
+                    break;
+                default:
+                    break;
                 }
             }
         }
@@ -524,42 +491,10 @@ ACVP_RESULT acvp_enable_sym_cipher_cap_parm(
     return ACVP_SUCCESS;
 }
 
-/*
- * Append a SYM pre req val to the capabilities
- */
-static ACVP_RESULT acvp_add_sym_prereq_val(ACVP_SYM_CIPHER_CAP  *sym_cap,
-                                           ACVP_SYM_PRE_REQ pre_req, char *value)
-{
-    ACVP_SYM_PREREQ_VALS *prereq_entry, *prereq_entry_2;
 
-    prereq_entry = calloc(1, sizeof(ACVP_SYM_PREREQ_VALS));
-    if (!prereq_entry) {
-        return ACVP_MALLOC_FAIL;
-    }
-    prereq_entry->prereq_alg_val.alg = pre_req;
-    prereq_entry->prereq_alg_val.val = value;
-
-    /*
-     * 1st entry
-     */
-    if (!sym_cap->prereq_vals) {
-        sym_cap->prereq_vals= prereq_entry;
-    } else {
-        /*
-         * append to the last in the list
-         */
-        prereq_entry_2 = sym_cap->prereq_vals;
-        while (prereq_entry_2->next) {
-            prereq_entry_2 = prereq_entry_2->next;
-        }
-        prereq_entry_2->next = prereq_entry;
-    }
-    return (ACVP_SUCCESS);
-}
-
-ACVP_RESULT acvp_enable_sym_prereq_cap(ACVP_CTX *ctx,
+ACVP_RESULT acvp_enable_prereq_cap(ACVP_CTX *ctx,
                                        ACVP_CIPHER      cipher,
-                            	       ACVP_SYM_PRE_REQ pre_req_cap,
+                                    ACVP_PREREQ_ALG pre_req_cap,
                              	       char              *value)
 {
     ACVP_CAPS_LIST          *cap_list;
@@ -580,8 +515,7 @@ ACVP_RESULT acvp_enable_sym_prereq_cap(ACVP_CTX *ctx,
     /*
      * Add the value to the cap
      */
-
-    return (acvp_add_sym_prereq_val(cap_list->cap.sym_cap, pre_req_cap, value));
+    return (acvp_add_prereq_val(cipher, cap_list, pre_req_cap, value));
 }
 
 ACVP_RESULT acvp_enable_hash_cap(
@@ -782,52 +716,6 @@ ACVP_RESULT acvp_enable_hmac_cap_parm(
     return ACVP_SUCCESS;
 }
 
-ACVP_RESULT acvp_enable_hmac_prereq_cap(ACVP_CTX       *ctx,
-                                     ACVP_CIPHER       cipher,
-                                     ACVP_HMAC_PRE_REQ pre_req,
-                                     char              *value)
-{
-    ACVP_CAPS_LIST          *cap_list;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    /*
-     * Locate this cipher in the caps array
-     */
-    cap_list = acvp_locate_cap_entry(ctx, cipher);
-    if (!cap_list) {
-        ACVP_LOG_ERR("Cap entry not found.");
-        return ACVP_NO_CAP;
-    }
-
-    ACVP_HMAC_PREREQ_VALS *prereq_entry, *prereq_entry_2;
-
-    prereq_entry = calloc(1, sizeof(ACVP_HMAC_PREREQ_VALS));
-    if (!prereq_entry) {
-        return ACVP_MALLOC_FAIL;
-    }
-    prereq_entry->prereq_alg_val.alg = pre_req;
-    prereq_entry->prereq_alg_val.val = value;
-
-    /*
-     * 1st entry
-     */
-    if (!cap_list->cap.hmac_cap->prereq_vals) {
-        cap_list->cap.hmac_cap->prereq_vals= prereq_entry;
-    } else {
-        /*
-         * append to the last in the list
-         */
-        prereq_entry_2 = cap_list->cap.hmac_cap->prereq_vals;
-        while (prereq_entry_2->next) {
-            prereq_entry_2 = prereq_entry_2->next;
-        }
-        prereq_entry_2->next = prereq_entry;
-    }
-    return ACVP_SUCCESS;
-}
 
 ACVP_RESULT acvp_validate_cmac_parm_value(ACVP_CMAC_PARM parm, int value) {
   ACVP_RESULT retval = ACVP_INVALID_ARG;
@@ -931,52 +819,6 @@ ACVP_RESULT acvp_enable_cmac_cap_parm(
     return ACVP_SUCCESS;
 }
 
-ACVP_RESULT acvp_enable_cmac_prereq_cap(ACVP_CTX       *ctx,
-                                     ACVP_CIPHER       cipher,
-                                     ACVP_CMAC_PRE_REQ pre_req,
-                                     char              *value)
-{
-    ACVP_CAPS_LIST          *cap_list;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    /*
-     * Locate this cipher in the caps array
-     */
-    cap_list = acvp_locate_cap_entry(ctx, cipher);
-    if (!cap_list) {
-        ACVP_LOG_ERR("Cap entry not found.");
-        return ACVP_NO_CAP;
-    }
-
-    ACVP_CMAC_PREREQ_VALS *prereq_entry, *prereq_entry_2;
-
-    prereq_entry = calloc(1, sizeof(ACVP_CMAC_PREREQ_VALS));
-    if (!prereq_entry) {
-        return ACVP_MALLOC_FAIL;
-    }
-    prereq_entry->prereq_alg_val.alg = pre_req;
-    prereq_entry->prereq_alg_val.val = value;
-
-    /*
-     * 1st entry
-     */
-    if (!cap_list->cap.cmac_cap->prereq_vals) {
-        cap_list->cap.cmac_cap->prereq_vals = prereq_entry;
-    } else {
-        /*
-         * append to the last in the list
-         */
-        prereq_entry_2 = cap_list->cap.cmac_cap->prereq_vals;
-        while (prereq_entry_2->next) {
-            prereq_entry_2 = prereq_entry_2->next;
-        }
-        prereq_entry_2->next = prereq_entry;
-    }
-    return ACVP_SUCCESS;
-}
 
 ACVP_RESULT acvp_validate_drbg_parm_value(ACVP_DRBG_PARM parm, int value) {
   ACVP_RESULT retval = ACVP_INVALID_ARG;
@@ -1186,11 +1028,11 @@ static ACVP_RESULT acvp_add_hmac_drbg_cap_parm (
  * Append a DRBG pre req val to the
  */
 static ACVP_RESULT acvp_add_drbg_prereq_val(ACVP_DRBG_CAP_MODE *drbg_cap_mode,
-                   ACVP_DRBG_MODE mode, ACVP_DRBG_PRE_REQ pre_req, char *value)
+                   ACVP_DRBG_MODE mode, ACVP_PREREQ_ALG pre_req, char *value)
 {
-    ACVP_DRBG_PREREQ_VALS *prereq_entry, *prereq_entry_2;
+    ACVP_PREREQ_LIST *prereq_entry, *prereq_entry_2;
 
-    prereq_entry = calloc(1, sizeof(ACVP_DRBG_PREREQ_VALS));
+    prereq_entry = calloc(1, sizeof(ACVP_PREREQ_LIST));
     if (!prereq_entry) {
         return ACVP_MALLOC_FAIL;
     }
@@ -1214,6 +1056,111 @@ static ACVP_RESULT acvp_add_drbg_prereq_val(ACVP_DRBG_CAP_MODE *drbg_cap_mode,
     }
     return (ACVP_SUCCESS);
 }
+
+static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG pre_req) {
+    switch(cipher) {
+    case ACVP_AES_GCM:
+    case ACVP_AES_CCM:
+    case ACVP_AES_ECB:
+    case ACVP_AES_CFB1:
+    case ACVP_AES_CFB8:
+    case ACVP_AES_CFB128:
+    case ACVP_AES_OFB:
+    case ACVP_AES_CBC:
+    case ACVP_AES_KW:
+    case ACVP_AES_CTR:
+    case ACVP_TDES_ECB:
+    case ACVP_TDES_CBC:
+    case ACVP_TDES_OFB:
+    case ACVP_TDES_CFB64:
+    case ACVP_TDES_CFB8:
+    case ACVP_TDES_CFB1:
+        if (pre_req == ACVP_PREREQ_AES ||
+            pre_req == ACVP_PREREQ_DRBG)
+            return ACVP_SUCCESS;
+        break;
+    case ACVP_SHA1:
+    case ACVP_SHA224:
+    case ACVP_SHA256:
+    case ACVP_SHA384:
+    case ACVP_SHA512:
+        return ACVP_INVALID_ARG;
+        break;
+    case ACVP_HASHDRBG:
+    case ACVP_HMACDRBG:
+    case ACVP_CTRDRBG:
+        if (pre_req == ACVP_PREREQ_AES ||
+            pre_req == ACVP_PREREQ_DRBG ||
+            pre_req == ACVP_PREREQ_SHA ||
+            pre_req == ACVP_PREREQ_TDES)
+            return ACVP_SUCCESS;
+        break;
+    case ACVP_HMAC_SHA1:
+    case ACVP_HMAC_SHA2_224:
+    case ACVP_HMAC_SHA2_256:
+    case ACVP_HMAC_SHA2_384:
+    case ACVP_HMAC_SHA2_512:
+        if (pre_req == ACVP_PREREQ_SHA)
+            return ACVP_SUCCESS;
+        break;
+    case ACVP_CMAC_AES_128:
+    case ACVP_CMAC_AES_192:
+    case ACVP_CMAC_AES_256:
+    case ACVP_CMAC_TDES:
+        if (pre_req == ACVP_PREREQ_AES)
+            return ACVP_SUCCESS;
+        break;
+    case ACVP_RSA:
+        if (pre_req == ACVP_PREREQ_SHA)
+            return ACVP_SUCCESS;
+        break;
+    case ACVP_KDF135_TLS:
+    case ACVP_KDF135_SNMP:
+        if (pre_req == ACVP_PREREQ_SHA ||
+            pre_req == ACVP_PREREQ_HMAC)
+            return ACVP_SUCCESS;
+        break;
+    default:
+        break;
+    }
+
+    return ACVP_INVALID_ARG;
+}
+
+static ACVP_RESULT acvp_add_prereq_val(ACVP_CIPHER cipher,
+                    ACVP_CAPS_LIST *cap_list,
+                    ACVP_PREREQ_ALG pre_req, char *value)
+{
+    ACVP_PREREQ_LIST *prereq_entry, *prereq_entry_2;
+    ACVP_RESULT result;
+
+    prereq_entry = calloc(1, sizeof(ACVP_PREREQ_LIST));
+    if (!prereq_entry) {
+        return ACVP_MALLOC_FAIL;
+    }
+    prereq_entry->prereq_alg_val.alg = pre_req;
+    prereq_entry->prereq_alg_val.val = value;
+
+    result = acvp_validate_prereq_val(cipher, pre_req);
+    if (result != ACVP_SUCCESS) return result;
+    /*
+     * 1st entry
+     */
+    if (!cap_list->prereq_vals) {
+        cap_list->prereq_vals = prereq_entry;
+    } else {
+        /*
+         * append to the last in the list
+         */
+        prereq_entry_2 = cap_list->prereq_vals;
+        while (prereq_entry_2->next) {
+            prereq_entry_2 = prereq_entry_2->next;
+        }
+        prereq_entry_2->next = prereq_entry;
+    }
+    return (ACVP_SUCCESS);
+}
+
 
 /*
  * Add top level RSA keygen parameters
@@ -1240,38 +1187,6 @@ static ACVP_RESULT acvp_add_rsa_keygen_parm (
     }
 
     return ACVP_SUCCESS;
-}
-
-/*
- * Append a RSA pre req val to the list of prereqs
- */
-static ACVP_RESULT acvp_add_rsa_prereq_val(ACVP_RSA_CAP *rsa_cap, ACVP_RSA_PRE_REQ pre_req, char *value)
-{
-    ACVP_RSA_PREREQ_VALS *prereq_entry, *prereq_entry_2;
-
-    prereq_entry = calloc(1, sizeof(ACVP_RSA_PREREQ_VALS));
-    if (!prereq_entry) {
-        return ACVP_MALLOC_FAIL;
-    }
-    prereq_entry->prereq_alg_val.alg = pre_req;
-    prereq_entry->prereq_alg_val.val = value;
-
-    /*
-     * 1st entry
-     */
-    if (!rsa_cap->prereq_vals) {
-        rsa_cap->prereq_vals= prereq_entry;
-    } else {
-        /*
-         * append to the last in the list
-         */
-        prereq_entry_2 = rsa_cap->prereq_vals;
-        while (prereq_entry_2->next) {
-            prereq_entry_2 = prereq_entry_2->next;
-        }
-        prereq_entry_2->next = prereq_entry;
-    }
-    return (ACVP_SUCCESS);
 }
 
 ACVP_RESULT acvp_rsa_prepare_to_add_param(ACVP_CTX *ctx, ACVP_CIPHER cipher,
@@ -1433,7 +1348,6 @@ ACVP_RESULT acvp_enable_rsa_cap_parm (ACVP_CTX *ctx,
     ACVP_RSA_CAP_MODE_LIST      *rsa_cap_mode_list;
     ACVP_CAPS_LIST              *cap_list;
     ACVP_RESULT                 result;
-
     result = acvp_rsa_prepare_to_add_param(ctx, cipher, mode, &cap_list,
                                            &rsa_cap_mode_list);
     if(result != ACVP_SUCCESS) return result;
@@ -1742,7 +1656,7 @@ ACVP_RESULT acvp_enable_drbg_cap_parm (ACVP_CTX *ctx,
 ACVP_RESULT acvp_enable_drbg_prereq_cap(ACVP_CTX          *ctx,
                              ACVP_CIPHER       cipher,
                              ACVP_DRBG_MODE    mode,
-                             ACVP_DRBG_PRE_REQ pre_req,
+                             ACVP_PREREQ_ALG pre_req,
                              char              *value)
 {
     ACVP_DRBG_CAP_MODE_LIST *drbg_cap_mode_list;
@@ -1779,7 +1693,6 @@ ACVP_RESULT acvp_enable_drbg_prereq_cap(ACVP_CTX          *ctx,
     /*
      * Add the value to the cap
      */
-
     return (acvp_add_drbg_prereq_val(&drbg_cap_mode_list->cap_mode, mode, pre_req, value));
 }
 
@@ -1863,32 +1776,6 @@ ACVP_RESULT acvp_enable_drbg_cap(
     return result;
 }
 
-ACVP_RESULT acvp_enable_rsa_prereq_cap(ACVP_CTX          *ctx,
-                                       ACVP_CIPHER       cipher,
-                                       ACVP_RSA_PRE_REQ pre_req,
-                                       char              *value)
-{
-    ACVP_CAPS_LIST          *cap_list;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    /*
-     * Locate this cipher in the caps array
-     */
-    cap_list = acvp_locate_cap_entry(ctx, cipher);
-    if (!cap_list) {
-        ACVP_LOG_ERR("Cap entry not found.");
-        return ACVP_NO_CAP;
-    }
-
-    /*
-     * Add the value to the cap
-     */
-    return (acvp_add_rsa_prereq_val(cap_list->cap.rsa_cap, pre_req, value));
-}
-
 ACVP_RESULT acvp_enable_rsa_cap(
      ACVP_CTX *ctx,
      ACVP_CIPHER cipher,
@@ -1916,7 +1803,6 @@ ACVP_RESULT acvp_enable_rsa_cap(
         return ACVP_MALLOC_FAIL;
     }
 
-    rsa_cap->cipher = cipher;
     result = acvp_append_rsa_caps_entry(ctx, rsa_cap, cipher, crypto_handler);
     if (result != ACVP_SUCCESS) {
         free(rsa_cap);
@@ -2032,7 +1918,7 @@ ACVP_RESULT acvp_set_cacerts(ACVP_CTX *ctx, char *ca_file)
     /*
      * Enable peer verification when CA certs are provided.
      */
-    ctx->verify_peer = 1;
+    ctx->verify_peer = 0;
 
     return ACVP_SUCCESS;
 }
@@ -2059,6 +1945,51 @@ ACVP_RESULT acvp_set_certkey(ACVP_CTX *ctx, char *cert_file, char *key_file)
 }
 
 
+static ACVP_RESULT acvp_lookup_prereqVals (JSON_Object *cap_obj, ACVP_CAPS_LIST *cap_entry)
+{
+    JSON_Array *prereq_array = NULL;
+    ACVP_PREREQ_LIST *prereq_vals, *next_pre_req;
+    ACVP_PREREQ_ALG_VAL *pre_req;
+    char *alg_str;
+    int i = 0;
+
+    if(!cap_entry) return ACVP_INVALID_ARG;
+
+    /*
+     * Init json array
+     */
+    json_object_set_value(cap_obj, "prereqVals", json_value_init_array());
+    prereq_array = json_object_get_array(cap_obj, "prereqVals");
+
+    /*
+     * return OK if nothing present
+     */
+     prereq_vals = cap_entry->prereq_vals;
+
+     while (prereq_vals) {
+        JSON_Value *val = NULL;
+        JSON_Object *obj = NULL;
+        val = json_value_init_object();
+        obj = json_value_get_object(val);
+        pre_req = &prereq_vals->prereq_alg_val;
+
+        for (i = 0; i < ACVP_NUM_PREREQS; i++) {
+            if (acvp_prereqs_tbl[i].alg == pre_req->alg) {
+                alg_str = acvp_prereqs_tbl[i].name;
+                json_object_set_string(obj, "algorithm", alg_str);
+                json_object_set_string(obj, "value", pre_req->val);
+                break;
+            }
+        }
+
+        json_array_append_value(prereq_array, val);
+        next_pre_req = prereq_vals->next;
+        prereq_vals = next_pre_req;
+    }
+
+    return ACVP_SUCCESS;
+}
+
 static ACVP_RESULT acvp_build_hash_register_cap(JSON_Object *cap_obj, ACVP_CAPS_LIST *cap_entry)
 {
     json_object_set_string(cap_obj, "algorithm", acvp_lookup_cipher_name(cap_entry->cipher));
@@ -2072,6 +2003,7 @@ static ACVP_RESULT acvp_build_hmac_register_cap(JSON_Object *cap_obj, ACVP_CAPS_
 {
     JSON_Array *temp_arr = NULL;
     ACVP_SL_LIST *sl_list;
+    ACVP_RESULT result;
 
     json_object_set_string(cap_obj, "algorithm", acvp_lookup_cipher_name(cap_entry->cipher));
     json_object_set_value(cap_obj, "keyRange1", json_value_init_array());
@@ -2098,50 +2030,9 @@ static ACVP_RESULT acvp_build_hmac_register_cap(JSON_Object *cap_obj, ACVP_CAPS_
       sl_list = sl_list->next;
     }
 
-    JSON_Array *prereq_array = NULL;
+    result = acvp_lookup_prereqVals(cap_obj, cap_entry);
+    if (result != ACVP_SUCCESS) return result;
 
-    ACVP_HMAC_PREREQ_VALS *prereq_vals;
-    ACVP_HMAC_PREREQ_VALS *next_pre_req;
-    ACVP_HMAC_PREREQ_ALG_VAL *pre_req;
-    char *alg_str;
-    /*
-     * Init json array
-     */
-    json_object_set_value(cap_obj, "prereqVals", json_value_init_array());
-    prereq_array = json_object_get_array(cap_obj, "prereqVals");
-
-    /*
-     * return OK if nothing present
-     */
-    prereq_vals = cap_entry->cap.hmac_cap->prereq_vals;
-    if(!prereq_vals) {
-        goto end;
-    }
-
-
-    while (prereq_vals) {
-        JSON_Value *val = NULL;
-        JSON_Object *obj = NULL;
-        val = json_value_init_object();
-        obj = json_value_get_object(val);
-        pre_req = &prereq_vals->prereq_alg_val;
-
-        switch(pre_req->alg) {
-        case HMAC_SHA:
-            alg_str = ACVP_HMAC_PREREQ_SHA;
-            json_object_set_string(obj, "algorithm", alg_str);
-            json_object_set_string(obj, "value", pre_req->val);
-            break;
-        default:
-            return ACVP_INVALID_ARG;
-        }
-
-        json_array_append_value(prereq_array, val);
-        next_pre_req = prereq_vals->next;
-        prereq_vals = next_pre_req;
-    }
-
-    end:
     return ACVP_SUCCESS;
 }
 
@@ -2150,6 +2041,7 @@ static ACVP_RESULT acvp_build_cmac_register_cap(JSON_Object *cap_obj, ACVP_CAPS_
     JSON_Array *temp_arr = NULL;
     ACVP_SL_LIST *sl_list;
     int i;
+    ACVP_RESULT result;
 
     json_object_set_string(cap_obj, "algorithm", acvp_lookup_cipher_name(cap_entry->cipher));
     json_object_set_value(cap_obj, "msgLen", json_value_init_array());
@@ -2172,105 +2064,12 @@ static ACVP_RESULT acvp_build_cmac_register_cap(JSON_Object *cap_obj, ACVP_CAPS_
       sl_list = sl_list->next;
     }
 
-    JSON_Array *prereq_array = NULL;
-
-    ACVP_CMAC_PREREQ_VALS *prereq_vals;
-    ACVP_CMAC_PREREQ_VALS *next_pre_req;
-    ACVP_CMAC_PREREQ_ALG_VAL *pre_req;
-    char *alg_str;
-    /*
-     * Init json array
-     */
-    json_object_set_value(cap_obj, "prereqVals", json_value_init_array());
-    prereq_array = json_object_get_array(cap_obj, "prereqVals");
-
-    /*
-     * return OK if nothing present
-     */
-    prereq_vals = cap_entry->cap.cmac_cap->prereq_vals;
-    if(!prereq_vals) {
-        goto end;
-    }
-
-
-    while (prereq_vals) {
-        JSON_Value *val = NULL;
-        JSON_Object *obj = NULL;
-        val = json_value_init_object();
-        obj = json_value_get_object(val);
-        pre_req = &prereq_vals->prereq_alg_val;
-
-        switch(pre_req->alg) {
-        case CMAC_AES:
-            alg_str = ACVP_CMAC_PREREQ_AES;
-            json_object_set_string(obj, "algorithm", alg_str);
-            json_object_set_string(obj, "value", pre_req->val);
-            break;
-        default:
-            return ACVP_INVALID_ARG;
-        }
-
-        json_array_append_value(prereq_array, val);
-        next_pre_req = prereq_vals->next;
-        prereq_vals = next_pre_req;
-    }
-
-    end:
-    return ACVP_SUCCESS;
-}
-
-static ACVP_RESULT acvp_lookup_sym_prereqVals (JSON_Object *cap_obj, ACVP_SYM_CIPHER_CAP *sym_cap)
-{
-    JSON_Array *prereq_array = NULL;
-    ACVP_SYM_PREREQ_VALS *prereq_vals;
-    ACVP_SYM_PREREQ_ALG_VAL *pre_req;
-    ACVP_SYM_PREREQ_VALS *next_pre_req;
-    char *alg_str;
-
-    if(!sym_cap) return ACVP_INVALID_ARG;
-
-    /*
-     * Init json array
-     */
-    json_object_set_value(cap_obj, "prereqVals", json_value_init_array());
-    prereq_array = json_object_get_array(cap_obj, "prereqVals");
-
-    /*
-     * return OK if nothing present
-     */
-    prereq_vals = sym_cap->prereq_vals;
-    if(!prereq_vals) {
-        return ACVP_SUCCESS;
-    }
-
-    while (prereq_vals) {
-        JSON_Value *val = NULL;
-        JSON_Object *obj = NULL;
-        val = json_value_init_object();
-        obj = json_value_get_object(val);
-        pre_req = &prereq_vals->prereq_alg_val;
-
-        switch(pre_req->alg) {
-        case ACVP_SYM_PREREQ_AES:
-            alg_str = ACVP_SYM_PREREQ_AES_STR;
-            json_object_set_string(obj, "algorithm", alg_str);
-            json_object_set_string(obj, "value", pre_req->val);
-            break;
-        case ACVP_SYM_PREREQ_DRBG:
-            alg_str = ACVP_SYM_PREREQ_DRBG_STR;
-            json_object_set_string(obj, "algorithm", alg_str);
-            json_object_set_string(obj, "value", pre_req->val);
-            break;
-        default:
-            return ACVP_INVALID_ARG;
-        }
-        json_array_append_value(prereq_array, val);
-        next_pre_req = prereq_vals->next;
-        prereq_vals = next_pre_req;
-    }
+    result = acvp_lookup_prereqVals(cap_obj, cap_entry);
+    if(result != ACVP_SUCCESS) return result;
 
     return ACVP_SUCCESS;
 }
+
 
 static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP_CAPS_LIST *cap_entry)
 {
@@ -2283,7 +2082,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
     json_object_set_string(cap_obj, "algorithm", acvp_lookup_cipher_name(cap_entry->cipher));
 
     sym_cap = cap_entry->cap.sym_cap;
-    result = acvp_lookup_sym_prereqVals(cap_obj, sym_cap);
+    result = acvp_lookup_prereqVals(cap_obj, cap_entry);
     if (result != ACVP_SUCCESS) return result;
 
     /*
@@ -2474,10 +2273,8 @@ static char *acvp_lookup_drbg_mode_string (ACVP_CAPS_LIST *cap_entry)
 static ACVP_RESULT acvp_lookup_drbg_prereqVals (JSON_Object *cap_obj, ACVP_DRBG_CAP_MODE *drbg_cap_mode)
 {
     JSON_Array *prereq_array = NULL;
-
-    ACVP_DRBG_PREREQ_VALS *prereq_vals;
-    ACVP_DRBG_PREREQ_VALS *next_pre_req;
-    ACVP_DRBG_PREREQ_ALG_VAL *pre_req;
+    ACVP_PREREQ_LIST *prereq_vals, *next_pre_req;
+    ACVP_PREREQ_ALG_VAL *pre_req;
     char *alg_str;
 
     if(!drbg_cap_mode) return ACVP_INVALID_ARG;
@@ -2504,25 +2301,13 @@ static ACVP_RESULT acvp_lookup_drbg_prereqVals (JSON_Object *cap_obj, ACVP_DRBG_
         obj = json_value_get_object(val);
         pre_req = &prereq_vals->prereq_alg_val;
 
-        switch(pre_req->alg) {
-        case DRBG_SHA:
-            alg_str = ACVP_DRBG_PREREQ_SHA;
-            json_object_set_string(obj, "algorithm", alg_str);
-            json_object_set_string(obj, "value", pre_req->val);
-            break;
-        case DRBG_HMAC:
-            alg_str = ACVP_DRBG_PREREQ_HMAC;
-            json_object_set_string(obj, "algorithm", alg_str);
-            json_object_set_string(obj, "value", pre_req->val);
-            break;
-        case DRBG_AES:
-            alg_str = ACVP_DRBG_PREREQ_AES;
-            json_object_set_string(obj, "algorithm", alg_str);
-            json_object_set_string(obj, "value", pre_req->val);
-            break;
-        case DRBG_TDES:
-        default:
-            return ACVP_INVALID_ARG;
+        for (i = 0; i < ACVP_NUM_PREREQS; i++) {
+            if (acvp_prereqs_tbl[i].alg == pre_req->alg) {
+                alg_str = acvp_prereqs_tbl[i].name;
+                json_object_set_string(obj, "algorithm", alg_str);
+                json_object_set_string(obj, "value", pre_req->val);
+                break;
+            }
         }
 
         json_array_append_value(prereq_array, val);
@@ -2681,55 +2466,6 @@ static ACVP_RESULT acvp_lookup_rsa_primes(JSON_Object *cap_obj, ACVP_RSA_CAP *rs
     return ACVP_SUCCESS;
 }
 
-static ACVP_RESULT acvp_lookup_rsa_prereqVals (JSON_Object *cap_obj, ACVP_RSA_CAP *rsa_cap)
-{
-    JSON_Array *prereq_array = NULL;
-
-    ACVP_RSA_PREREQ_VALS *prereq_vals;
-    ACVP_RSA_PREREQ_VALS *next_pre_req;
-    ACVP_RSA_PREREQ_ALG_VAL *pre_req;
-    char *alg_str;
-
-    if(!rsa_cap) return ACVP_INVALID_ARG;
-
-    /*
-     * Init json array
-     */
-    json_object_set_value(cap_obj, "prereqVals", json_value_init_array());
-    prereq_array = json_object_get_array(cap_obj, "prereqVals");
-
-    /*
-     * return OK if nothing present
-     */
-    prereq_vals = rsa_cap->prereq_vals;
-    if(!prereq_vals) {
-        return ACVP_SUCCESS;
-    }
-
-    while (prereq_vals) {
-        JSON_Value *val = NULL;
-        JSON_Object *obj = NULL;
-        val = json_value_init_object();
-        obj = json_value_get_object(val);
-        pre_req = &prereq_vals->prereq_alg_val;
-
-        switch(pre_req->alg) {
-        case RSA_SHA:
-            alg_str = ACVP_RSA_PREREQ_SHA;
-            json_object_set_string(obj, "algorithm", alg_str);
-            json_object_set_string(obj, "value", pre_req->val);
-            break;
-        default:
-            return ACVP_INVALID_ARG;
-        }
-
-        json_array_append_value(prereq_array, val);
-        next_pre_req = prereq_vals->next;
-        prereq_vals = next_pre_req;
-    }
-    return ACVP_SUCCESS;
-}
-
 static char *acvp_lookup_rsa_mode_string (ACVP_RSA_MODE mode)
 {
     char *mode_str = NULL;
@@ -2772,7 +2508,7 @@ static ACVP_RESULT acvp_build_rsa_register_cap(JSON_Object *cap_obj, ACVP_CAPS_L
     JSON_Object *mode_specs_obj = NULL, *cap_specs_obj = NULL;
 
     json_object_set_string(cap_obj, "algorithm", acvp_lookup_cipher_name(cap_entry->cipher));
-    result = acvp_lookup_rsa_prereqVals(cap_obj, cap_entry->cap.rsa_cap);
+    result = acvp_lookup_prereqVals(cap_obj, cap_entry);
     if (result != ACVP_SUCCESS) return result;
 
     json_object_set_value(cap_obj, "algSpecs", json_value_init_array());
@@ -2808,6 +2544,7 @@ static ACVP_RESULT acvp_build_rsa_register_cap(JSON_Object *cap_obj, ACVP_CAPS_L
 static ACVP_RESULT acvp_build_kdf135_tls_register_cap(JSON_Object *cap_obj, ACVP_CAPS_LIST *cap_entry)
 {
     JSON_Array *temp_arr = NULL;
+    ACVP_RESULT result;
 
     json_object_set_string(cap_obj, "algorithm", acvp_lookup_cipher_name(cap_entry->cipher));
     json_object_set_value(cap_obj, "methods", json_value_init_array());
@@ -2831,108 +2568,19 @@ static ACVP_RESULT acvp_build_kdf135_tls_register_cap(JSON_Object *cap_obj, ACVP
     if (cap_entry->cap.kdf135_tls_cap->sha || ACVP_KDF135_TLS_CAP_SHA512)
         json_array_append_string(temp_arr, "SHA-512");
 
-
-    JSON_Array *prereq_array = NULL;
-
-    ACVP_KDF135_TLS_PREREQ_VALS *prereq_vals;
-    ACVP_KDF135_TLS_PREREQ_VALS *next_pre_req;
-    ACVP_KDF135_TLS_PREREQ_ALG_VAL *pre_req;
-    char *alg_str;
-    /*
-     * Init json array
-     */
-    json_object_set_value(cap_obj, "prereqVals", json_value_init_array());
-    prereq_array = json_object_get_array(cap_obj, "prereqVals");
-
-    /*
-     * return OK if nothing present
-     */
-    prereq_vals = cap_entry->cap.kdf135_tls_cap->prereq_vals;
-    if(!prereq_vals) {
-        goto end;
-    }
-
-
-    while (prereq_vals) {
-        JSON_Value *val = NULL;
-        JSON_Object *obj = NULL;
-        val = json_value_init_object();
-        obj = json_value_get_object(val);
-        pre_req = &prereq_vals->prereq_alg_val;
-
-        switch(pre_req->alg) {
-        case ACVP_KDF135_TLS_PREREQ_SHA:
-            alg_str = ACVP_KDF135_TLS_PREREQ_SHA_STR;
-            json_object_set_string(obj, "algorithm", alg_str);
-            json_object_set_string(obj, "value", pre_req->val);
-            break;
-        case ACVP_KDF135_TLS_PREREQ_HMAC:
-            alg_str = ACVP_KDF135_TLS_PREREQ_HMAC_STR;
-            json_object_set_string(obj, "algorithm", alg_str);
-            json_object_set_string(obj, "value", pre_req->val);
-            break;
-        default:
-            return ACVP_INVALID_ARG;
-        }
-
-        json_array_append_value(prereq_array, val);
-        next_pre_req = prereq_vals->next;
-        prereq_vals = next_pre_req;
-    }
-
-    end:
+    result = acvp_lookup_prereqVals(cap_obj, cap_entry);
+    if(result != ACVP_SUCCESS) return result;
 
     return ACVP_SUCCESS;
 }
 
 static ACVP_RESULT acvp_build_kdf135_snmp_register_cap(JSON_Object *cap_obj, ACVP_CAPS_LIST *cap_entry)
 {
+    ACVP_RESULT result;
     json_object_set_string(cap_obj, "algorithm", acvp_lookup_cipher_name(cap_entry->cipher));
 
-    JSON_Array *prereq_array = NULL;
-
-    ACVP_KDF135_SNMP_PREREQ_VALS *prereq_vals;
-    ACVP_KDF135_SNMP_PREREQ_VALS *next_pre_req;
-    ACVP_KDF135_SNMP_PREREQ_ALG_VAL *pre_req;
-    char *alg_str;
-    /*
-     * Init json array
-     */
-    json_object_set_value(cap_obj, "prereqVals", json_value_init_array());
-    prereq_array = json_object_get_array(cap_obj, "prereqVals");
-
-    /*
-     * return OK if nothing present
-     */
-    prereq_vals = cap_entry->cap.kdf135_snmp_cap->prereq_vals;
-    if(!prereq_vals) {
-        goto end;
-    }
-
-
-    while (prereq_vals) {
-        JSON_Value *val = NULL;
-        JSON_Object *obj = NULL;
-        val = json_value_init_object();
-        obj = json_value_get_object(val);
-        pre_req = &prereq_vals->prereq_alg_val;
-
-        switch(pre_req->alg) {
-        case ACVP_KDF135_SNMP_PREREQ_SHA:
-            alg_str = ACVP_KDF135_SNMP_PREREQ_SHA_STR;
-            json_object_set_string(obj, "algorithm", alg_str);
-            json_object_set_string(obj, "value", pre_req->val);
-            break;
-        default:
-            return ACVP_INVALID_ARG;
-        }
-
-        json_array_append_value(prereq_array, val);
-        next_pre_req = prereq_vals->next;
-        prereq_vals = next_pre_req;
-    }
-
-    end:
+    result = acvp_lookup_prereqVals(cap_obj, cap_entry);
+    if(result != ACVP_SUCCESS) return result;
 
     return ACVP_SUCCESS;
 }
@@ -3169,7 +2817,6 @@ static ACVP_RESULT acvp_build_register(ACVP_CTX *ctx, char **reg)
     json_object_set_value(obj, "capabilityExchange", caps_val);
 
     json_array_append_value(reg_arry, val);
-    //*reg = json_serialize_to_string(val);
     *reg = json_serialize_to_string_pretty(reg_arry_val);
     json_value_free(reg_arry_val);
     json_value_free(dep_val);
@@ -3552,7 +3199,6 @@ static ACVP_RESULT acvp_parse_register(ACVP_CTX *ctx)
      * processing later.
      */
     cap_obj = json_object_get_object(obj, "capabilityResponse");
-    //const char *op = json_object_get_string(obj, "operation");
     vect_sets = json_object_get_array(cap_obj, "vectorSets");
     vs_cnt = json_array_get_count(vect_sets);
     for (i = 0; i < vs_cnt; i++) {
@@ -3986,54 +3632,6 @@ ACVP_RESULT acvp_enable_kdf135_tls_cap_parm(
     return ACVP_SUCCESS;
 }
 
-ACVP_RESULT acvp_enable_kdf135_tls_prereq_cap(ACVP_CTX       *ctx,
-                                          ACVP_KDF135_TLS_METHOD method,
-                                          ACVP_KDF135_TLS_PRE_REQ pre_req,
-                                          char              *value)
-{
-    ACVP_CAPS_LIST          *cap_list;
-
-    if (!ctx) {
-        return ACVP_INVALID_ARG;
-    }
-
-    /*
-     * Locate this cipher in the caps array
-     */
-    cap_list = acvp_locate_cap_entry(ctx, ACVP_KDF135_TLS);
-    if (!cap_list) {
-        ACVP_LOG_ERR("Cap entry not found.");
-        return ACVP_NO_CAP;
-    }
-
-    ACVP_KDF135_TLS_PREREQ_VALS *prereq_entry, *prereq_entry_2;
-
-    prereq_entry = calloc(1, sizeof(ACVP_KDF135_TLS_PREREQ_VALS));
-    if (!prereq_entry) {
-        return ACVP_MALLOC_FAIL;
-    }
-    prereq_entry->prereq_alg_val.alg = pre_req;
-    prereq_entry->prereq_alg_val.val = value;
-
-    /*
-     * 1st entry
-     */
-    if (!cap_list->cap.kdf135_tls_cap->prereq_vals) {
-        cap_list->cap.kdf135_tls_cap->prereq_vals= prereq_entry;
-    } else {
-        /*
-         * append to the last in the list
-         */
-        prereq_entry_2 = cap_list->cap.kdf135_tls_cap->prereq_vals;
-        while (prereq_entry_2->next) {
-            prereq_entry_2 = prereq_entry_2->next;
-        }
-        prereq_entry_2->next = prereq_entry;
-    }
-
-    return ACVP_SUCCESS;
-}
-
 static ACVP_RESULT acvp_append_kdf135_snmp_caps_entry(
        ACVP_CTX *ctx,
        ACVP_KDF135_SNMP_CAP *cap,
@@ -4082,52 +3680,3 @@ ACVP_RESULT acvp_enable_kdf135_snmp_cap(
 
     return (acvp_append_kdf135_snmp_caps_entry(ctx, cap, crypto_handler));
 }
-
-
-ACVP_RESULT acvp_enable_kdf135_snmp_prereq_cap(ACVP_CTX       *ctx,
-                                          ACVP_KDF135_SNMP_PRE_REQ pre_req,
-                                          char              *value)
-{
-    ACVP_CAPS_LIST          *cap_list;
-
-    if (!ctx) {
-        return ACVP_INVALID_ARG;
-    }
-
-    /*
-     * Locate this cipher in the caps array
-     */
-    cap_list = acvp_locate_cap_entry(ctx, ACVP_KDF135_SNMP);
-    if (!cap_list) {
-        ACVP_LOG_ERR("Cap entry not found.");
-        return ACVP_NO_CAP;
-    }
-
-    ACVP_KDF135_SNMP_PREREQ_VALS *prereq_entry, *prereq_entry_2;
-
-    prereq_entry = calloc(1, sizeof(ACVP_KDF135_SNMP_PREREQ_VALS));
-    if (!prereq_entry) {
-        return ACVP_MALLOC_FAIL;
-    }
-    prereq_entry->prereq_alg_val.alg = pre_req;
-    prereq_entry->prereq_alg_val.val = value;
-
-    /*
-     * 1st entry
-     */
-    if (!cap_list->cap.kdf135_snmp_cap->prereq_vals) {
-        cap_list->cap.kdf135_snmp_cap->prereq_vals= prereq_entry;
-    } else {
-        /*
-         * append to the last in the list
-         */
-        prereq_entry_2 = cap_list->cap.kdf135_snmp_cap->prereq_vals;
-        while (prereq_entry_2->next) {
-            prereq_entry_2 = prereq_entry_2->next;
-        }
-        prereq_entry_2->next = prereq_entry;
-    }
-
-    return ACVP_SUCCESS;
-}
-

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2090,19 +2090,19 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
      */
     json_object_set_value(cap_obj, "direction", json_value_init_array());
     mode_arr = json_object_get_array(cap_obj, "direction");
-    if (cap_entry->cap.sym_cap->direction == ACVP_DIR_ENCRYPT ||
-        cap_entry->cap.sym_cap->direction == ACVP_DIR_BOTH) {
+    if (sym_cap->direction == ACVP_DIR_ENCRYPT ||
+        sym_cap->direction == ACVP_DIR_BOTH) {
 	json_array_append_string(mode_arr, "encrypt");
     }
-    if (cap_entry->cap.sym_cap->direction == ACVP_DIR_DECRYPT ||
-        cap_entry->cap.sym_cap->direction == ACVP_DIR_BOTH) {
+    if (sym_cap->direction == ACVP_DIR_DECRYPT ||
+        sym_cap->direction == ACVP_DIR_BOTH) {
 	json_array_append_string(mode_arr, "decrypt");
     }
 
     /*
      * Set the IV generation source if applicable
      */
-    switch(cap_entry->cap.sym_cap->ivgen_source) {
+    switch(sym_cap->ivgen_source) {
     case ACVP_IVGEN_SRC_INT:
 	json_object_set_string(cap_obj, "ivGen", "internal");
 	break;
@@ -2117,7 +2117,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
     /*
      * Set the IV generation mode if applicable
      */
-    switch(cap_entry->cap.sym_cap->ivgen_mode) {
+    switch(sym_cap->ivgen_mode) {
     case ACVP_IVGEN_MODE_821:
 	json_object_set_string(cap_obj, "ivGenMode", "8.2.1");
 	break;
@@ -2132,15 +2132,15 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
     /*
      * Set the TDES keyingOptions  if applicable
      */
-    if (cap_entry->cap.sym_cap->keying_option != ACVP_KO_NA) {
+    if (sym_cap->keying_option != ACVP_KO_NA) {
         json_object_set_value(cap_obj, "keyingOption", json_value_init_array());
     	opts_arr = json_object_get_array(cap_obj, "keyingOption");
-        if (cap_entry->cap.sym_cap->keying_option == ACVP_KO_THREE ||
-            cap_entry->cap.sym_cap->keying_option == ACVP_KO_BOTH) {
+        if (sym_cap->keying_option == ACVP_KO_THREE ||
+            sym_cap->keying_option == ACVP_KO_BOTH) {
 	    json_array_append_number(opts_arr, 1);
         }
-    	if (cap_entry->cap.sym_cap->keying_option == ACVP_KO_TWO ||
-            cap_entry->cap.sym_cap->keying_option == ACVP_KO_BOTH) {
+    	if (sym_cap->keying_option == ACVP_KO_TWO ||
+            sym_cap->keying_option == ACVP_KO_BOTH) {
 	    json_array_append_number(opts_arr, 2);
         }
     }
@@ -2149,7 +2149,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
      */
     json_object_set_value(cap_obj, "keyLen", json_value_init_array());
     opts_arr = json_object_get_array(cap_obj, "keyLen");
-    sl_list = cap_entry->cap.sym_cap->keylen;
+    sl_list = sym_cap->keylen;
     while (sl_list) {
 	json_array_append_number(opts_arr, sl_list->length);
 	sl_list = sl_list->next;
@@ -2161,7 +2161,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
     if ((cap_entry->cipher == ACVP_AES_GCM) || (cap_entry->cipher == ACVP_AES_CCM)) {
         json_object_set_value(cap_obj, "tagLen", json_value_init_array());
     	opts_arr = json_object_get_array(cap_obj, "tagLen");
-    	sl_list = cap_entry->cap.sym_cap->taglen;
+    	sl_list = sym_cap->taglen;
     	while (sl_list) {
 	   json_array_append_number(opts_arr, sl_list->length);
 	   sl_list = sl_list->next;
@@ -2190,7 +2190,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
 	default:
     	    json_object_set_value(cap_obj, "ivLen", json_value_init_array());
     	    opts_arr = json_object_get_array(cap_obj, "ivLen");
-    	    sl_list = cap_entry->cap.sym_cap->ivlen;
+    	    sl_list = sym_cap->ivlen;
     	    while (sl_list) {
 	        json_array_append_number(opts_arr, sl_list->length);
 		sl_list = sl_list->next;
@@ -2201,7 +2201,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
      */
     json_object_set_value(cap_obj, "ptLen", json_value_init_array());
     opts_arr = json_object_get_array(cap_obj, "ptLen");
-    sl_list = cap_entry->cap.sym_cap->ptlen;
+    sl_list = sym_cap->ptlen;
     while (sl_list) {
 	json_array_append_number(opts_arr, sl_list->length);
 	sl_list = sl_list->next;
@@ -2213,7 +2213,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
     if ((cap_entry->cipher == ACVP_AES_GCM) || (cap_entry->cipher == ACVP_AES_CCM)) {
         json_object_set_value(cap_obj, "aadLen", json_value_init_array());
     	opts_arr = json_object_get_array(cap_obj, "aadLen");
-    	sl_list = cap_entry->cap.sym_cap->aadlen;
+    	sl_list = sym_cap->aadlen;
     	while (sl_list) {
 	    json_array_append_number(opts_arr, sl_list->length);
 	    sl_list = sl_list->next;
@@ -2276,6 +2276,7 @@ static ACVP_RESULT acvp_lookup_drbg_prereqVals (JSON_Object *cap_obj, ACVP_DRBG_
     ACVP_PREREQ_LIST *prereq_vals, *next_pre_req;
     ACVP_PREREQ_ALG_VAL *pre_req;
     char *alg_str;
+    int i;
 
     if(!drbg_cap_mode) return ACVP_INVALID_ARG;
 

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1918,7 +1918,7 @@ ACVP_RESULT acvp_set_cacerts(ACVP_CTX *ctx, char *ca_file)
     /*
      * Enable peer verification when CA certs are provided.
      */
-    ctx->verify_peer = 0;
+    ctx->verify_peer = 1;
 
     return ACVP_SUCCESS;
 }

--- a/src/acvp.h
+++ b/src/acvp.h
@@ -146,7 +146,7 @@ typedef enum acvp_prereq_mode_t {
 typedef struct acvp_prereqs_mode_name_t {
     ACVP_PREREQ_ALG alg;
     char *name;
-};
+} ACVP_PREREQ_MODE_NAME;
 
 #define ACVP_KDF135_SNMP_ENGID_MAX 32
 #define ACVP_KDF135_SNMP_SKEY_MAX 32

--- a/src/acvp.h
+++ b/src/acvp.h
@@ -134,27 +134,22 @@ typedef enum acvp_sym_cipher {
     ACVP_CIPHER_END
 } ACVP_CIPHER;
 
-#define ACVP_SYM_PREREQ_AES_STR      "AES"
-#define ACVP_SYM_PREREQ_DRBG_STR     "DRBG"
-typedef enum acvp_sym_pre_req {
-    ACVP_SYM_PREREQ_AES = 1,
-    ACVP_SYM_PREREQ_DRBG
-} ACVP_SYM_PRE_REQ;
 
-#define ACVP_KDF135_TLS_PREREQ_HMAC_STR    "HMAC"
-#define ACVP_KDF135_TLS_PREREQ_SHA_STR     "SHA"
+typedef enum acvp_prereq_mode_t {
+  ACVP_PREREQ_AES = 1,
+  ACVP_PREREQ_TDES,
+  ACVP_PREREQ_DRBG,
+  ACVP_PREREQ_HMAC,
+  ACVP_PREREQ_SHA
+} ACVP_PREREQ_ALG;
 
-typedef enum acvp_kdf135_tls_pre_req {
-    ACVP_KDF135_TLS_PREREQ_HMAC = 1,
-    ACVP_KDF135_TLS_PREREQ_SHA
-} ACVP_KDF135_TLS_PRE_REQ;
+typedef struct acvp_prereqs_mode_name_t {
+    ACVP_PREREQ_ALG alg;
+    char *name;
+};
 
 #define ACVP_KDF135_SNMP_ENGID_MAX 32
 #define ACVP_KDF135_SNMP_SKEY_MAX 32
-#define ACVP_KDF135_SNMP_PREREQ_SHA_STR     "SHA"
-typedef enum acvp_kdf135_snmp_pre_req {
-    ACVP_KDF135_SNMP_PREREQ_SHA = 1
-} ACVP_KDF135_SNMP_PRE_REQ;
 
 /* these are bit flags */
 typedef enum acvp_kdf135_tls_cap_parm {
@@ -275,18 +270,6 @@ typedef enum acvp_drbg_param {
     ACVP_DRBG_PRE_REQ_VALS
 } ACVP_DRBG_PARM;
 
-#define ACVP_DRBG_PREREQ_SHA      "SHA"
-#define ACVP_DRBG_PREREQ_HMAC     "HMAC"
-#define ACVP_DRBG_PREREQ_AES      "AES"
-#define ACVP_DRBG_PREREQ_TDES     "TDES"
-typedef enum acvp_drbg_pre_req {
-    DRBG_SHA = 1,
-    DRBG_HMAC,
-    DRBG_AES,
-    DRBG_TDES
-} ACVP_DRBG_PRE_REQ;
-
-
 #define ACVP_RSA_PRIME_SHA_1         "SHA-1"
 #define ACVP_RSA_PRIME_SHA_224       "SHA-224"
 #define ACVP_RSA_PRIME_SHA_256       "SHA-256"
@@ -323,11 +306,6 @@ typedef enum acvp_rsa_param {
 #define RSA_PUB_EXP_FIXED      1
 #define RSA_PUB_EXP_RANDOM     0
 
-#define ACVP_RSA_PREREQ_SHA      "SHA"
-typedef enum acvp_rsa_pre_req {
-    RSA_SHA = 1,
-} ACVP_RSA_PRE_REQ;
-
 typedef enum acvp_rsa_mode {
     ACVP_RSA_MODE_START = 0,
     ACVP_RSA_MODE_KEYGEN,
@@ -356,11 +334,6 @@ typedef enum acvp_hash_testtype {
     ACVP_HASH_TEST_TYPE_MCT
 } ACVP_HASH_TESTTYPE;
 
-#define ACVP_HMAC_PREREQ_SHA      "SHA"
-typedef enum acvp_hmac_pre_req {
-    HMAC_SHA = 1
-} ACVP_HMAC_PRE_REQ;
-
 typedef enum acvp_hmac_parameter {
     ACVP_HMAC_KEYRANGE1_MIN = 0,
     ACVP_HMAC_KEYRANGE1_MAX,
@@ -370,11 +343,6 @@ typedef enum acvp_hmac_parameter {
     ACVP_HMAC_IN_EMPTY,
     ACVP_HMAC_MACLEN
 } ACVP_HMAC_PARM;
-
-#define ACVP_CMAC_PREREQ_AES      "AES"
-typedef enum acvp_cmac_pre_req {
-    CMAC_AES = 1
-} ACVP_CMAC_PRE_REQ;
 
 typedef enum acvp_cmac_parameter {
     ACVP_CMAC_MACLEN,
@@ -741,11 +709,6 @@ ACVP_RESULT acvp_enable_sym_cipher_cap_parm(
 	ACVP_SYM_CIPH_PARM parm,
 	int length);
 
-ACVP_RESULT acvp_enable_sym_prereq_cap(ACVP_CTX *ctx,
-                                       ACVP_CIPHER      cipher,
-                              	       ACVP_SYM_PRE_REQ pre_req_cap,
-                              	       char              *value);
-
 /*! @brief acvp_enable_hash_cap() allows an application to specify a
        hash capability to be tested by the ACVP server.
 
@@ -776,8 +739,6 @@ ACVP_RESULT acvp_enable_hash_cap_parm (
 		   ACVP_CIPHER cipher,
                    ACVP_HASH_PARM       param,
                    int                  value);
-
-
 
 /*! @brief acvp_enable_drbg_cap() allows an application to specify a
        hash capability to be tested by the ACVP server.
@@ -816,7 +777,7 @@ ACVP_RESULT acvp_enable_drbg_prereq_cap(
                              ACVP_CTX *ctx,
                              ACVP_CIPHER cipher,
                              ACVP_DRBG_MODE mode,
-                             ACVP_DRBG_PRE_REQ pre_req,
+                             ACVP_PREREQ_ALG pre_req,
                              char *value
                              );
 
@@ -867,13 +828,6 @@ ACVP_RESULT acvp_enable_rsa_bignum_parm (ACVP_CTX *ctx,
                              BIGNUM *value
                            );
 
-ACVP_RESULT acvp_enable_rsa_prereq_cap(
-                            ACVP_CTX *ctx,
-                            ACVP_CIPHER cipher,
-                            ACVP_RSA_PRE_REQ pre_req,
-                            char *value
-                            );
-
 ACVP_RESULT acvp_enable_rsa_primes_parm (ACVP_CTX *ctx,
                              ACVP_CIPHER cipher,
                              ACVP_RSA_MODE mode,
@@ -913,12 +867,6 @@ ACVP_RESULT acvp_enable_hmac_cap_parm(
                           ACVP_HMAC_PARM parm,
                           int value);
 
-ACVP_RESULT acvp_enable_hmac_prereq_cap(
-                          ACVP_CTX       *ctx,
-                          ACVP_CIPHER       cipher,
-                          ACVP_HMAC_PRE_REQ pre_req,
-                          char              *value);
-
 /*! @brief acvp_enable_cmac_cap() allows an application to specify an
 	   CMAC capability to be tested by the ACVP server.
 
@@ -950,7 +898,7 @@ ACVP_RESULT acvp_enable_cmac_cap_parm(
                           ACVP_CMAC_PARM parm,
                           int value);
 
-/*! @brief acvp_enable_kdf135_tls_cap() allows an application to specify a
+/*! @brief acvp_enable_kdf135_*_cap() allows an application to specify a
        kdf cipher capability to be tested by the ACVP server.
 
     When the application enables a crypto capability, such as KDF135_TLS, it
@@ -970,11 +918,6 @@ ACVP_RESULT acvp_enable_kdf135_tls_cap(
           ACVP_KDF135_TLS_METHOD method,
           ACVP_RESULT (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-ACVP_RESULT acvp_enable_kdf135_tls_prereq_cap(
-                          ACVP_CTX       *ctx,
-                          ACVP_KDF135_TLS_METHOD method,
-                          ACVP_KDF135_TLS_PRE_REQ pre_req,
-                          char              *value);
 ACVP_RESULT acvp_enable_kdf135_tls_cap_parm(
                           ACVP_CTX *ctx,
                           ACVP_CIPHER cap,
@@ -986,10 +929,22 @@ ACVP_RESULT acvp_enable_kdf135_snmp_cap(
           ACVP_CTX *ctx,
           ACVP_RESULT (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-ACVP_RESULT acvp_enable_kdf135_snmp_prereq_cap(
-                          ACVP_CTX       *ctx,
-                          ACVP_KDF135_SNMP_PRE_REQ pre_req,
-                          char              *value);
+/*! @brief acvp_enable_prereq_cap() allows an application to specify a
+       prerequisite for a cipher capability that was previously registered.
+
+    @param ctx Address of pointer to a previously allocated ACVP_CTX.
+    @param cipher ACVP_CIPHER enum value identifying the crypto capability that has a prerequisite
+    @param pre_req_alg ACVP_PREREQ_ALG enum identifying the prerequisite
+    @param value value for specified prerequisite
+
+    @return ACVP_RESULT
+ */
+
+ACVP_RESULT acvp_enable_prereq_cap(
+                ACVP_CTX *ctx,
+                ACVP_CIPHER cipher,
+                ACVP_PREREQ_ALG pre_req_cap,
+                char *value);
 
 /*! @brief acvp_create_test_session() creates a context that can be used to
       commence a test session with an ACVP server.

--- a/src/acvp_lcl.h
+++ b/src/acvp_lcl.h
@@ -190,18 +190,17 @@ typedef struct acvp_sl_list_t {
     struct acvp_sl_list_t *next;
 } ACVP_SL_LIST;
 
-typedef struct acvp_sym_prereq_alg_val {
-    ACVP_SYM_PRE_REQ alg;
+typedef struct acvp_prereq_alg_val {
+    ACVP_PREREQ_ALG alg;
     char *val;
-} ACVP_SYM_PREREQ_ALG_VAL;
+} ACVP_PREREQ_ALG_VAL;
 
-typedef struct acvp_sym_prereq_vals {
-    ACVP_SYM_PREREQ_ALG_VAL prereq_alg_val;
-    struct acvp_sym_prereq_vals *next;
-} ACVP_SYM_PREREQ_VALS;
+typedef struct acvp_prereq_list {
+    ACVP_PREREQ_ALG_VAL prereq_alg_val;
+    struct acvp_prereq_list *next;
+} ACVP_PREREQ_LIST;
 
 typedef struct acvp_sym_cipher_capability {
-    ACVP_SYM_PREREQ_VALS *prereq_vals;
     ACVP_SYM_CIPH_DIR direction;
     ACVP_SYM_CIPH_KO keying_option;
     ACVP_SYM_CIPH_IVGEN_SRC ivgen_source;
@@ -218,48 +217,16 @@ typedef struct acvp_hash_capability {
     int               in_empty;
 } ACVP_HASH_CAP;
 
-typedef struct acvp_kdf135_tls_prereq_alg_val {
-    ACVP_KDF135_TLS_PRE_REQ alg;
-    char *val;
-} ACVP_KDF135_TLS_PREREQ_ALG_VAL;
-
-typedef struct acvp_kdf135_tls_prereq_vals {
-    ACVP_KDF135_TLS_PREREQ_ALG_VAL prereq_alg_val;
-    struct acvp_kdf135_tls_prereq_vals *next;
-} ACVP_KDF135_TLS_PREREQ_VALS;
-
 typedef struct acvp_kdf135_tls_capability {
-    ACVP_KDF135_TLS_PREREQ_VALS     *prereq_vals;
     int                   method[2];
     int    	  	  sha;
 } ACVP_KDF135_TLS_CAP;
 
-typedef struct acvp_kdf135_snmp_prereq_alg_val {
-    ACVP_KDF135_SNMP_PRE_REQ alg;
-    char *val;
-} ACVP_KDF135_SNMP_PREREQ_ALG_VAL;
-
-typedef struct acvp_kdf135_snmp_prereq_vals {
-    ACVP_KDF135_SNMP_PREREQ_ALG_VAL prereq_alg_val;
-    struct acvp_kdf135_snmp_prereq_vals *next;
-} ACVP_KDF135_SNMP_PREREQ_VALS;
-
 typedef struct acvp_kdf135_snmp_capability {
-    ACVP_KDF135_SNMP_PREREQ_VALS     *prereq_vals;
+
 } ACVP_KDF135_SNMP_CAP;
 
-typedef struct acvp_hmac_prereq_alg_val {
-    ACVP_HMAC_PRE_REQ alg;
-    char *val;
-} ACVP_HMAC_PREREQ_ALG_VAL;
-
-typedef struct acvp_hmac_prereq_vals {
-    ACVP_HMAC_PREREQ_ALG_VAL prereq_alg_val;
-    struct acvp_hmac_prereq_vals *next;
-} ACVP_HMAC_PREREQ_VALS;
-
 typedef struct acvp_hmac_capability {
-    ACVP_HMAC_PREREQ_VALS     *prereq_vals;
     int                       key_range_1[2];      //":"65536"
     int                       key_range_2[2];      //":"65536"
     int                       key_block;        //":"yes"
@@ -267,37 +234,16 @@ typedef struct acvp_hmac_capability {
     ACVP_SL_LIST              *mac_len;
 } ACVP_HMAC_CAP;
 
-typedef struct acvp_cmac_prereq_alg_val {
-    ACVP_CMAC_PRE_REQ alg;
-    char *val;
-} ACVP_CMAC_PREREQ_ALG_VAL;
-
-typedef struct acvp_cmac_prereq_vals {
-    ACVP_CMAC_PREREQ_ALG_VAL prereq_alg_val;
-    struct acvp_cmac_prereq_vals *next;
-} ACVP_CMAC_PREREQ_VALS;
-
 typedef struct acvp_cmac_capability {
-    ACVP_CMAC_PREREQ_VALS     *prereq_vals;
     int                       in_empty;         //":"yes"
     ACVP_SL_LIST              *mac_len;
     int                       msg_len[5];
 } ACVP_CMAC_CAP;
 
-typedef struct acvp_drbg_prereq_alg_val {
-    ACVP_DRBG_PRE_REQ alg;
-    char *val;
-} ACVP_DRBG_PREREQ_ALG_VAL;
-
-typedef struct acvp_drbg_prereq_vals {
-    ACVP_DRBG_PREREQ_ALG_VAL prereq_alg_val;
-    struct acvp_drbg_prereq_vals *next;
-} ACVP_DRBG_PREREQ_VALS;
-
 typedef struct acvp_drbg_cap_mode {
     ACVP_DRBG_MODE   mode;                   //"3KeyTDEA",
     int              der_func_enabled;       //":"yes",
-    ACVP_DRBG_PREREQ_VALS *prereq_vals;
+    ACVP_PREREQ_LIST *prereq_vals;
     int              pred_resist_enabled;    //": "yes",
     int              reseed_implemented;     //" : "yes",
     int              entropy_input_len;      //":"112",
@@ -355,16 +301,6 @@ typedef struct acvp_rsa_primes_list {
    struct acvp_rsa_primes_list *next;
 } ACVP_RSA_PRIMES_LIST;
 
-typedef struct acvp_rsa_prereq_alg_val {
-    ACVP_RSA_PRE_REQ alg;
-    char *val;
-} ACVP_RSA_PREREQ_ALG_VAL;
-
-typedef struct acvp_rsa_prereq_vals {
-    ACVP_RSA_PREREQ_ALG_VAL prereq_alg_val;
-    struct acvp_rsa_prereq_vals *next;
-} ACVP_RSA_PREREQ_VALS;
-
 typedef struct acvp_rsa_keygen_attrs_t {
     ACVP_RSA_MODE   mode;                    // "keyGen"
     int pub_exp;                             // 0 - random, 1 - fixed
@@ -384,13 +320,13 @@ typedef struct acvp_rsa_cap_mode_list_t {
 
 typedef struct acvp_rsa_capability {
   ACVP_CIPHER               cipher;
-  ACVP_RSA_PREREQ_VALS *prereq_vals;
   ACVP_RSA_CAP_MODE_LIST *rsa_cap_mode_list;
 } ACVP_RSA_CAP;
 
 typedef struct acvp_caps_list_t {
     ACVP_CIPHER       cipher;
     ACVP_CAP_TYPE     cap_type;
+    ACVP_PREREQ_LIST *prereq_vals;
     union {
       ACVP_SYM_CIPHER_CAP   *sym_cap;
       ACVP_HASH_CAP         *hash_cap;


### PR DESCRIPTION
Collapses repeated prereq code into common structs and methods

DRBG prereqs are not included in this because the prereqs for DRBG are added according to each mode and therefore exist at a different level