### PR TITLE
Spec updates

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -359,256 +359,256 @@ int main(int argc, char **argv)
    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PTLEN, 1536);
    CHECK_ENABLE_CAP_RV(rv);
 
-   /*
-    * Enable AES-CBC 128 bit key
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CBC, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_KEYLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_KEYLEN, 256);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PTLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable AES-CBC 128 bit key
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CBC, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_KEYLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_KEYLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PTLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   /*
-    * Enable AES-CFB8 128,192,256 bit key
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CFB8, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_KEYLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_KEYLEN, 256);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PTLEN, 256);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable AES-CFB8 128,192,256 bit key
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CFB8, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_KEYLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_KEYLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PTLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   /*
-    * Enable AES-CFB128 128,192,256 bit key
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CFB128, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_KEYLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_KEYLEN, 256);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PTLEN, 1536);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable AES-CFB128 128,192,256 bit key
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CFB128, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_KEYLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_KEYLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PTLEN, 1536);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   /*
-    * Enable AES-OFB 128, 192, 256 bit key
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_OFB, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_KEYLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_KEYLEN, 256);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PTLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable AES-OFB 128, 192, 256 bit key
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_OFB, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_KEYLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_KEYLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PTLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   /*
-    * Register AES CCM capabilities
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CCM, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler_aead);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_prereq_cap(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, value);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 256);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_PTLEN, 0);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_PTLEN, 256);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_IVLEN, 56);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_AADLEN, 0);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_AADLEN, 65536);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Register AES CCM capabilities
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CCM, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler_aead);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_PTLEN, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_PTLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_IVLEN, 56);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_AADLEN, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_AADLEN, 65536);
+    CHECK_ENABLE_CAP_RV(rv);
 
 #ifdef ACVP_V04
-   /*
-    * Enable AES-CFB1 128,192,256 bit key
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CFB1, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_KEYLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_KEYLEN, 256);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PTLEN, 1536);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable AES-CFB1 128,192,256 bit key
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CFB1, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_KEYLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_KEYLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PTLEN, 1536);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   /*
-    * Enable AES keywrap for various key sizes and PT lengths
-    * Note: this is with padding disabled, minimum PT length is 128 bits and must be
-    *       a multiple of 64 bits. openssl does not support INVERSE mode.
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_KW, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_keywrap_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_value(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KW_MODE, ACVP_SYM_KW_CIPHER);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 256);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PTLEN, 512);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PTLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PTLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable AES keywrap for various key sizes and PT lengths
+     * Note: this is with padding disabled, minimum PT length is 128 bits and must be
+     *       a multiple of 64 bits. openssl does not support INVERSE mode.
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_KW, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_keywrap_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_value(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KW_MODE, ACVP_SYM_KW_CIPHER);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PTLEN, 512);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PTLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PTLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   /*
-    * Enable AES-CTR 128 bit key
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CTR, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_KEYLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PTLEN, 128);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable AES-CTR 128 bit key
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_AES_CTR, ACVP_DIR_BOTH, ACVP_KO_NA, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_aes_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_KEYLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PTLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
 #endif
 
-   /*
-    * Enable 3DES-ECB
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_ECB, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PTLEN, 16*8*4);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable 3DES-ECB
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_ECB, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PTLEN, 16*8*4);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   /*
-    * Enable 3DES-CBC
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_CBC, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_IVLEN, 192/3);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64*2);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64*3);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64*12);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable 3DES-CBC
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_CBC, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_IVLEN, 192/3);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64*2);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64*3);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64*12);
+    CHECK_ENABLE_CAP_RV(rv);
 
 #ifdef ACVP_V04
-   /*
-    * Enable 3DES-OFB
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_OFB, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_IVLEN, 192/3);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PTLEN, 64);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable 3DES-OFB
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_OFB, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_IVLEN, 192/3);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PTLEN, 64);
+    CHECK_ENABLE_CAP_RV(rv);
 #endif
 
 #ifdef ACVP_V05
-   /*
-    * Enable 3DES-CFB64
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_CFB64, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_IVLEN, 192/3);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PTLEN, 64 * 5);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable 3DES-CFB64
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_CFB64, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_IVLEN, 192/3);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PTLEN, 64 * 5);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   /*
-    * Enable 3DES-CFB8
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_CFB8, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_IVLEN, 192/3);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PTLEN, 64);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PTLEN, 64 * 4);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable 3DES-CFB8
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_CFB8, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_IVLEN, 192/3);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PTLEN, 64);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PTLEN, 64 * 4);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   /*
-    * Enable 3DES-CFB1
-    */
-   rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_CFB1, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_KEYLEN, 192);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_IVLEN, 192/3);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PTLEN, 64);
-   CHECK_ENABLE_CAP_RV(rv);
+    /*
+     * Enable 3DES-CFB1
+     */
+    rv = acvp_enable_sym_cipher_cap(ctx, ACVP_TDES_CFB1, ACVP_DIR_BOTH, ACVP_KO_THREE, ACVP_IVGEN_SRC_NA, ACVP_IVGEN_MODE_NA, &app_des_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_KEYLEN, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_IVLEN, 192/3);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_sym_cipher_cap_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PTLEN, 64);
+    CHECK_ENABLE_CAP_RV(rv);
 #endif
    /*
     * Enable SHA-1 and SHA-2
     */
-   rv = acvp_enable_hash_cap(ctx, ACVP_SHA1, &app_sha_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA1, ACVP_HASH_IN_BIT, 0);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA1, ACVP_HASH_IN_EMPTY, 1);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap(ctx, ACVP_SHA1, &app_sha_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA1, ACVP_HASH_IN_BIT, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA1, ACVP_HASH_IN_EMPTY, 1);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   rv = acvp_enable_hash_cap(ctx, ACVP_SHA224, &app_sha_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA224, ACVP_HASH_IN_BIT, 0);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA224, ACVP_HASH_IN_EMPTY, 1);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap(ctx, ACVP_SHA224, &app_sha_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA224, ACVP_HASH_IN_BIT, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA224, ACVP_HASH_IN_EMPTY, 1);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   rv = acvp_enable_hash_cap(ctx, ACVP_SHA256, &app_sha_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA256, ACVP_HASH_IN_BIT, 0);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA256, ACVP_HASH_IN_EMPTY, 1);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap(ctx, ACVP_SHA256, &app_sha_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA256, ACVP_HASH_IN_BIT, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA256, ACVP_HASH_IN_EMPTY, 1);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   rv = acvp_enable_hash_cap(ctx, ACVP_SHA384, &app_sha_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA384, ACVP_HASH_IN_BIT, 0);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA384, ACVP_HASH_IN_EMPTY, 1);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap(ctx, ACVP_SHA384, &app_sha_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA384, ACVP_HASH_IN_BIT, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA384, ACVP_HASH_IN_EMPTY, 1);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   rv = acvp_enable_hash_cap(ctx, ACVP_SHA512, &app_sha_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA512, ACVP_HASH_IN_BIT, 0);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA512, ACVP_HASH_IN_EMPTY, 1);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap(ctx, ACVP_SHA512, &app_sha_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA512, ACVP_HASH_IN_BIT, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_hash_cap_parm(ctx, ACVP_SHA512, ACVP_HASH_IN_EMPTY, 1);
+    CHECK_ENABLE_CAP_RV(rv);
 
-#ifdef ACVP_V04
+ #ifdef ACVP_V04
     /*
      * Enable CMAC
      */
@@ -690,44 +690,44 @@ int main(int argc, char **argv)
 #endif
 
 #ifdef OPENSSL_KDF_SUPPORT
-   /*
-    * Enable KDF-135
-    */
+    /*
+     * Enable KDF-135
+     */
 
-   rv = acvp_enable_kdf135_tls_cap(ctx, ACVP_KDF135_TLS, &app_kdf135_tls_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_TLS, ACVP_PREREQ_SHA, value);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_TLS, ACVP_PREREQ_HMAC, value);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_kdf135_tls_cap_parm(ctx, ACVP_KDF135_TLS, ACVP_KDF135_TLS12, ACVP_KDF135_TLS_CAP_SHA256 | ACVP_KDF135_TLS_CAP_SHA384 | ACVP_KDF135_TLS_CAP_SHA512);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kdf135_tls_cap(ctx, ACVP_KDF135_TLS, &app_kdf135_tls_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_TLS, ACVP_PREREQ_SHA, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_TLS, ACVP_PREREQ_HMAC, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kdf135_tls_cap_parm(ctx, ACVP_KDF135_TLS, ACVP_KDF135_TLS12, ACVP_KDF135_TLS_CAP_SHA256 | ACVP_KDF135_TLS_CAP_SHA384 | ACVP_KDF135_TLS_CAP_SHA512);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   rv = acvp_enable_kdf135_snmp_cap(ctx, &app_kdf135_snmp_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, value);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kdf135_snmp_cap(ctx, &app_kdf135_snmp_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, value);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   rv = acvp_enable_kdf135_ssh_cap(ctx, &app_kdf135_ssh_handler);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, value);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_TDES, value);
-   CHECK_ENABLE_CAP_RV(rv);
-   rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_AES, value);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kdf135_ssh_cap(ctx, &app_kdf135_ssh_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_TDES, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_AES, value);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   rv = acvp_enable_kdf135_ssh_cap_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_TDES_CBC, ACVP_KDF135_SSH_CAP_SHA256 | ACVP_KDF135_SSH_CAP_SHA384 | ACVP_KDF135_SSH_CAP_SHA512);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kdf135_ssh_cap_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_TDES_CBC, ACVP_KDF135_SSH_CAP_SHA256 | ACVP_KDF135_SSH_CAP_SHA384 | ACVP_KDF135_SSH_CAP_SHA512);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   rv = acvp_enable_kdf135_ssh_cap_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_128_CBC, ACVP_KDF135_SSH_CAP_SHA256 | ACVP_KDF135_SSH_CAP_SHA384 | ACVP_KDF135_SSH_CAP_SHA512);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kdf135_ssh_cap_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_128_CBC, ACVP_KDF135_SSH_CAP_SHA256 | ACVP_KDF135_SSH_CAP_SHA384 | ACVP_KDF135_SSH_CAP_SHA512);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   rv = acvp_enable_kdf135_ssh_cap_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_192_CBC, ACVP_KDF135_SSH_CAP_SHA256 | ACVP_KDF135_SSH_CAP_SHA384 | ACVP_KDF135_SSH_CAP_SHA512);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kdf135_ssh_cap_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_192_CBC, ACVP_KDF135_SSH_CAP_SHA256 | ACVP_KDF135_SSH_CAP_SHA384 | ACVP_KDF135_SSH_CAP_SHA512);
+    CHECK_ENABLE_CAP_RV(rv);
 
-   rv = acvp_enable_kdf135_ssh_cap_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_256_CBC, ACVP_KDF135_SSH_CAP_SHA256 | ACVP_KDF135_SSH_CAP_SHA384 | ACVP_KDF135_SSH_CAP_SHA512);
-   CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kdf135_ssh_cap_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_256_CBC, ACVP_KDF135_SSH_CAP_SHA256 | ACVP_KDF135_SSH_CAP_SHA384 | ACVP_KDF135_SSH_CAP_SHA512);
+    CHECK_ENABLE_CAP_RV(rv);
 #endif
 
 #if 0 /* until DSA is supported on the server side */
@@ -765,13 +765,13 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
-#ifdef ACVP_NO_RUNTIME
+ #ifdef ACVP_NO_RUNTIME
 
 #if 0 /* until RSA is supported on the server side */
     /*
      * Enable RSA keygen...
      */
-    rv = acvp_enable_rsa_cap(ctx, ACVP_RSA, &app_rsa_sigver_handler);
+    rv = acvp_enable_rsa_cap(ctx, ACVP_RSA, &app_rsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_prereq_cap(ctx, ACVP_RSA, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -844,136 +844,137 @@ int main(int argc, char **argv)
 // RSA w/ sigType: X9.31
     rv = acvp_enable_rsa_cap_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, ACVP_SIG_TYPE, RSA_SIG_TYPE_X931);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
 // RSA w/ sigType: PKCS1v1.5
     rv = acvp_enable_rsa_cap_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, ACVP_SIG_TYPE, RSA_SIG_TYPE_PKCS1V15);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
 // RSA w/ sigType: PKCS1PSS -- has saltSigGen
     rv = acvp_enable_rsa_cap_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, ACVP_SIG_TYPE, RSA_SIG_TYPE_PKCS1PSS);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGGEN, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
     CHECK_ENABLE_CAP_RV(rv);
 
 // RSA w/ sigType: PKCS1v1.5
     rv = acvp_enable_rsa_cap_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, ACVP_SIG_TYPE, RSA_SIG_TYPE_PKCS1V15);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_2048, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_3072, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1V15, MOD_RSA_4096, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
 // RSA w/ sigType: X9.31
     rv = acvp_enable_rsa_cap_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, ACVP_SIG_TYPE, RSA_SIG_TYPE_X931);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_2048, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_3072, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_224);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_256);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_512);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_X931, MOD_RSA_4096, ACVP_RSA_SHA_512, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
 // RSA w/ sigType: PKCS1PSS -- has saltSigVer, so new function is made as suggested by Ellie
     rv = acvp_enable_rsa_cap_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, ACVP_SIG_TYPE, RSA_SIG_TYPE_PKCS1PSS);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_2048, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_3072, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_224, RSA_SALT_SIGGEN_28);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_256, RSA_SALT_SIGGEN_32);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_rsa_cap_sig_type_salt_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
+    rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
+#ifdef ACVP_NO_RUNTIME
 #if 0  /* until drbg is supported by the server */
     /*
      * Register DRBG
@@ -2466,11 +2467,22 @@ static ACVP_RESULT app_rsa_handler(ACVP_TEST_CASE *test_case)
      * to be filled in
      */
     ACVP_RSA_TC    *tc;
+    ACVP_RESULT rv;
     RSA       *rsa;
+    
+    /* keygen vars */
     unsigned int bitlen1, bitlen2, bitlen3, bitlen4, seed_len, keylen;
     BIGNUM *exponent;
     unsigned long m;
     unsigned char *seed = NULL;
+
+    /* siggen vars */
+    EVP_MD *tc_md = NULL;
+    unsigned char *msg = NULL, *sigbuf = NULL;
+    int siglen, pad_mode;
+    long msglen = -1;
+    BIGNUM *bn_e = NULL;    
+    
     if (!test_case) {
         return ACVP_INVALID_ARG;
     }
@@ -2532,10 +2544,140 @@ static ACVP_RESULT app_rsa_handler(ACVP_TEST_CASE *test_case)
         BN_free(exponent);
         RSA_free(rsa);
         break;
+    case ACVP_RSA_MODE_SIGGEN:
+//        if(strncmp(tc->sig_tc->sig_attrs_tc->hash_alg, ACVP_RSA_SHA_1, RSA_HASH_ALG_MAX_LEN ) == 0 ) {
+//            tc_md = (EVP_MD *)EVP_sha1();
+//        } else if(strncmp(tc->sig_tc->sig_attrs_tc->hash_alg, ACVP_RSA_SHA_224, RSA_HASH_ALG_MAX_LEN ) == 0 ) {
+//            tc_md = (EVP_MD *)EVP_sha224();
+//        } else if(strncmp(tc->sig_tc->sig_attrs_tc->hash_alg, ACVP_RSA_SHA_256, RSA_HASH_ALG_MAX_LEN ) == 0 ) {
+//            tc_md = (EVP_MD *)EVP_sha256();
+//        } else if(strncmp(tc->sig_tc->sig_attrs_tc->hash_alg, ACVP_RSA_SHA_384, RSA_HASH_ALG_MAX_LEN ) == 0 ) {
+//            tc_md = (EVP_MD *)EVP_sha384();
+//        } else if(strncmp(tc->sig_tc->sig_attrs_tc->hash_alg, ACVP_RSA_SHA_512, RSA_HASH_ALG_MAX_LEN ) == 0 ) {
+//            tc_md = (EVP_MD *)EVP_sha512();
+//        } else {
+//            printf("\nError: hashAlg not supported for RSA SigGen\n");
+//            rv = ACVP_INVALID_ARG;
+//            goto err;
+//        }
+//
+//        /*
+//         * Set the message given from the tc to binary form
+//         */
+//        msg = calloc(1,RSA_MSG_MAX_LEN);
+//        if(!msg) {
+//            printf("\nError: Alloc failure in RSA SigGen Handler\n");
+//            rv = ACVP_INVALID_ARG;
+//            goto err;
+//        }
+//        rv = acvp_hexstr_to_bin(tc->sig_tc->sig_attrs_tc->msg,msg,RSA_MSG_MAX_LEN);
+//        if (rv != ACVP_SUCCESS) {
+//            printf("\nError: hex2bin error for RSA SigGen\n");
+//            rv = ACVP_INVALID_ARG;
+//            goto err;
+//        }
+//        msglen = strlen((const char*)tc->sig_tc->sig_attrs_tc->msg)/2;
+//        /*
+//         * Make an RSA object and set a new BN exponent to use to generate a key
+//         */
+//        rsa = FIPS_rsa_new();
+//        if (!rsa) {
+//            printf("\nError: Issue with RSA obj in RSA SigGen\n");
+//            rv = ACVP_CRYPTO_MODULE_FAIL;
+//            goto err;
+//        }
+//        bn_e = BN_new();
+//        if (!bn_e || !BN_set_word(bn_e, 0x1001)) {
+//            printf("\nError: Issue with exponent in RSA SigGen\n");
+//            rv = ACVP_CRYPTO_MODULE_FAIL;
+//            goto err;
+//        }
+//        if (!tc->sig_tc->sig_attrs_tc->modulo) {
+//            printf("\nError: Issue with modulo in RSA SigGen\n");
+//            rv = ACVP_CRYPTO_MODULE_FAIL;
+//            goto err;
+//        }
+//
+//        /*
+//         * Set the pad mode and generate a key given the respective sigType
+//         */
+//        if(strncmp(tc->sig_tc->sig_type, RSA_SIG_TYPE_X931_NAME, RSA_SIG_TYPE_MAX ) == 0 ) {
+//            pad_mode = RSA_X931_PADDING;
+//            if (!RSA_X931_generate_key_ex(rsa, tc->sig_tc->sig_attrs_tc->modulo, bn_e, NULL)) {
+//                printf("\nError: Issue with keygen during siggen mode for sigType %s\n",RSA_SIG_TYPE_X931_NAME);
+//                rv = ACVP_CRYPTO_MODULE_FAIL;
+//                goto err;
+//            }
+//        } else if(strncmp(tc->sig_tc->sig_type, RSA_SIG_TYPE_PKCS1V15_NAME, RSA_SIG_TYPE_MAX ) == 0 ) {
+//            pad_mode = RSA_PKCS1_PADDING;
+//            if (!RSA_X931_generate_key_ex(rsa, tc->sig_tc->sig_attrs_tc->modulo, bn_e, NULL)) {
+//                printf("\nError: Issue with keygen during siggen mode for sigType PKCS1V15\n");
+//                rv = ACVP_CRYPTO_MODULE_FAIL;
+//                goto err;
+//            }
+//        } else if(strncmp(tc->sig_tc->sig_type, RSA_SIG_TYPE_PKCS1PSS_NAME, RSA_SIG_TYPE_MAX ) == 0 ) {
+//            pad_mode = RSA_PKCS1_PSS_PADDING;
+//            if (!RSA_X931_generate_key_ex(rsa, tc->sig_tc->sig_attrs_tc->modulo, bn_e, NULL)) { /*** only need to (can) generate key with x931-- sigType doesn't matter for key generation ***/
+//                printf("\nError: Issue with keygen during siggen mode for sigType PKCS1PSS\n");
+//                rv = ACVP_CRYPTO_MODULE_FAIL;
+//                goto err;
+//            }
+//        } else {
+//            printf("\nError: sigType not supported\n");
+//            rv = ACVP_INVALID_ARG;
+//            goto err;
+//        }
+//
+//        /*
+//         * Retrieve and save the exponent and modulus from the key generation process
+//         */
+//        tc->sig_tc->sig_attrs_tc->e = BN_dup(rsa->e);
+//        tc->sig_tc->sig_attrs_tc->n = BN_dup(rsa->n);
+//
+//        if (msg && tc_md) {
+//            siglen = RSA_size(rsa);
+//            sigbuf = OPENSSL_malloc(siglen);
+//
+//            if (!sigbuf) {
+//                printf("\nError: SigBuf fail in RSA SigGen\n");
+//                rv = ACVP_CRYPTO_MODULE_FAIL;
+//                goto err;
+//            }
+//
+//            if (!FIPS_rsa_sign(rsa, msg, msglen, tc_md, pad_mode, tc->sig_tc->sig_attrs_tc->salt_len, NULL,
+//                                    sigbuf, (unsigned int *)&siglen)) {
+//                printf("\nError: RSA Signature Generation fail\n");
+//                rv = ACVP_CRYPTO_MODULE_FAIL;
+//                goto err;
+//            }
+//
+//            /*
+//             * Retrieve and save the signature generated from signing the generated key
+//             */
+//            tc->sig_tc->sig_attrs_tc->s = BN_bin2bn(sigbuf, siglen, NULL);
+//            if(!tc->sig_tc->sig_attrs_tc->s) {
+//                printf("\nError: RSA Signature BigNum alloc failure\n");
+//                rv = ACVP_MALLOC_FAIL;
+//                goto err;
+//            }
+//        }
+//        break;
+    case ACVP_RSA_MODE_SIGVER:
+        // rv = app_rsa_sigver_handler(test_case);
     default:
         break;
     }
+    
+    err:
+    if (msg) free(msg);
+    if (sigbuf) OPENSSL_free(sigbuf);
+    if (bn_e) BN_free(bn_e);
+//    if (rsa) FIPS_rsa_free(rsa);
+    
+    
+//    return rv;
     return ACVP_SUCCESS;
+
 }
 
 #ifdef ACVP_NO_RUNTIME

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -629,6 +629,23 @@ int main(int argc, char **argv)
     rv = acvp_enable_prereq_cap(ctx, ACVP_CMAC_AES_128, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
 
+    rv = acvp_enable_cmac_cap(ctx, ACVP_CMAC_TDES, &app_cmac_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_cmac_cap_parm(ctx, ACVP_CMAC_TDES, ACVP_CMAC_BLK_DIVISIBLE_1, 1024);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_cmac_cap_parm(ctx, ACVP_CMAC_TDES, ACVP_CMAC_BLK_NOT_DIVISIBLE_1, 2048);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_cmac_cap_parm(ctx, ACVP_CMAC_TDES, ACVP_CMAC_MACLEN, 64);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_cmac_cap_parm(ctx, ACVP_CMAC_TDES, ACVP_CMAC_MACLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_cmac_cap_parm(ctx, ACVP_CMAC_TDES, ACVP_CMAC_DIRECTION_GEN, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_cmac_cap_parm(ctx, ACVP_CMAC_TDES, ACVP_CMAC_DIRECTION_VER, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_CMAC_TDES, ACVP_PREREQ_AES, value);
+    CHECK_ENABLE_CAP_RV(rv);
+
     /*
      * Enable HMAC: TODO - need to add increment value in bits, default to 64 now.
      */
@@ -973,9 +990,7 @@ int main(int argc, char **argv)
     rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
     CHECK_ENABLE_CAP_RV(rv);
 #endif
-#endif
 
-#ifdef ACVP_NO_RUNTIME
 #if 0  /* until drbg is supported by the server */
     /*
      * Register DRBG
@@ -2529,8 +2544,6 @@ static ACVP_RESULT app_rsa_handler(ACVP_TEST_CASE *test_case)
         default:
             break;
         }
-        break;
-
         if(rsa_generate_key_internal(&rsa->p, &rsa->q, &rsa->n, &rsa->d,
                                       seed, seed_len,
                                       bitlen1, bitlen2, bitlen3, bitlen4,
@@ -2546,125 +2559,7 @@ static ACVP_RESULT app_rsa_handler(ACVP_TEST_CASE *test_case)
         RSA_free(rsa);
         break;
     case ACVP_RSA_MODE_SIGGEN:
-//        if(strncmp(tc->sig_tc->sig_attrs_tc->hash_alg, ACVP_RSA_SHA_1, RSA_HASH_ALG_MAX_LEN ) == 0 ) {
-//            tc_md = (EVP_MD *)EVP_sha1();
-//        } else if(strncmp(tc->sig_tc->sig_attrs_tc->hash_alg, ACVP_RSA_SHA_224, RSA_HASH_ALG_MAX_LEN ) == 0 ) {
-//            tc_md = (EVP_MD *)EVP_sha224();
-//        } else if(strncmp(tc->sig_tc->sig_attrs_tc->hash_alg, ACVP_RSA_SHA_256, RSA_HASH_ALG_MAX_LEN ) == 0 ) {
-//            tc_md = (EVP_MD *)EVP_sha256();
-//        } else if(strncmp(tc->sig_tc->sig_attrs_tc->hash_alg, ACVP_RSA_SHA_384, RSA_HASH_ALG_MAX_LEN ) == 0 ) {
-//            tc_md = (EVP_MD *)EVP_sha384();
-//        } else if(strncmp(tc->sig_tc->sig_attrs_tc->hash_alg, ACVP_RSA_SHA_512, RSA_HASH_ALG_MAX_LEN ) == 0 ) {
-//            tc_md = (EVP_MD *)EVP_sha512();
-//        } else {
-//            printf("\nError: hashAlg not supported for RSA SigGen\n");
-//            rv = ACVP_INVALID_ARG;
-//            goto err;
-//        }
-//
-//        /*
-//         * Set the message given from the tc to binary form
-//         */
-//        msg = calloc(1,RSA_MSG_MAX_LEN);
-//        if(!msg) {
-//            printf("\nError: Alloc failure in RSA SigGen Handler\n");
-//            rv = ACVP_INVALID_ARG;
-//            goto err;
-//        }
-//        rv = acvp_hexstr_to_bin(tc->sig_tc->sig_attrs_tc->msg,msg,RSA_MSG_MAX_LEN);
-//        if (rv != ACVP_SUCCESS) {
-//            printf("\nError: hex2bin error for RSA SigGen\n");
-//            rv = ACVP_INVALID_ARG;
-//            goto err;
-//        }
-//        msglen = strlen((const char*)tc->sig_tc->sig_attrs_tc->msg)/2;
-//        /*
-//         * Make an RSA object and set a new BN exponent to use to generate a key
-//         */
-//        rsa = FIPS_rsa_new();
-//        if (!rsa) {
-//            printf("\nError: Issue with RSA obj in RSA SigGen\n");
-//            rv = ACVP_CRYPTO_MODULE_FAIL;
-//            goto err;
-//        }
-//        bn_e = BN_new();
-//        if (!bn_e || !BN_set_word(bn_e, 0x1001)) {
-//            printf("\nError: Issue with exponent in RSA SigGen\n");
-//            rv = ACVP_CRYPTO_MODULE_FAIL;
-//            goto err;
-//        }
-//        if (!tc->sig_tc->sig_attrs_tc->modulo) {
-//            printf("\nError: Issue with modulo in RSA SigGen\n");
-//            rv = ACVP_CRYPTO_MODULE_FAIL;
-//            goto err;
-//        }
-//
-//        /*
-//         * Set the pad mode and generate a key given the respective sigType
-//         */
-//        if(strncmp(tc->sig_tc->sig_type, RSA_SIG_TYPE_X931_NAME, RSA_SIG_TYPE_MAX ) == 0 ) {
-//            pad_mode = RSA_X931_PADDING;
-//            if (!RSA_X931_generate_key_ex(rsa, tc->sig_tc->sig_attrs_tc->modulo, bn_e, NULL)) {
-//                printf("\nError: Issue with keygen during siggen mode for sigType %s\n",RSA_SIG_TYPE_X931_NAME);
-//                rv = ACVP_CRYPTO_MODULE_FAIL;
-//                goto err;
-//            }
-//        } else if(strncmp(tc->sig_tc->sig_type, RSA_SIG_TYPE_PKCS1V15_NAME, RSA_SIG_TYPE_MAX ) == 0 ) {
-//            pad_mode = RSA_PKCS1_PADDING;
-//            if (!RSA_X931_generate_key_ex(rsa, tc->sig_tc->sig_attrs_tc->modulo, bn_e, NULL)) {
-//                printf("\nError: Issue with keygen during siggen mode for sigType PKCS1V15\n");
-//                rv = ACVP_CRYPTO_MODULE_FAIL;
-//                goto err;
-//            }
-//        } else if(strncmp(tc->sig_tc->sig_type, RSA_SIG_TYPE_PKCS1PSS_NAME, RSA_SIG_TYPE_MAX ) == 0 ) {
-//            pad_mode = RSA_PKCS1_PSS_PADDING;
-//            if (!RSA_X931_generate_key_ex(rsa, tc->sig_tc->sig_attrs_tc->modulo, bn_e, NULL)) { /*** only need to (can) generate key with x931-- sigType doesn't matter for key generation ***/
-//                printf("\nError: Issue with keygen during siggen mode for sigType PKCS1PSS\n");
-//                rv = ACVP_CRYPTO_MODULE_FAIL;
-//                goto err;
-//            }
-//        } else {
-//            printf("\nError: sigType not supported\n");
-//            rv = ACVP_INVALID_ARG;
-//            goto err;
-//        }
-//
-//        /*
-//         * Retrieve and save the exponent and modulus from the key generation process
-//         */
-//        tc->sig_tc->sig_attrs_tc->e = BN_dup(rsa->e);
-//        tc->sig_tc->sig_attrs_tc->n = BN_dup(rsa->n);
-//
-//        if (msg && tc_md) {
-//            siglen = RSA_size(rsa);
-//            sigbuf = OPENSSL_malloc(siglen);
-//
-//            if (!sigbuf) {
-//                printf("\nError: SigBuf fail in RSA SigGen\n");
-//                rv = ACVP_CRYPTO_MODULE_FAIL;
-//                goto err;
-//            }
-//
-//            if (!FIPS_rsa_sign(rsa, msg, msglen, tc_md, pad_mode, tc->sig_tc->sig_attrs_tc->salt_len, NULL,
-//                                    sigbuf, (unsigned int *)&siglen)) {
-//                printf("\nError: RSA Signature Generation fail\n");
-//                rv = ACVP_CRYPTO_MODULE_FAIL;
-//                goto err;
-//            }
-//
-//            /*
-//             * Retrieve and save the signature generated from signing the generated key
-//             */
-//            tc->sig_tc->sig_attrs_tc->s = BN_bin2bn(sigbuf, siglen, NULL);
-//            if(!tc->sig_tc->sig_attrs_tc->s) {
-//                printf("\nError: RSA Signature BigNum alloc failure\n");
-//                rv = ACVP_MALLOC_FAIL;
-//                goto err;
-//            }
-//        }
-//        break;
     case ACVP_RSA_MODE_SIGVER:
-        // rv = app_rsa_sigver_handler(test_case);
     default:
         break;
     }
@@ -2673,10 +2568,7 @@ static ACVP_RESULT app_rsa_handler(ACVP_TEST_CASE *test_case)
     if (msg) free(msg);
     if (sigbuf) OPENSSL_free(sigbuf);
     if (bn_e) BN_free(bn_e);
-//    if (rsa) FIPS_rsa_free(rsa);
-    
-    
-//    return rv;
+
     return ACVP_SUCCESS;
 
 }

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -765,7 +765,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
- #ifdef ACVP_NO_RUNTIME
+#ifdef ACVP_NO_RUNTIME
 
 #if 0 /* until RSA is supported on the server side */
     /*
@@ -972,6 +972,7 @@ int main(int argc, char **argv)
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_rsa_cap_sig_type_parm(ctx, ACVP_RSA, ACVP_RSA_MODE_SIGVER, RSA_SIG_TYPE_PKCS1PSS, MOD_RSA_4096, ACVP_RSA_SHA_512, RSA_SALT_SIGGEN_64);
     CHECK_ENABLE_CAP_RV(rv);
+#endif
 #endif
 
 #ifdef ACVP_NO_RUNTIME

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -82,7 +82,6 @@ static ACVP_RESULT acvp_append_kdf135_tls_caps_entry(
     ACVP_RESULT (*crypto_handler)(ACVP_TEST_CASE *test_case));
 static void acvp_cap_free_sl(ACVP_SL_LIST *list);
 static void acvp_cap_free_nl(ACVP_NAME_LIST *list);
-static void acvp_cap_free_saltl(ACVP_SALT_SIZES *list);
 static void acvp_cap_free_rsa_sig_tl(ACVP_RSA_CAP_SIG_TYPE *list);
 static void acvp_cap_free_rsa_primesl(ACVP_RSA_PRIMES_LIST *list);
 static void acvp_cap_free_rsa_ml(ACVP_RSA_CAP_MODE_LIST *list);
@@ -403,21 +402,22 @@ static void acvp_cap_free_nl(ACVP_NAME_LIST *list)
         free(tmp);
     }
 }
-/*
- * Simple utility function to free a name
- * list from the capabilities structure.
- */
-static void acvp_cap_free_saltl(ACVP_SALT_SIZES *list)
+
+
+static void acvp_cap_free_hash_pairs(ACVP_RSA_HASH_PAIR_LIST *list)
 {
-    ACVP_SALT_SIZES *top = list;
-    ACVP_SALT_SIZES *tmp;
+    ACVP_RSA_HASH_PAIR_LIST *top = list;
+    ACVP_RSA_HASH_PAIR_LIST *tmp;
 
     while(top) {
         tmp = top;
+        free(top->name);
+        top->name = NULL;
         top = top->next;
         free(tmp);
     }
 }
+
 static void acvp_cap_free_rsa_sig_tl(ACVP_RSA_CAP_SIG_TYPE *list)
 {
     ACVP_RSA_CAP_SIG_TYPE *top = list;
@@ -426,13 +426,9 @@ static void acvp_cap_free_rsa_sig_tl(ACVP_RSA_CAP_SIG_TYPE *list)
     while(top) {
         tmp = top;
         top = top->next;
-        if(tmp->salt_sig) {
-            acvp_cap_free_saltl(tmp->salt_sig);
-            tmp->salt_sig = NULL;
-        }
-        if(tmp->compatible_hashes_sig) {
-            acvp_cap_free_nl(tmp->compatible_hashes_sig);
-            tmp->compatible_hashes_sig = NULL;
+        if (tmp->hash_pairs) {
+            acvp_cap_free_hash_pairs(tmp->hash_pairs);
+            tmp->hash_pairs = NULL;
         }
         free(tmp);
     }
@@ -1356,23 +1352,32 @@ static ACVP_RESULT acvp_add_rsa_siggen_parm (
                              ACVP_RSA_SIG_TYPE   value
                              )
 {
-
     // TODO: NEED TO ADD VALIDATION here
+    ACVP_RSA_SIG_ATTRS *current_sig_type = NULL;
 
     switch (param) {
     case ACVP_SIG_TYPE:
-    	switch (value) {
-    	case RSA_SIG_TYPE_X931:
-    		rsa_cap_mode_list->cap_mode_attrs.siggen->sig_type = RSA_SIG_TYPE_X931_NAME;
-    		break;
-    	case RSA_SIG_TYPE_PKCS1V15:
-			rsa_cap_mode_list->cap_mode_attrs.siggen->sig_type = RSA_SIG_TYPE_PKCS1V15_NAME;
-			break;
-    	case RSA_SIG_TYPE_PKCS1PSS:
-			rsa_cap_mode_list->cap_mode_attrs.siggen->sig_type = RSA_SIG_TYPE_PKCS1PSS_NAME;
-			break;
-		default:
-            break;
+        current_sig_type = rsa_cap_mode_list->cap_mode_attrs.siggen;
+        while (current_sig_type) {
+            current_sig_type = current_sig_type->next;
+        }
+        current_sig_type = calloc(1, sizeof(ACVP_RSA_SIG_ATTRS));
+
+        switch (value) {
+            case RSA_SIG_TYPE_X931:
+                printf("setting sig type to x931 %d %s\n", value, RSA_SIG_TYPE_X931_NAME);
+                current_sig_type->sig_type = RSA_SIG_TYPE_X931_NAME;
+                break;
+            case RSA_SIG_TYPE_PKCS1V15:
+                printf("setting sig type to pcks %d %s\n", value, RSA_SIG_TYPE_PKCS1V15_NAME);
+                current_sig_type->sig_type = RSA_SIG_TYPE_PKCS1V15_NAME;
+                break;
+            case RSA_SIG_TYPE_PKCS1PSS:
+                printf("setting sig type to pss %d %s\n", value, RSA_SIG_TYPE_PKCS1PSS_NAME);
+                current_sig_type->sig_type = RSA_SIG_TYPE_PKCS1PSS_NAME;
+                break;
+            default:
+                break;
         }
         break;
     default:
@@ -1394,25 +1399,33 @@ static ACVP_RESULT acvp_add_rsa_sigver_parm (
 
     // TODO: NEED TO ADD VALIDATION here
 
+    ACVP_RSA_SIG_ATTRS *current_sig_type = NULL;
+
     switch (param) {
-    case ACVP_SIG_TYPE:
-        switch (value) {
-        case RSA_SIG_TYPE_X931:
-            rsa_cap_mode_list->cap_mode_attrs.sigver->sig_type = RSA_SIG_TYPE_X931_NAME;
-            break;
-        case RSA_SIG_TYPE_PKCS1V15:
-            rsa_cap_mode_list->cap_mode_attrs.sigver->sig_type = RSA_SIG_TYPE_PKCS1V15_NAME;
-            break;
-        case RSA_SIG_TYPE_PKCS1PSS:
-            rsa_cap_mode_list->cap_mode_attrs.sigver->sig_type = RSA_SIG_TYPE_PKCS1PSS_NAME;
+        case ACVP_SIG_TYPE:
+            current_sig_type = rsa_cap_mode_list->cap_mode_attrs.sigver;
+            while (current_sig_type) {
+                current_sig_type = current_sig_type->next;
+            }
+            current_sig_type = calloc(1, sizeof(ACVP_RSA_SIG_ATTRS));
+
+            switch (value) {
+                case RSA_SIG_TYPE_X931:
+                    current_sig_type->sig_type = RSA_SIG_TYPE_X931_NAME;
+                    break;
+                case RSA_SIG_TYPE_PKCS1V15:
+                    current_sig_type->sig_type = RSA_SIG_TYPE_PKCS1V15_NAME;
+                    break;
+                case RSA_SIG_TYPE_PKCS1PSS:
+                    current_sig_type->sig_type = RSA_SIG_TYPE_PKCS1PSS_NAME;
+                    break;
+                default:
+                    break;
+            }
             break;
         default:
+            return ACVP_INVALID_ARG;
             break;
-        }
-        break;
-    default:
-        return ACVP_INVALID_ARG;
-        break;
     }
     return ACVP_SUCCESS;
 }
@@ -1538,14 +1551,14 @@ ACVP_RESULT acvp_rsa_prepare_to_add_param(ACVP_CTX *ctx, ACVP_CIPHER cipher,
             (*rsa_cap_mode_list)->cap_mode_attrs.keygen->rand_pq = 0;
             break;
         case ACVP_RSA_MODE_SIGGEN:
-			(*rsa_cap_mode_list)->cap_mode_attrs.siggen = calloc(1, sizeof(ACVP_RSA_SIGGEN_ATTRS));
+			(*rsa_cap_mode_list)->cap_mode_attrs.siggen = calloc(1, sizeof(ACVP_RSA_SIG_ATTRS));
 			if (!(*rsa_cap_mode_list)->cap_mode_attrs.siggen) {
 				ACVP_LOG_ERR("Malloc Failed -- RSA SigGen cap attributes");
 				return ACVP_MALLOC_FAIL;
 			}
 			break;
         case ACVP_RSA_MODE_SIGVER:
-                    (*rsa_cap_mode_list)->cap_mode_attrs.sigver = calloc(1, sizeof(ACVP_RSA_SIGVER_ATTRS));
+                    (*rsa_cap_mode_list)->cap_mode_attrs.sigver = calloc(1, sizeof(ACVP_RSA_SIG_ATTRS));
                     if (!(*rsa_cap_mode_list)->cap_mode_attrs.sigver) {
                         ACVP_LOG_ERR("Malloc Failed -- RSA SigVer cap attributes");
                         return ACVP_MALLOC_FAIL;
@@ -1669,10 +1682,8 @@ ACVP_RESULT acvp_enable_rsa_cap_parm (ACVP_CTX *ctx,
     /*
      * Add the value to the cap
      */
-    result = acvp_rsa_prepare_to_add_param(ctx, cipher, mode, &cap_list,
-            &rsa_cap_mode_list);
-    if (result != ACVP_SUCCESS)
-        return result;
+    result = acvp_rsa_prepare_to_add_param(ctx, cipher, mode, &cap_list, &rsa_cap_mode_list);
+    if (result != ACVP_SUCCESS) return result;
     if (acvp_validate_rsa_parm_value(param, value, rsa_cap_mode_list)
                 != ACVP_SUCCESS) {
             ACVP_LOG_ERR("Invalid value for specified RSA param");
@@ -1680,31 +1691,17 @@ ACVP_RESULT acvp_enable_rsa_cap_parm (ACVP_CTX *ctx,
         }
     switch (mode) {
     case ACVP_RSA_MODE_KEYGEN:
-
         result = acvp_add_rsa_keygen_parm(rsa_cap_mode_list, param, value);
         if (result != ACVP_SUCCESS)
-            ACVP_LOG_ERR(
-                    "Invalid param to enable_rsa_cap_parm. If registering primes, use enable_rsa_primes instead");
+            ACVP_LOG_ERR("Invalid param to enable_rsa_cap_parm. If registering primes, use enable_rsa_primes instead");
         break;
     case ACVP_RSA_MODE_SIGGEN:
-        if (rsa_cap_mode_list->cap_mode_attrs.siggen->sig_type) {
-            rsa_cap_mode_list= acvp_locate_rsa_sig_type_entry(ctx, cap_list, mode,
-                                            value);
-            if (!rsa_cap_mode_list) {
-                return ACVP_INVALID_ARG;
-            }
-        }
         result = acvp_add_rsa_siggen_parm(rsa_cap_mode_list, param, value);
+        if (result != ACVP_SUCCESS) ACVP_LOG_ERR("Invalid param to enable_rsa_cap_parm");
         break;
     case ACVP_RSA_MODE_SIGVER:
-        if (rsa_cap_mode_list->cap_mode_attrs.sigver->sig_type) {
-            rsa_cap_mode_list = acvp_locate_rsa_sig_type_entry(ctx, cap_list, mode,
-        	                    value);
-            if (!rsa_cap_mode_list) {
-                return ACVP_INVALID_ARG;
-            }
-        }
         result = acvp_add_rsa_sigver_parm(rsa_cap_mode_list, param, value);
+        if (result != ACVP_SUCCESS) ACVP_LOG_ERR("Invalid param to enable_rsa_cap_parm");
         break;
     default:
         ACVP_LOG_ERR("RSA Mode Type Not Found - RSA mode %d is not supported.",mode);
@@ -1718,177 +1715,6 @@ ACVP_RESULT acvp_enable_rsa_cap_parm (ACVP_CTX *ctx,
  * The user should call this after invoking acvp_enable_rsa_cap_parm().
  */
 ACVP_RESULT acvp_enable_rsa_cap_sig_type_parm (ACVP_CTX *ctx,
-                             ACVP_CIPHER cipher,
-                             ACVP_RSA_MODE mode,
-                             ACVP_RSA_SIG_TYPE sig_type,
-                             int mod,
-                             char *hash
-                             )
-{
-    ACVP_RSA_CAP_MODE_LIST      *rsa_cap_mode_list;
-    ACVP_CAPS_LIST              *cap_list;
-
-    /*
-     * Validate input
-     */
-    if (!ctx) {
-        return ACVP_INVALID_ARG;
-    }
-
-    switch (cipher) {
-    case ACVP_RSA:
-        break;
-    default:
-        return ACVP_INVALID_ARG;
-    }
-
-    /*
-     * Locate this cipher in the caps array
-     */
-    cap_list = acvp_locate_cap_entry(ctx, cipher);
-    if (!cap_list) {
-        ACVP_LOG_ERR("Cap entry not found.");
-        return ACVP_NO_CAP;
-    }
-
-    /*
-     * Locate cap mode from array
-     * if the mode does not exist yet then create it.
-     */
-    if (!cap_list->cap.rsa_cap) {
-        ACVP_LOG_ERR("RSA Cap entry not found.");
-        return ACVP_NO_CAP;
-    }
-    rsa_cap_mode_list = acvp_locate_rsa_sig_type_entry(ctx, cap_list, mode, sig_type);
-    if (!rsa_cap_mode_list) {
-        return ACVP_INVALID_ARG;
-    }
-    // TODO CHECK PARAMS BEFORE DOING ALL THIS LOOKUP
-    int found = 0;
-    ACVP_RSA_CAP_SIG_TYPE *current_cap_sig_type = NULL;
-    if(mode==ACVP_RSA_MODE_SIGGEN)
-    {
-        if(!rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type) {
-          rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type = calloc(1, sizeof(ACVP_RSA_CAP_SIG_TYPE));
-          if(!rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type) {
-              ACVP_LOG_ERR("Malloc Failed -- RSA SigGen cap sig type entry");
-              return ACVP_MALLOC_FAIL;
-          }
-          rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type->mod_rsa_sig = mod;
-          current_cap_sig_type = rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type;
-
-        } else {
-            current_cap_sig_type = rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type;
-
-            int found = 0;
-            do {
-                if(current_cap_sig_type->mod_rsa_sig != mod) {
-                    if(current_cap_sig_type->next == NULL) {
-                        current_cap_sig_type->next = calloc(1, sizeof(ACVP_RSA_CAP_SIG_TYPE));
-                        if(!current_cap_sig_type->next) {
-                            ACVP_LOG_ERR("Malloc Failed -- RSA SigGen cap sig type entry");
-                            return ACVP_MALLOC_FAIL;
-                        }
-                        current_cap_sig_type = current_cap_sig_type->next;
-                        current_cap_sig_type->mod_rsa_sig = mod;
-                        found = 1;
-                    } else {
-                        current_cap_sig_type = current_cap_sig_type->next;
-                    }
-                } else {
-                    found = 1;
-                }
-            } while (!found);
-        }
-
-        ACVP_NAME_LIST *current_hash = NULL;
-        if(!current_cap_sig_type->compatible_hashes_sig) {
-            current_cap_sig_type->compatible_hashes_sig = calloc(1, sizeof(ACVP_NAME_LIST));
-            if(!current_cap_sig_type->compatible_hashes_sig) {
-                ACVP_LOG_ERR("Malloc Failed -- RSA SigGen compatible hashes entry");
-                return ACVP_MALLOC_FAIL;
-            }
-            current_cap_sig_type->compatible_hashes_sig->name = hash;
-        } else {
-            current_hash = current_cap_sig_type->compatible_hashes_sig;
-            while(current_hash->next != NULL) {
-                current_hash = current_hash->next;
-            }
-            current_hash->next = calloc(1, sizeof(ACVP_NAME_LIST));
-            if(!current_hash->next) {
-                ACVP_LOG_ERR("Malloc Failed -- RSA SigGen compatible hashes entry");
-                return ACVP_MALLOC_FAIL;
-            }
-            current_hash->next->name = hash;
-        }
-    }
-    else if (mode == ACVP_RSA_MODE_SIGVER)
-    {
-        if(!rsa_cap_mode_list->cap_mode_attrs.sigver->cap_sig_type) {
-              rsa_cap_mode_list->cap_mode_attrs.sigver->cap_sig_type = calloc(1, sizeof(ACVP_RSA_CAP_SIG_TYPE));
-              if(!rsa_cap_mode_list->cap_mode_attrs.sigver->cap_sig_type) {
-                  ACVP_LOG_ERR("Malloc Failed -- RSA SigVer cap sig type entry");
-                  return ACVP_MALLOC_FAIL;
-              }
-              rsa_cap_mode_list->cap_mode_attrs.sigver->cap_sig_type->mod_rsa_sig = mod;
-              current_cap_sig_type = rsa_cap_mode_list->cap_mode_attrs.sigver->cap_sig_type;
-
-            } else {
-                current_cap_sig_type = rsa_cap_mode_list->cap_mode_attrs.sigver->cap_sig_type;
-
-                int found = 0;
-                do {
-                    if(current_cap_sig_type->mod_rsa_sig != mod) {
-                        if(current_cap_sig_type->next == NULL) {
-                            current_cap_sig_type->next = calloc(1, sizeof(ACVP_RSA_CAP_SIG_TYPE));
-                            if(!current_cap_sig_type->next) {
-                                ACVP_LOG_ERR("Malloc Failed -- RSA SigVer cap sig type entry");
-                                return ACVP_MALLOC_FAIL;
-                            }
-                            current_cap_sig_type = current_cap_sig_type->next;
-                            current_cap_sig_type->mod_rsa_sig = mod;
-                            found = 1;
-                        } else {
-                            current_cap_sig_type = current_cap_sig_type->next;
-                        }
-                    } else {
-                        found = 1;
-                    }
-                } while (!found);
-            }
-
-            ACVP_NAME_LIST *current_hash = NULL;
-            if(!current_cap_sig_type->compatible_hashes_sig) {
-                current_cap_sig_type->compatible_hashes_sig = calloc(1, sizeof(ACVP_NAME_LIST));
-                if(!current_cap_sig_type->compatible_hashes_sig) {
-                    ACVP_LOG_ERR("Malloc Failed -- RSA SigVer compatible hashes entry");
-                    return ACVP_MALLOC_FAIL;
-                }
-                current_cap_sig_type->compatible_hashes_sig->name = hash;
-            } else {
-                current_hash = current_cap_sig_type->compatible_hashes_sig;
-                while(current_hash->next != NULL) {
-                    current_hash = current_hash->next;
-                }
-                current_hash->next = calloc(1, sizeof(ACVP_NAME_LIST));
-                if(!current_hash->next) {
-                    ACVP_LOG_ERR("Malloc Failed -- RSA SigVer compatible hashes entry");
-                    return ACVP_MALLOC_FAIL;
-                }
-                current_hash->next->name = hash;
-            }
-    }
-    else
-    {
-        return (ACVP_INVALID_ARG);
-    }
-    return (ACVP_SUCCESS);
-}
-
-/*
- * The user should call this after invoking acvp_enable_rsa_cap_parm().
- */
-ACVP_RESULT acvp_enable_rsa_cap_sig_type_salt_parm (ACVP_CTX *ctx,
                              ACVP_CIPHER cipher,
                              ACVP_RSA_MODE mode,
                              ACVP_RSA_SIG_TYPE sig_type,
@@ -1914,6 +1740,10 @@ ACVP_RESULT acvp_enable_rsa_cap_sig_type_salt_parm (ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
+    if (sig_type == RSA_SIG_TYPE_PKCS1PSS && !salt) {
+        return ACVP_INVALID_ARG;
+    }
+
     /*
      * Locate this cipher in the caps array
      */
@@ -1931,193 +1761,101 @@ ACVP_RESULT acvp_enable_rsa_cap_sig_type_salt_parm (ACVP_CTX *ctx,
         ACVP_LOG_ERR("RSA Cap entry not found.");
         return ACVP_NO_CAP;
     }
-    rsa_cap_mode_list = acvp_locate_rsa_sig_type_entry(ctx, cap_list, mode, sig_type);
-    if (!rsa_cap_mode_list) {
+
+    ACVP_RSA_SIG_ATTRS *rsa_sig_cap_list = acvp_locate_rsa_sig_type_entry(ctx, cap_list, mode, sig_type);
+    if (!rsa_sig_cap_list) {
         return ACVP_INVALID_ARG;
     }
 
     // TODO CHECK PARAMS BEFORE DOING ALL THIS LOOKUP
-    int found = 0;
     ACVP_RSA_CAP_SIG_TYPE *current_cap_sig_type = NULL;
     if (mode == ACVP_RSA_MODE_SIGGEN) {
-        if (!rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type) {
-            rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type = calloc(1,
-                    sizeof(ACVP_RSA_CAP_SIG_TYPE));
-            if (!rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type) {
-                ACVP_LOG_ERR("Malloc Failed -- RSA SigGen cap sig type entry");
-                return ACVP_MALLOC_FAIL;
+        ACVP_RSA_HASH_PAIR_LIST *current_hash = NULL;
+
+        current_cap_sig_type = rsa_sig_cap_list->cap_sig_type;
+        if (current_cap_sig_type) {
+            if (current_cap_sig_type->mod_rsa_sig == mod) goto process_sig;
+            while (current_cap_sig_type->next) {
+                current_cap_sig_type = current_cap_sig_type->next;
+                if (current_cap_sig_type->mod_rsa_sig == mod) goto process_sig;
             }
-            rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type->mod_rsa_sig =
-                    mod;
-            current_cap_sig_type =
-                    rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type;
-
+            current_cap_sig_type->next = calloc(1, sizeof(ACVP_RSA_CAP_SIG_TYPE));
+            current_cap_sig_type = current_cap_sig_type->next;
         } else {
-            current_cap_sig_type =
-                    rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type;
-
-            int found = 0;
-            do {
-                if (current_cap_sig_type->mod_rsa_sig != mod) {
-                    if (current_cap_sig_type->next == NULL) {
-                        current_cap_sig_type->next = calloc(1,
-                                sizeof(ACVP_RSA_CAP_SIG_TYPE));
-                        if (!current_cap_sig_type->next) {
-                            ACVP_LOG_ERR(
-                                    "Malloc Failed -- RSA SigGen cap sig type entry");
-                            return ACVP_MALLOC_FAIL;
-                        }
-                        current_cap_sig_type = current_cap_sig_type->next;
-                        current_cap_sig_type->mod_rsa_sig = mod;
-                        found = 1;
-                    } else {
-                        current_cap_sig_type = current_cap_sig_type->next;
-                    }
-                } else {
-                    found = 1;
-                }
-            } while (!found);
+            rsa_sig_cap_list->cap_sig_type = calloc(1, sizeof(ACVP_RSA_CAP_SIG_TYPE));
+            current_cap_sig_type = rsa_sig_cap_list->cap_sig_type;
         }
 
-        ACVP_NAME_LIST *current_hash = NULL;
-        if (!current_cap_sig_type->compatible_hashes_sig) {
-            current_cap_sig_type->compatible_hashes_sig = calloc(1,
-                    sizeof(ACVP_NAME_LIST));
-            if (!current_cap_sig_type->compatible_hashes_sig) {
-                ACVP_LOG_ERR("Malloc Failed -- RSA SigGen compatible hashes entry");
+        current_cap_sig_type->mod_rsa_sig = mod;
+
+        process_sig:
+        if (!current_cap_sig_type->hash_pairs) {
+            current_cap_sig_type->hash_pairs = calloc(1, sizeof(ACVP_RSA_HASH_PAIR_LIST));
+            if (!current_cap_sig_type->hash_pairs) {
+                ACVP_LOG_ERR("Malloc Failed -- RSA SigGen hash pair list");
                 return ACVP_MALLOC_FAIL;
             }
-            current_cap_sig_type->compatible_hashes_sig->name = hash;
+            current_cap_sig_type->hash_pairs->name = hash;
+            if (salt) current_cap_sig_type->hash_pairs->salt = salt;
         } else {
-            current_hash = current_cap_sig_type->compatible_hashes_sig;
+            current_hash = current_cap_sig_type->hash_pairs;
             while (current_hash->next != NULL) {
                 current_hash = current_hash->next;
             }
-            current_hash->next = calloc(1, sizeof(ACVP_NAME_LIST));
+            current_hash->next = calloc(1, sizeof(ACVP_RSA_HASH_PAIR_LIST));
             if (!current_hash->next) {
-                ACVP_LOG_ERR("Malloc Failed -- RSA SigGen compatible hashes entry");
+                ACVP_LOG_ERR("Malloc Failed -- RSA SigGen hash pair list");
                 return ACVP_MALLOC_FAIL;
             }
             current_hash->next->name = hash;
+            if (salt) current_hash->next->salt = salt;
         }
 
-        // checks that sigType is "PKCS1PSS" before creating salt array
-        // this check should be unnecessary, since this function should only be called when sigType is "PKCS1PSS"
-        if (strncmp(rsa_cap_mode_list->cap_mode_attrs.siggen->sig_type,
-                RSA_SIG_TYPE_PKCS1PSS_NAME, RSA_SIG_TYPE_MAX_LEN) == 0) {
-            ACVP_SALT_SIZES *current_salt = NULL;
-            if (!current_cap_sig_type->salt_sig) {
-                current_cap_sig_type->salt_sig = calloc(1,
-                        sizeof(ACVP_SALT_SIZES));
-                if (!current_cap_sig_type->salt_sig) {
-                    ACVP_LOG_ERR("Malloc Failed -- RSA SigGen salt size entry");
-                    return ACVP_MALLOC_FAIL;
-                }
-                current_cap_sig_type->salt_sig->saltVal = salt;
-            } else {
-                current_salt = current_cap_sig_type->salt_sig;
-                while (current_salt->next != NULL) {
-                    current_salt = current_salt->next;
-                }
-                current_salt->next = calloc(1, sizeof(ACVP_SALT_SIZES));
-                if (!current_salt->next) {
-                    ACVP_LOG_ERR("Malloc Failed -- RSA SigGen salt size entry");
-                    return ACVP_MALLOC_FAIL;
-                }
-                current_salt->next->saltVal = salt;
-            }
-        }
     } else if (mode == ACVP_RSA_MODE_SIGVER) {
-        if (!rsa_cap_mode_list->cap_mode_attrs.sigver->cap_sig_type) {
-                    rsa_cap_mode_list->cap_mode_attrs.sigver->cap_sig_type = calloc(1,
-                            sizeof(ACVP_RSA_CAP_SIG_TYPE));
-                    if (!rsa_cap_mode_list->cap_mode_attrs.sigver->cap_sig_type) {
-                        ACVP_LOG_ERR("Malloc Failed -- RSA SigVer cap sig type entry");
-                        return ACVP_MALLOC_FAIL;
-                    }
-                    rsa_cap_mode_list->cap_mode_attrs.siggen->cap_sig_type->mod_rsa_sig =
-                            mod;
-                    current_cap_sig_type =
-                            rsa_cap_mode_list->cap_mode_attrs.sigver->cap_sig_type;
+        ACVP_RSA_HASH_PAIR_LIST *current_hash = NULL;
 
-                } else {
-                    current_cap_sig_type =
-                            rsa_cap_mode_list->cap_mode_attrs.sigver->cap_sig_type;
+        current_cap_sig_type = rsa_sig_cap_list->cap_sig_type;
+        if (current_cap_sig_type) {
+            if (current_cap_sig_type->mod_rsa_sig == mod) goto process_ver;
+            while (current_cap_sig_type->next) {
+                current_cap_sig_type = current_cap_sig_type->next;
+                if (current_cap_sig_type->mod_rsa_sig == mod) goto process_ver;
+            }
+            current_cap_sig_type->next = calloc(1, sizeof(ACVP_RSA_CAP_SIG_TYPE));
+            current_cap_sig_type = current_cap_sig_type->next;
+        } else {
+            rsa_sig_cap_list->cap_sig_type = calloc(1, sizeof(ACVP_RSA_CAP_SIG_TYPE));
+            current_cap_sig_type = rsa_sig_cap_list->cap_sig_type;
+        }
+        current_cap_sig_type->mod_rsa_sig = mod;
 
-                    int found = 0;
-                    do {
-                        if (current_cap_sig_type->mod_rsa_sig != mod) {
-                            if (current_cap_sig_type->next == NULL) {
-                                current_cap_sig_type->next = calloc(1,
-                                        sizeof(ACVP_RSA_CAP_SIG_TYPE));
-                                if (!current_cap_sig_type->next) {
-                                    ACVP_LOG_ERR(
-                                            "Malloc Failed -- RSA SigVer cap sig type entry");
-                                    return ACVP_MALLOC_FAIL;
-                                }
-                                current_cap_sig_type = current_cap_sig_type->next;
-                                current_cap_sig_type->mod_rsa_sig = mod;
-                                found = 1;
-                            } else {
-                                current_cap_sig_type = current_cap_sig_type->next;
-                            }
-                        } else {
-                            found = 1;
-                        }
-                    } while (!found);
-                }
+        process_ver:
 
-                ACVP_NAME_LIST *current_hash = NULL;
-                if (!current_cap_sig_type->compatible_hashes_sig) {
-                    current_cap_sig_type->compatible_hashes_sig = calloc(1,
-                            sizeof(ACVP_NAME_LIST));
-                    if (!current_cap_sig_type->compatible_hashes_sig) {
-                        ACVP_LOG_ERR("Malloc Failed -- RSA SigVer compatible hashes entry");
-                        return ACVP_MALLOC_FAIL;
-                    }
-                    current_cap_sig_type->compatible_hashes_sig->name = hash;
-                } else {
-                    current_hash = current_cap_sig_type->compatible_hashes_sig;
-                    while (current_hash->next != NULL) {
-                        current_hash = current_hash->next;
-                    }
-                    current_hash->next = calloc(1, sizeof(ACVP_NAME_LIST));
-                    if (!current_hash->next) {
-                        ACVP_LOG_ERR("Malloc Failed -- RSA SigVer compatible hashes entry");
-                        return ACVP_MALLOC_FAIL;
-                    }
-                    current_hash->next->name = hash;
-                }
-
-                // checks that sigType is "PKCS1PSS" before creating salt array
-                // this check should be unnecessary, since this function should only be called when sigType is "PKCS1PSS"
-                if (strncmp(rsa_cap_mode_list->cap_mode_attrs.sigver->sig_type,
-                        RSA_SIG_TYPE_PKCS1PSS_NAME, RSA_SIG_TYPE_MAX_LEN) == 0) {
-                    ACVP_SALT_SIZES *current_salt = NULL;
-                    if (!current_cap_sig_type->salt_sig) {
-                        current_cap_sig_type->salt_sig = calloc(1,
-                                sizeof(ACVP_SALT_SIZES));
-                        if (!current_cap_sig_type->salt_sig) {
-                            ACVP_LOG_ERR("Malloc Failed -- RSA SigVer salt size entry");
-                            return ACVP_MALLOC_FAIL;
-                        }
-                        current_cap_sig_type->salt_sig->saltVal = salt;
-                    } else {
-                        current_salt = current_cap_sig_type->salt_sig;
-                        while (current_salt->next != NULL) {
-                            current_salt = current_salt->next;
-                        }
-                        current_salt->next = calloc(1, sizeof(ACVP_SALT_SIZES));
-                        if (!current_salt->next) {
-                            ACVP_LOG_ERR("Malloc Failed -- RSA SigVer salt size entry");
-                            return ACVP_MALLOC_FAIL;
-                        }
-                        current_salt->next->saltVal = salt;
-                    }
-                }
+        if (!current_cap_sig_type->hash_pairs) {
+            current_cap_sig_type->hash_pairs = calloc(1, sizeof(ACVP_RSA_HASH_PAIR_LIST));
+            if (!current_cap_sig_type->hash_pairs) {
+                ACVP_LOG_ERR("Malloc Failed -- RSA SigGen hash pair list");
+                return ACVP_MALLOC_FAIL;
+            }
+            current_cap_sig_type->hash_pairs->name = hash;
+            if (salt) current_cap_sig_type->hash_pairs->salt = salt;
+        } else {
+            current_hash = current_cap_sig_type->hash_pairs;
+            while (current_hash->next != NULL) {
+                current_hash = current_hash->next;
+            }
+            current_hash->next = calloc(1, sizeof(ACVP_RSA_HASH_PAIR_LIST));
+            if (!current_hash->next) {
+                ACVP_LOG_ERR("Malloc Failed -- RSA SigGen hash pair list");
+                return ACVP_MALLOC_FAIL;
+            }
+            current_hash->next->name = hash;
+            if (salt) current_hash->next->salt = salt;
+        }
     } else {
         return (ACVP_INVALID_ARG);
     }
+
     return (ACVP_SUCCESS);
 }
 
@@ -2708,8 +2446,8 @@ static ACVP_RESULT acvp_lookup_prereqVals (JSON_Object *cap_obj, ACVP_CAPS_LIST 
     /*
      * Init json array
      */
-    json_object_set_value(cap_obj, "prereqVals", json_value_init_array());
-    prereq_array = json_object_get_array(cap_obj, "prereqVals");
+    json_object_set_value(cap_obj, ACVP_PREREQ_OBJ_STR, json_value_init_array());
+    prereq_array = json_object_get_array(cap_obj, ACVP_PREREQ_OBJ_STR);
 
     /*
      * return OK if nothing present
@@ -2727,7 +2465,7 @@ static ACVP_RESULT acvp_lookup_prereqVals (JSON_Object *cap_obj, ACVP_CAPS_LIST 
             if (acvp_prereqs_tbl[i].alg == pre_req->alg) {
                 alg_str = acvp_prereqs_tbl[i].name;
                 json_object_set_string(obj, "algorithm", alg_str);
-                json_object_set_string(obj, "value", pre_req->val);
+                json_object_set_string(obj, ACVP_PREREQ_VAL_STR, pre_req->val);
                 break;
             }
         }
@@ -3060,8 +2798,8 @@ static ACVP_RESULT acvp_lookup_drbg_prereqVals (JSON_Object *cap_obj, ACVP_DRBG_
     /*
      * Init json array
      */
-    json_object_set_value(cap_obj, "prereqVals", json_value_init_array());
-    prereq_array = json_object_get_array(cap_obj, "prereqVals");
+    json_object_set_value(cap_obj, ACVP_PREREQ_OBJ_STR, json_value_init_array());
+    prereq_array = json_object_get_array(cap_obj, ACVP_PREREQ_OBJ_STR);
 
     /*
      * return OK if nothing present
@@ -3083,7 +2821,7 @@ static ACVP_RESULT acvp_lookup_drbg_prereqVals (JSON_Object *cap_obj, ACVP_DRBG_
             if (acvp_prereqs_tbl[i].alg == pre_req->alg) {
                 alg_str = acvp_prereqs_tbl[i].name;
                 json_object_set_string(obj, "algorithm", alg_str);
-                json_object_set_string(obj, "value", pre_req->val);
+                json_object_set_string(obj, ACVP_PREREQ_VAL_STR, pre_req->val);
                 break;
             }
         }
@@ -3244,118 +2982,114 @@ static ACVP_RESULT acvp_lookup_rsa_primes(JSON_Object *cap_obj, ACVP_RSA_CAP *rs
     return ACVP_SUCCESS;
 }
 
-static ACVP_RESULT acvp_lookup_rsa_cap_sig_type(JSON_Object *cap_obj, ACVP_RSA_CAP_MODE_LIST *mode_list)
+static ACVP_RESULT acvp_lookup_rsa_cap_sig_type(JSON_Array *alg_specs_array, ACVP_RSA_CAP_MODE_LIST *mode_list)
 {
     JSON_Array *mod_rsa_sig_array = NULL, *hash_sig_array = NULL;
 
-    ACVP_RSA_CAP_SIG_TYPE *type, *next_type;
-    ACVP_NAME_LIST *comp_hash, *next_hash;
+    ACVP_RSA_SIG_ATTRS *type, *next_type;
+    ACVP_RSA_HASH_PAIR_LIST *comp_hash, *next_hash;
+    JSON_Value *hashval = NULL;
+    JSON_Object *hashobj = NULL;
 
     if(!mode_list) return ACVP_INVALID_ARG;
 
     /*
      * Init json array
      */
-    if(mode_list->cap_mode==ACVP_RSA_MODE_SIGGEN)
+    if(mode_list->cap_mode == ACVP_RSA_MODE_SIGGEN)
     {
-        json_object_set_value(cap_obj, "capSigType", json_value_init_array());
-        mod_rsa_sig_array = json_object_get_array(cap_obj, "capSigType");
 
-        /*
-         * return OK if nothing present
-         */
-        type = mode_list->cap_mode_attrs.siggen->cap_sig_type;
-        if(!mode_list->cap_mode_attrs.siggen->cap_sig_type) {
+        type = mode_list->cap_mode_attrs.siggen;
+        if(!type) {
             return ACVP_SUCCESS;
         }
 
-
+        ACVP_RSA_CAP_SIG_TYPE *mods, *next_mod;
         while (type) {
-            JSON_Value *val = NULL;
-            JSON_Object *obj = NULL;
-            val = json_value_init_object();
-            obj = json_value_get_object(val);
+            JSON_Value *sig_type_obj_val = json_value_init_object();
+            JSON_Object *sig_type_obj = json_value_get_object(sig_type_obj_val);
 
-            json_object_set_number(obj, "modulo", type->mod_rsa_sig);
-            json_object_set_value(obj, ACVP_RSA_CAP_HASHALG_OBJ_NAME, json_value_init_array());
-            hash_sig_array = json_object_get_array(obj, ACVP_RSA_CAP_HASHALG_OBJ_NAME);
-            comp_hash = type->compatible_hashes_sig;
+            json_object_set_string(sig_type_obj, "sigType", type->sig_type);
+            json_object_set_value(sig_type_obj, "capSigType", json_value_init_array());
+            mod_rsa_sig_array = json_object_get_array(sig_type_obj, "capSigType");
 
-            while(comp_hash) {
-                json_array_append_string(hash_sig_array, comp_hash->name);
-                next_hash = comp_hash->next;
-                comp_hash = next_hash;
-            }
+            mods = type->cap_sig_type;
+            while (mods) {
+                JSON_Value *val = json_value_init_object();
+                JSON_Object *obj = json_value_get_object(val);
 
-            // only print saltSigGen if sigType is "PKCS1PSS"
-            if(strncmp(mode_list->cap_mode_attrs.siggen->sig_type, RSA_SIG_TYPE_PKCS1PSS_NAME, RSA_SIG_TYPE_MAX_LEN ) == 0 ) {
-                ACVP_SALT_SIZES *salt, *next_salt;
-                JSON_Array *salt_sig_array = NULL;
+                json_object_set_number(obj, "modulo", mods->mod_rsa_sig);
+                json_object_set_value(obj, ACVP_RSA_CAP_HASHPAIR_NAME, json_value_init_array());
+                hash_sig_array = NULL;
+                hash_sig_array = json_object_get_array(obj, ACVP_RSA_CAP_HASHPAIR_NAME);
+                comp_hash = mods->hash_pairs;
 
-                json_object_set_value(obj, ACVP_RSA_SALTLEN_OBJ_NAME, json_value_init_array());
-                salt_sig_array = json_object_get_array(obj, ACVP_RSA_SALTLEN_OBJ_NAME);
-                salt = type->salt_sig;
-
-                while(salt) {
-                    json_array_append_number(salt_sig_array, salt->saltVal);
-                    next_salt = salt->next;
-                    salt = next_salt;
+                while(comp_hash) {
+                    hashval = NULL;
+                    hashobj = NULL;
+                    hashval = json_value_init_object();
+                    hashobj = json_value_get_object(hashval);
+                    json_object_set_string(hashobj, ACVP_RSA_CAP_HASHALG_OBJ_NAME, comp_hash->name);
+                    if (comp_hash->salt) json_object_set_number(hashobj, "salt", comp_hash->salt);
+                    json_array_append_value(hash_sig_array, hashval);
+                    next_hash = comp_hash->next;
+                    comp_hash = next_hash;
                 }
-
+                json_array_append_value(mod_rsa_sig_array, val);
+                next_mod = mods->next;
+                mods = next_mod;
             }
-            json_array_append_value(mod_rsa_sig_array, val);
+
+            json_array_append_value(alg_specs_array, sig_type_obj_val);
             next_type = type->next;
             type = next_type;
         }
     }
     else if(mode_list->cap_mode==ACVP_RSA_MODE_SIGVER)
     {
-        json_object_set_value(cap_obj, "capSigType", json_value_init_array());
-        mod_rsa_sig_array = json_object_get_array(cap_obj, "capSigType");
 
-        /*
-         * return OK if nothing present
-         */
-        type = mode_list->cap_mode_attrs.sigver->cap_sig_type;
-        if(!mode_list->cap_mode_attrs.sigver->cap_sig_type) {
+        type = mode_list->cap_mode_attrs.sigver;
+        if(!type) {
             return ACVP_SUCCESS;
         }
 
-
+        ACVP_RSA_CAP_SIG_TYPE *mods, *next_mod;
         while (type) {
-            JSON_Value *val = NULL;
-            JSON_Object *obj = NULL;
-            val = json_value_init_object();
-            obj = json_value_get_object(val);
+            JSON_Value *sig_type_obj_val = json_value_init_object();
+            JSON_Object *sig_type_obj = json_value_get_object(sig_type_obj_val);
 
-            json_object_set_number(obj, "modulo", type->mod_rsa_sig);
-            json_object_set_value(obj, ACVP_RSA_CAP_HASHALG_OBJ_NAME, json_value_init_array());
-            hash_sig_array = json_object_get_array(obj, ACVP_RSA_CAP_HASHALG_OBJ_NAME);
-            comp_hash = type->compatible_hashes_sig;
+            json_object_set_string(sig_type_obj, "sigType", type->sig_type);
+            json_object_set_value(sig_type_obj, "capSigType", json_value_init_array());
+            mod_rsa_sig_array = json_object_get_array(sig_type_obj, "capSigType");
 
-            while(comp_hash) {
-                json_array_append_string(hash_sig_array, comp_hash->name);
-                next_hash = comp_hash->next;
-                comp_hash = next_hash;
-            }
+            mods = type->cap_sig_type;
+            while (mods) {
+                JSON_Value *val = json_value_init_object();
+                JSON_Object *obj = json_value_get_object(val);
 
-            // only print saltSigVer if sigType is "PKCS1PSS"
-            if(strncmp(mode_list->cap_mode_attrs.sigver->sig_type, RSA_SIG_TYPE_PKCS1PSS_NAME, RSA_SIG_TYPE_MAX_LEN ) == 0 ) {
-                ACVP_SALT_SIZES *salt, *next_salt;
-                JSON_Array *salt_sig_array = NULL;
+                json_object_set_number(obj, "modulo", mods->mod_rsa_sig);
+                json_object_set_value(obj, ACVP_RSA_CAP_HASHPAIR_NAME, json_value_init_array());
+                hash_sig_array = NULL;
+                hash_sig_array = json_object_get_array(obj, ACVP_RSA_CAP_HASHPAIR_NAME);
+                comp_hash = mods->hash_pairs;
 
-                json_object_set_value(obj, ACVP_RSA_SALTLEN_OBJ_NAME, json_value_init_array());
-                salt_sig_array = json_object_get_array(obj, ACVP_RSA_SALTLEN_OBJ_NAME);
-                salt = type->salt_sig;
-
-                while(salt) {
-                    json_array_append_number(salt_sig_array, salt->saltVal);
-                    next_salt = salt->next;
-                    salt = next_salt;
+                while(comp_hash) {
+                    hashval = NULL;
+                    hashobj = NULL;
+                    hashval = json_value_init_object();
+                    hashobj = json_value_get_object(hashval);
+                    json_object_set_string(hashobj, ACVP_RSA_CAP_HASHALG_OBJ_NAME, comp_hash->name);
+                    if (comp_hash->salt) json_object_set_number(hashobj, "salt", comp_hash->salt);
+                    json_array_append_value(hash_sig_array, hashval);
+                    next_hash = comp_hash->next;
+                    comp_hash = next_hash;
                 }
-
+                json_array_append_value(mod_rsa_sig_array, val);
+                next_mod = mods->next;
+                mods = next_mod;
             }
-            json_array_append_value(mod_rsa_sig_array, val);
+
+            json_array_append_value(alg_specs_array, sig_type_obj_val);
             next_type = type->next;
             type = next_type;
         }
@@ -3403,51 +3137,50 @@ static ACVP_RESULT acvp_build_rsa_keygen_register(JSON_Object **cap_specs_obj, A
     return result;
 }
 
-static ACVP_RESULT acvp_build_rsa_siggen_register(JSON_Object **cap_specs_obj, ACVP_RSA_CAP_MODE_LIST *mode_list) {
-    ACVP_RSA_SIGGEN_ATTRS *rsa_cap_mode = NULL;
-    rsa_cap_mode = mode_list->cap_mode_attrs.siggen;
-    json_object_set_string(*cap_specs_obj, "sigType", rsa_cap_mode->sig_type);
-
-    return acvp_lookup_rsa_cap_sig_type(*cap_specs_obj, mode_list);
+static ACVP_RESULT acvp_build_rsa_siggen_register(JSON_Array **alg_specs_array, ACVP_RSA_CAP_MODE_LIST *mode_list) {
+    ACVP_RSA_SIG_ATTRS *rsa_cap_mode = NULL;
+    return acvp_lookup_rsa_cap_sig_type(*alg_specs_array, mode_list);
 }
 
-static ACVP_RESULT acvp_build_rsa_sigver_register(JSON_Object **cap_specs_obj, ACVP_RSA_CAP_MODE_LIST *mode_list) {
-    ACVP_RSA_SIGVER_ATTRS *rsa_cap_mode = NULL;
-    rsa_cap_mode = mode_list->cap_mode_attrs.sigver;
-    json_object_set_string(*cap_specs_obj, "sigType", rsa_cap_mode->sig_type);
-
-    return acvp_lookup_rsa_cap_sig_type(*cap_specs_obj, mode_list);
+static ACVP_RESULT acvp_build_rsa_sigver_register(JSON_Array **alg_specs_array, ACVP_RSA_CAP_MODE_LIST *mode_list) {
+    ACVP_RSA_SIG_ATTRS *rsa_cap_mode = NULL;
+    return acvp_lookup_rsa_cap_sig_type(*alg_specs_array, mode_list);
 }
 
-static ACVP_RESULT acvp_build_rsa_register_cap(JSON_Object *cap_obj, ACVP_CAPS_LIST *cap_entry)
+static ACVP_RESULT acvp_build_rsa_register_cap(JSON_Array *caps_arr, ACVP_CAPS_LIST *cap_entry)
 {
 	ACVP_RESULT result;
 	ACVP_RSA_MODE mode;
 
 	JSON_Array *specs_array = NULL;
-	JSON_Value *mode_specs_val = NULL, *cap_specs_val = NULL, *mode_val = NULL;
-	JSON_Object *mode_specs_obj = NULL, *cap_specs_obj = NULL, *mode_obj = NULL;
+	JSON_Value *mode_specs_val = NULL, *cap_specs_val = NULL, *mode_val = NULL, *cap_val = NULL;
+	JSON_Object *mode_specs_obj = NULL, *cap_specs_obj = NULL, *mode_obj = NULL, *cap_obj = NULL;
 
-	json_object_set_string(cap_obj, "algorithm", acvp_lookup_cipher_name(cap_entry->cipher));
-	result = acvp_lookup_prereqVals(cap_obj, cap_entry);
-	if (result != ACVP_SUCCESS) return result;
+    char *rsa_str = acvp_lookup_cipher_name(cap_entry->cipher);
 
-	json_object_set_value(cap_obj, "algSpecs", json_value_init_array());
-	specs_array = json_object_get_array(cap_obj, "algSpecs");
-
+    /*
+     * Iterate through list of RSA modes and create registration object
+     * for each one, appending to the array as we go
+     */
 	ACVP_RSA_CAP_MODE_LIST *mode_list = cap_entry->cap.rsa_cap->rsa_cap_mode_list;
 	while(mode_list)
 	{
-	    mode = mode_list->cap_mode;
-	    char *mode_str = acvp_lookup_rsa_mode_string(mode);
-        if (!mode_str)
-            return ACVP_INVALID_ARG;
+        cap_val = NULL;
+        cap_obj = NULL;
+        cap_val = json_value_init_object();
+        cap_obj = json_value_get_object(cap_val);
 
-	    mode_specs_val = json_value_init_object();
-        mode_specs_obj = json_value_get_object(mode_specs_val);
+        json_object_set_string(cap_obj, "algorithm", rsa_str);
+        result = acvp_lookup_prereqVals(cap_obj, cap_entry);
+        if (result != ACVP_SUCCESS) return result;
 
-        mode_val = json_value_init_object();
-        mode_obj = json_value_get_object(mode_val);
+        mode = mode_list->cap_mode;
+        char *mode_str = acvp_lookup_rsa_mode_string(mode);
+        if (!mode_str) return ACVP_INVALID_ARG;
+        json_object_set_string(cap_obj, "mode", mode_str);
+
+        json_object_set_value(cap_obj, "algSpecs", json_value_init_array());
+        specs_array = json_object_get_array(cap_obj, "algSpecs");
 
 	    cap_specs_val = json_value_init_object();
 	    cap_specs_obj = json_value_get_object(cap_specs_val);
@@ -3458,23 +3191,22 @@ static ACVP_RESULT acvp_build_rsa_register_cap(JSON_Object *cap_obj, ACVP_CAPS_L
 	        if (result != ACVP_SUCCESS) return result;
 	        break;
 	    case ACVP_RSA_MODE_SIGGEN:
-	        result = acvp_build_rsa_siggen_register(&cap_specs_obj, mode_list);
+	        result = acvp_build_rsa_siggen_register(&specs_array, mode_list);
 	        if (result != ACVP_SUCCESS) return result;
 	        break;
 	    case ACVP_RSA_MODE_SIGVER:
-	        result = acvp_build_rsa_sigver_register(&cap_specs_obj, mode_list);
+	        result = acvp_build_rsa_sigver_register(&specs_array, mode_list);
 	        if (result != ACVP_SUCCESS) return result;
 	        break;
 	    default:
             return ACVP_INVALID_ARG;
 	    }
 
-	    json_object_set_string(mode_obj, "mode", mode_str);
-	    json_object_set_value(mode_obj, "capSpecs", cap_specs_val);
-	    json_object_set_value(mode_specs_obj, "modeSpecs", mode_val);
-	    json_array_append_value(specs_array, mode_specs_val);
+        json_array_append_value(specs_array, cap_specs_val);
 	    mode_list = mode_list->next;
-	}
+        json_array_append_value(caps_arr, cap_val);
+
+    }
 	return ACVP_SUCCESS;
 }
 
@@ -3880,11 +3612,12 @@ static ACVP_RESULT acvp_build_register(ACVP_CTX *ctx, char **reg)
             case ACVP_CMAC_TDES:
                 acvp_build_cmac_register_cap(cap_obj, cap_entry);
                 break;
-	    case ACVP_DSA:
+            case ACVP_DSA:
                 acvp_build_dsa_register_cap(cap_obj, cap_entry);
 	        break;
             case ACVP_RSA:
-                acvp_build_rsa_register_cap(cap_obj, cap_entry);
+                // pass the whole array to this one... or change architecture of rsa?
+                acvp_build_rsa_register_cap(caps_arr, cap_entry);
                 break;
             case ACVP_KDF135_TLS:
                 acvp_build_kdf135_tls_register_cap(cap_obj, cap_entry);
@@ -3904,7 +3637,8 @@ static ACVP_RESULT acvp_build_register(ACVP_CTX *ctx, char **reg)
              * Now that we've built up the JSON for this capability,
              * add it to the array of capabilities on the register message.
              */
-            json_array_append_value(caps_arr, cap_val);
+            if (cap_entry->cipher != ACVP_RSA)
+                json_array_append_value(caps_arr, cap_val);
 
             /* Advance to next cap entry */
             cap_entry = cap_entry->next;

--- a/src/acvp.h
+++ b/src/acvp.h
@@ -1052,14 +1052,6 @@ ACVP_RESULT acvp_enable_rsa_cap_sig_type_parm (ACVP_CTX *ctx,
                              ACVP_RSA_MODE mode,
                              ACVP_RSA_SIG_TYPE sig_type,
                              int mod,
-                             char *hash
-                             );
-
-ACVP_RESULT acvp_enable_rsa_cap_sig_type_salt_parm (ACVP_CTX *ctx,
-                             ACVP_CIPHER cipher,
-                             ACVP_RSA_MODE mode,
-                             ACVP_RSA_SIG_TYPE sig_type,
-                             int mod,
                              char *hash,
                              int salt
                              );

--- a/src/acvp_lcl.h
+++ b/src/acvp_lcl.h
@@ -118,7 +118,8 @@
 #define ACVP_RSA_KEYGEN         	 "keyGen"
 #define ACVP_RSA_SIGGEN         	 "sigGen"
 #define ACVP_RSA_SIGVER              "sigVer"
-#define ACVP_RSA_CAP_HASHALG_OBJ_NAME  "hashAlgs"
+#define ACVP_RSA_CAP_HASHALG_OBJ_NAME  "hashAlg"
+#define ACVP_RSA_CAP_HASHPAIR_NAME "hashPair"
 #define ACVP_RSA_TC_HASHALG_OBJ_NAME  "hashAlg"
 #define ACVP_RSA_SALTLEN_OBJ_NAME  "saltLen"
 #define ACVP_RSA_SIG_MSG_OBJ_NAME  "message"
@@ -130,6 +131,8 @@
 #define ACVP_RSA_SIGVER_PASS_YES_OBJ_NAME "passed"
 #define ACVP_RSA_SIGVER_PASS_NO_OBJ_NAME "failed"
 
+#define ACVP_PREREQ_VAL_STR "valValue"
+#define ACVP_PREREQ_OBJ_STR "prereqVals"
 
 #define ACVP_DRBG_MODE_SHA_1         "SHA-1"
 #define ACVP_DRBG_MODE_SHA_224       "SHA-224"
@@ -323,11 +326,6 @@ typedef struct acvp_name_list_t {
    struct acvp_name_list_t *next;
 } ACVP_NAME_LIST;
 
-typedef struct acvp_salt_t {
-   int saltVal;
-   struct acvp_salt_t *next;
-} ACVP_SALT_SIZES; // supported salt sizes list
-
 typedef struct acvp_rsa_primes_list {
    int modulo; // 2048, 3072, 4096 -- defined as macros
    ACVP_NAME_LIST *hash_algs;
@@ -335,10 +333,15 @@ typedef struct acvp_rsa_primes_list {
    struct acvp_rsa_primes_list *next;
 } ACVP_RSA_PRIMES_LIST;
 
+typedef struct acvp_rsa_hash_pair_list {
+    char *name;
+    int salt;
+    struct acvp_rsa_hash_pair_list *next;
+} ACVP_RSA_HASH_PAIR_LIST;
+
 typedef struct acvp_rsa_cap_sig_type {
    int mod_rsa_sig; // 2048, 3072, 4096 -- defined as macros
-   ACVP_NAME_LIST *compatible_hashes_sig;
-   ACVP_SALT_SIZES *salt_sig; // 28, 32, 64 -- when sigType = "PKCS1PSS"
+    ACVP_RSA_HASH_PAIR_LIST *hash_pairs;
    struct acvp_rsa_cap_sig_type *next;
 } ACVP_RSA_CAP_SIG_TYPE;
 
@@ -351,24 +354,19 @@ typedef struct acvp_rsa_keygen_attrs_t {
     ACVP_RSA_PRIMES_LIST *cap_primes_list;
 } ACVP_RSA_KEYGEN_ATTRS;
 
-typedef struct acvp_rsa_mode_siggen_t {
-    ACVP_RSA_MODE   mode;  // "sigGen"
+typedef struct acvp_rsa_mode_sig_t {
+    int sig_type_val;
     char *sig_type; // "X9.31", "PKCS1v1.5", "PKCS1PSS"
     ACVP_RSA_CAP_SIG_TYPE *cap_sig_type; //holds modRSASigGen (int) and hashSigGen (list)
-} ACVP_RSA_SIGGEN_ATTRS;
-
-typedef struct acvp_rsa_mode_sigver_t {
-    ACVP_RSA_MODE   mode;  // "sigVer"
-    char *sig_type; // "X9.31", "PKCS1v1.5", "PKCS1PSS"
-    ACVP_RSA_CAP_SIG_TYPE *cap_sig_type; //holds modRSASigVer (int) and hashSigVer (list)
-} ACVP_RSA_SIGVER_ATTRS;
+    struct acvp_rsa_mode_sig_t *next;
+} ACVP_RSA_SIG_ATTRS;
 
 typedef struct acvp_rsa_cap_mode_list_t {
     ACVP_RSA_MODE cap_mode;
     union {
         ACVP_RSA_KEYGEN_ATTRS *keygen;
-        ACVP_RSA_SIGGEN_ATTRS *siggen;
-        ACVP_RSA_SIGVER_ATTRS *sigver;
+        ACVP_RSA_SIG_ATTRS *siggen;
+        ACVP_RSA_SIG_ATTRS *sigver;
     } cap_mode_attrs;
     struct acvp_rsa_cap_mode_list_t *next;
 } ACVP_RSA_CAP_MODE_LIST;
@@ -503,7 +501,7 @@ ACVP_CIPHER acvp_lookup_cipher_index(const char *algorithm);
 ACVP_DRBG_MODE acvp_lookup_drbg_mode_index(const char *mode);
 ACVP_DRBG_CAP_MODE_LIST* acvp_locate_drbg_mode_entry(ACVP_CAPS_LIST *cap, ACVP_DRBG_MODE mode);
 ACVP_RSA_MODE acvp_lookup_rsa_mode_index(char *mode);
-ACVP_RSA_CAP_MODE_LIST* acvp_locate_rsa_sig_type_entry(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, ACVP_RSA_MODE mode, ACVP_RSA_SIG_TYPE sig_type);
+ACVP_RSA_SIG_ATTRS* acvp_locate_rsa_sig_type_entry(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, ACVP_RSA_MODE mode, ACVP_RSA_SIG_TYPE sig_type);
 ACVP_RSA_CAP_MODE_LIST* acvp_locate_rsa_mode_entry(ACVP_CAPS_LIST *cap, ACVP_RSA_MODE mode);
 char *acvp_rsa_get_sig_type_name(ACVP_RSA_SIG_TYPE sig_type);
 char *acvp_lookup_rsa_randpq_name(int value);


### PR DESCRIPTION
app_main has a fair amount of whitespace changes (sorry... I should really check the settings on my editor so it doesn't do this to you guys every time), but here is an outline of the rest so you don't have to dig:

- RSA API was consolidated because of the new "hashPair" object structure in the JSON registration. Because of this, there are a handful of API calls that have a NULL/0 final variable
- new structure added for "hashPair" and "salt" object was removed as it is now unnecessary
- removed a good amount of searching logic that was being called but not actually used
- reorganizing the JSON output
- added a registration for CMAC_TDES

--> there is one more layer of abstraction that I would like to add so that multiple RSA handlers can be registered in the case of multiples modes being registered... but will address that in another PR :)