### PR TITLE
Kdf135 tpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ SOURCES= src/acvp.c \
          src/acvp_kdf135_srtp.c \
          src/acvp_kdf135_ikev2.c \
          src/acvp_kdf135_ikev1.c \
+         src/acvp_kdf135_tpm.c \
          src/acvp_ecdsa.c
 OBJECTS=$(SOURCES:.c=.o)
 

--- a/Makefile.fom
+++ b/Makefile.fom
@@ -22,6 +22,7 @@ SOURCES= src/acvp.c \
          src/acvp_kdf135_srtp.c \
          src/acvp_kdf135_ikev2.c \
          src/acvp_kdf135_ikev1.c \
+         src/acvp_kdf135_tpm.c \
          src/acvp_ecdsa.c
 OBJECTS=$(SOURCES:.c=.o) $(MODULE_ROOT)/lib/fipscanister.o
 

--- a/Makefile.murl
+++ b/Makefile.murl
@@ -22,6 +22,7 @@ SOURCES= src/acvp.c \
          src/acvp_kdf135_srtp.c \
          src/acvp_kdf135_ikev2.c \
          src/acvp_kdf135_ikev1.c \
+         src/acvp_kdf135_tpm.c \
          src/acvp_ecdsa.c
 OBJECTS=$(SOURCES:.c=.o)
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -22,6 +22,7 @@ SOURCES= src/acvp.c \
          src/acvp_kdf135_srtp.c \
          src/acvp_kdf135_ikev2.c \
          src/acvp_kdf135_ikev1.c \
+         src/acvp_kdf135_tpm.c \
          src/acvp_ecdsa.c
 OBJECTS=$(SOURCES:.c=.o)
 

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -95,6 +95,7 @@ static ACVP_RESULT app_kdf135_ssh_handler(ACVP_TEST_CASE *test_case);
 static ACVP_RESULT app_kdf135_srtp_handler(ACVP_TEST_CASE *test_case);
 static ACVP_RESULT app_kdf135_ikev2_handler(ACVP_TEST_CASE *test_case);
 static ACVP_RESULT app_kdf135_ikev1_handler(ACVP_TEST_CASE *test_case);
+static ACVP_RESULT app_kdf135_tpm_handler(ACVP_TEST_CASE *test_case);
 #endif
 #ifdef ACVP_NO_RUNTIME
 static ACVP_RESULT app_drbg_handler(ACVP_TEST_CASE *test_case);
@@ -961,6 +962,13 @@ static void enable_kdf (ACVP_CTX *ctx) {
     rv = acvp_enable_kdf135_snmp_cap(ctx, &app_kdf135_snmp_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    
+    rv = acvp_enable_kdf135_tpm_cap(ctx, &app_kdf135_tpm_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_TPM, ACVP_PREREQ_SHA, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_prereq_cap(ctx, ACVP_KDF135_TPM, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_enable_kdf135_ssh_cap(ctx, &app_kdf135_ssh_handler);
@@ -2688,6 +2696,11 @@ static ACVP_RESULT app_kdf135_ikev1_handler(ACVP_TEST_CASE *test_case) {
     return rv;
 }
 
+static ACVP_RESULT app_kdf135_tpm_handler(ACVP_TEST_CASE *test_case) {
+    ACVP_RESULT rv = ACVP_CRYPTO_MODULE_FAIL;
+    return rv;
+}
+
 static ACVP_RESULT app_kdf135_tls_handler(ACVP_TEST_CASE *test_case)
 {
     ACVP_KDF135_TLS_TC    *tc;
@@ -2830,7 +2843,7 @@ static ACVP_RESULT app_kdf135_snmp_handler(ACVP_TEST_CASE *test_case)
         return ACVP_CRYPTO_MODULE_FAIL;
     }
 
-    tc->skey_len = strnlen((const char *)s_key, ACVP_KDF135_SNMP_SKEY_MAX);
+    tc->skey_len = strnlen((const char *)s_key, ACVP_KDF135_SKEY_MAX);
 
     return ACVP_SUCCESS;
 }

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -2843,7 +2843,7 @@ static ACVP_RESULT app_kdf135_snmp_handler(ACVP_TEST_CASE *test_case)
         return ACVP_CRYPTO_MODULE_FAIL;
     }
 
-    tc->skey_len = strnlen((const char *)s_key, ACVP_KDF135_SKEY_MAX);
+    tc->skey_len = strnlen((const char *)s_key, ACVP_KDF135_SNMP_SKEY_MAX);
 
     return ACVP_SUCCESS;
 }

--- a/src/acvp.h
+++ b/src/acvp.h
@@ -149,6 +149,7 @@ typedef enum acvp_cipher {
     ACVP_KDF135_SRTP,
     ACVP_KDF135_IKEV2,
     ACVP_KDF135_IKEV1,
+    ACVP_KDF135_TPM,
     ACVP_CIPHER_END
 } ACVP_CIPHER;
 
@@ -167,7 +168,7 @@ typedef enum acvp_prereq_mode_t {
 } ACVP_PREREQ_ALG;
 
 #define ACVP_KDF135_SNMP_ENGID_MAX 32
-#define ACVP_KDF135_SNMP_SKEY_MAX 32
+#define ACVP_KDF135_SKEY_MAX 32
 
 /*!
  * @struct ACVP_KDF135_TLS_CAP_PARM
@@ -613,6 +614,22 @@ typedef struct acvp_kdf135_snmp_tc_t {
 } ACVP_KDF135_SNMP_TC;
 
 /*!
+ * @struct ACVP_KDF135_TPM_TC
+ * @brief This struct holds data that represents a single test
+ * case for kdf135 TPM testing.  This data is
+ * passed between libacvp and the crypto module.
+ */
+typedef struct acvp_kdf135_tpm_tc_t {
+    ACVP_CIPHER cipher;
+    unsigned int tc_id;    /* Test case id */
+    char *auth;
+    char *nonce_even;
+    char *nonce_odd;
+    unsigned char *s_key;
+    unsigned int skey_len;
+} ACVP_KDF135_TPM_TC;
+
+/*!
  * @struct ACVP_KDF135_SRTP_TC
  * @brief This struct holds data that represents a single test
  * case for kdf135 SRTP testing.  This data is
@@ -932,6 +949,7 @@ typedef struct acvp_test_case_t {
         ACVP_KDF135_SRTP_TC *kdf135_srtp;
         ACVP_KDF135_IKEV2_TC *kdf135_ikev2;
         ACVP_KDF135_IKEV1_TC *kdf135_ikev1;
+        ACVP_KDF135_TPM_TC *kdf135_tpm;
     } tc;
 } ACVP_TEST_CASE;
 
@@ -1542,6 +1560,10 @@ ACVP_RESULT acvp_enable_kdf135_ikev2_cap (
         ACVP_RESULT (*crypto_handler) (ACVP_TEST_CASE *test_case));
 
 ACVP_RESULT acvp_enable_kdf135_ikev1_cap (
+        ACVP_CTX *ctx,
+        ACVP_RESULT (*crypto_handler) (ACVP_TEST_CASE *test_case));
+
+ACVP_RESULT acvp_enable_kdf135_tpm_cap (
         ACVP_CTX *ctx,
         ACVP_RESULT (*crypto_handler) (ACVP_TEST_CASE *test_case));
 

--- a/src/acvp.h
+++ b/src/acvp.h
@@ -168,7 +168,8 @@ typedef enum acvp_prereq_mode_t {
 } ACVP_PREREQ_ALG;
 
 #define ACVP_KDF135_SNMP_ENGID_MAX 32
-#define ACVP_KDF135_SKEY_MAX 32
+#define ACVP_KDF135_SNMP_SKEY_MAX 32
+#define ACVP_KDF135_TPM_SKEY_MAX 32
 
 /*!
  * @struct ACVP_KDF135_TLS_CAP_PARM

--- a/src/acvp_kdf135_snmp.c
+++ b/src/acvp_kdf135_snmp.c
@@ -218,7 +218,7 @@ static ACVP_RESULT acvp_kdf135_snmp_output_tc (ACVP_CTX *ctx, ACVP_KDF135_SNMP_T
     ACVP_RESULT rv;
     char *tmp;
 
-    tmp = calloc(1, ACVP_KDF135_SKEY_MAX);
+    tmp = calloc(1, ACVP_KDF135_SNMP_SKEY_MAX);
     if (!tmp) {
         ACVP_LOG_ERR("Unable to malloc in acvp_hmac_output_tc");
         return ACVP_MALLOC_FAIL;
@@ -249,7 +249,7 @@ static ACVP_RESULT acvp_kdf135_snmp_init_tc (ACVP_CTX *ctx,
     stc->s_key = calloc(1, p_len);
     if (!stc->s_key) { return ACVP_MALLOC_FAIL; }
 
-    memset(stc->s_key, 0, ACVP_KDF135_SKEY_MAX);
+    memset(stc->s_key, 0, ACVP_KDF135_SNMP_SKEY_MAX);
 
     stc->tc_id = tc_id;
     stc->cipher = alg_id;

--- a/src/acvp_kdf135_snmp.c
+++ b/src/acvp_kdf135_snmp.c
@@ -218,7 +218,7 @@ static ACVP_RESULT acvp_kdf135_snmp_output_tc (ACVP_CTX *ctx, ACVP_KDF135_SNMP_T
     ACVP_RESULT rv;
     char *tmp;
 
-    tmp = calloc(1, ACVP_KDF135_SNMP_SKEY_MAX);
+    tmp = calloc(1, ACVP_KDF135_SKEY_MAX);
     if (!tmp) {
         ACVP_LOG_ERR("Unable to malloc in acvp_hmac_output_tc");
         return ACVP_MALLOC_FAIL;
@@ -249,7 +249,7 @@ static ACVP_RESULT acvp_kdf135_snmp_init_tc (ACVP_CTX *ctx,
     stc->s_key = calloc(1, p_len);
     if (!stc->s_key) { return ACVP_MALLOC_FAIL; }
 
-    memset(stc->s_key, 0, ACVP_KDF135_SNMP_SKEY_MAX);
+    memset(stc->s_key, 0, ACVP_KDF135_SKEY_MAX);
 
     stc->tc_id = tc_id;
     stc->cipher = alg_id;

--- a/src/acvp_kdf135_tpm.c
+++ b/src/acvp_kdf135_tpm.c
@@ -41,7 +41,7 @@ static ACVP_RESULT acvp_kdf135_tpm_output_tc (ACVP_CTX *ctx, ACVP_KDF135_TPM_TC 
     ACVP_RESULT rv;
     char *tmp;
     
-    tmp = calloc(1, ACVP_KDF135_SKEY_MAX);
+    tmp = calloc(1, ACVP_KDF135_TPM_SKEY_MAX);
     if (!tmp) {
         ACVP_LOG_ERR("Unable to malloc in acvp_kdf135 tpm_output_tc");
         return ACVP_MALLOC_FAIL;
@@ -76,10 +76,10 @@ static ACVP_RESULT acvp_kdf135_tpm_init_tc (ACVP_CTX *ctx,
     stc->nonce_odd = calloc(strlen(nonce_odd), sizeof(char));
     if (!stc->nonce_odd) { return ACVP_MALLOC_FAIL; }
     
-    stc->s_key = calloc(ACVP_KDF135_SKEY_MAX, sizeof(char));
+    stc->s_key = calloc(ACVP_KDF135_TPM_SKEY_MAX, sizeof(char));
     if (!stc->s_key) { return ACVP_MALLOC_FAIL; }
     
-    memset(stc->s_key, 0, ACVP_KDF135_SKEY_MAX);
+    memset(stc->s_key, 0, ACVP_KDF135_TPM_SKEY_MAX);
     
     stc->tc_id = tc_id;
     stc->cipher = ACVP_KDF135_TPM;

--- a/src/acvp_kdf135_tpm.c
+++ b/src/acvp_kdf135_tpm.c
@@ -1,0 +1,263 @@
+/*****************************************************************************
+* Copyright (c) 2017, Cisco Systems, Inc.
+* All rights reserved.
+
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "acvp.h"
+#include "acvp_lcl.h"
+#include "parson.h"
+
+/*
+ * After the test case has been processed by the DUT, the results
+ * need to be JSON formated to be included in the vector set results
+ * file that will be uploaded to the server.  This routine handles
+ * the JSON processing for a single test case.
+ */
+static ACVP_RESULT acvp_kdf135_tpm_output_tc (ACVP_CTX *ctx, ACVP_KDF135_TPM_TC *stc, JSON_Object *tc_rsp) {
+    ACVP_RESULT rv;
+    char *tmp;
+    
+    tmp = calloc(1, ACVP_KDF135_SKEY_MAX);
+    if (!tmp) {
+        ACVP_LOG_ERR("Unable to malloc in acvp_kdf135 tpm_output_tc");
+        return ACVP_MALLOC_FAIL;
+    }
+    
+    rv = acvp_bin_to_hexstr(stc->s_key, stc->skey_len, (unsigned char *) tmp);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("hex conversion failure (s_key)");
+        return rv;
+    }
+    json_object_set_string(tc_rsp, "sKey", tmp);
+    
+    free(tmp);
+    return ACVP_SUCCESS;
+}
+
+static ACVP_RESULT acvp_kdf135_tpm_init_tc (ACVP_CTX *ctx,
+                                            ACVP_KDF135_TPM_TC *stc,
+                                            unsigned int tc_id,
+                                            char *auth,
+                                            char *nonce_even,
+                                            char *nonce_odd
+) {
+    memset(stc, 0x0, sizeof(ACVP_KDF135_TPM_TC));
+    
+    stc->auth = calloc(strlen(auth), sizeof(char));
+    if (!stc->auth) { return ACVP_MALLOC_FAIL; }
+    
+    stc->nonce_even = calloc(strlen(nonce_even), sizeof(char));
+    if (!stc->nonce_even) { return ACVP_MALLOC_FAIL; }
+    
+    stc->nonce_odd = calloc(strlen(nonce_odd), sizeof(char));
+    if (!stc->nonce_odd) { return ACVP_MALLOC_FAIL; }
+    
+    stc->s_key = calloc(ACVP_KDF135_SKEY_MAX, sizeof(char));
+    if (!stc->s_key) { return ACVP_MALLOC_FAIL; }
+    
+    memset(stc->s_key, 0, ACVP_KDF135_SKEY_MAX);
+    
+    stc->tc_id = tc_id;
+    stc->cipher = ACVP_KDF135_TPM;
+    stc->auth = auth;
+    stc->nonce_odd = nonce_odd;
+    stc->nonce_even = nonce_even;
+    
+    return ACVP_SUCCESS;
+}
+
+/*
+ * This function simply releases the data associated with
+ * a test case.
+ */
+static ACVP_RESULT acvp_kdf135_tpm_release_tc (ACVP_KDF135_TPM_TC *stc) {
+    free((void *) stc->auth);
+    free(stc->s_key);
+    free(stc->nonce_even);
+    free(stc->nonce_odd);
+    
+    memset(stc, 0x0, sizeof(ACVP_KDF135_TPM_TC));
+    return ACVP_SUCCESS;
+}
+
+ACVP_RESULT acvp_kdf135_tpm_kat_handler (ACVP_CTX *ctx, JSON_Object *obj) {
+    unsigned int tc_id;
+    JSON_Value *groupval;
+    JSON_Object *groupobj = NULL;
+    JSON_Value *testval;
+    JSON_Object *testobj = NULL;
+    JSON_Array *groups;
+    JSON_Array *tests;
+
+    JSON_Value *reg_arry_val = NULL;
+    JSON_Object *reg_obj = NULL;
+    JSON_Array *reg_arry = NULL;
+
+    int i, g_cnt;
+    int j, t_cnt;
+
+    JSON_Value *r_vs_val = NULL;
+    JSON_Object *r_vs = NULL;
+    JSON_Array *r_tarr = NULL; /* Response testarray */
+    JSON_Value *r_tval = NULL; /* Response testval */
+    JSON_Object *r_tobj = NULL; /* Response testobj */
+    ACVP_CAPS_LIST *cap;
+    ACVP_KDF135_TPM_TC stc;
+    ACVP_TEST_CASE tc;
+    ACVP_RESULT rv;
+    const char *alg_str = json_object_get_string(obj, "algorithm");
+    ACVP_CIPHER alg_id;
+    char *auth = NULL, *nonce_even = NULL, *nonce_odd = NULL;
+    char *json_result;
+
+    if (!alg_str) {
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
+        return (ACVP_MALFORMED_JSON);
+    }
+
+    /*
+     * Get a reference to the abstracted test case
+     */
+    tc.tc.kdf135_tpm = &stc;
+
+    /*
+     * Get the crypto module handler for this hash algorithm
+     */
+    alg_id = acvp_lookup_cipher_index(alg_str);
+    if (alg_id < ACVP_CIPHER_START) {
+        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
+        return (ACVP_UNSUPPORTED_OP);
+    }
+    cap = acvp_locate_cap_entry(ctx, alg_id);
+    if (!cap) {
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
+        return (ACVP_UNSUPPORTED_OP);
+    }
+
+    /*
+     * Create ACVP array for response
+     */
+    rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        return (rv);
+    }
+
+    /*
+     * Start to build the JSON response
+     */
+    if (ctx->kat_resp) {
+        json_value_free(ctx->kat_resp);
+    }
+    ctx->kat_resp = reg_arry_val;
+    r_vs_val = json_value_init_object();
+    r_vs = json_value_get_object(r_vs_val);
+
+    json_object_set_number(r_vs, "vsId", ctx->vs_id);
+    json_object_set_string(r_vs, "algorithm", alg_str);
+    json_object_set_value(r_vs, "testResults", json_value_init_array());
+    r_tarr = json_object_get_array(r_vs, "testResults");
+
+    groups = json_object_get_array(obj, "testGroups");
+    g_cnt = json_array_get_count(groups);
+    for (i = 0; i < g_cnt; i++) {
+        groupval = json_array_get_value(groups, i);
+        groupobj = json_value_get_object(groupval);
+
+        ACVP_LOG_INFO("    Test group: %d", i);
+
+        tests = json_object_get_array(groupobj, "tests");
+        t_cnt = json_array_get_count(tests);
+        for (j = 0; j < t_cnt; j++) {
+            ACVP_LOG_INFO("Found new kdf135 tpm test vector...");
+            testval = json_array_get_value(tests, j);
+            testobj = json_value_get_object(testval);
+
+            tc_id = (unsigned int) json_object_get_number(testobj, "tcId");
+            auth = json_object_get_string(testobj, "auth");
+            nonce_even = json_object_get_string(testobj, "nonceEven");
+            nonce_odd = json_object_get_string(testobj, "nonceOdd");
+
+            ACVP_LOG_INFO("        Test case: %d", j);
+            ACVP_LOG_INFO("             tcId: %d", tc_id);
+            ACVP_LOG_INFO("             auth: %d", auth);
+            ACVP_LOG_INFO("       nonce_even: %d", nonce_even);
+            ACVP_LOG_INFO("        nonce_odd: %d", nonce_odd);
+
+            /*
+             * Create a new test case in the response
+             */
+            r_tval = json_value_init_object();
+            r_tobj = json_value_get_object(r_tval);
+
+            json_object_set_number(r_tobj, "tcId", tc_id);
+
+            /*
+             * Setup the test case data that will be passed down to
+             * the crypto module.
+             * TODO: this does mallocs, we can probably do the mallocs once for
+             *       the entire vector set to be more efficient
+             */
+            acvp_kdf135_tpm_init_tc(ctx, &stc, tc_id, auth, nonce_even, nonce_odd);
+
+            /* Process the current test vector... */
+            rv = (cap->crypto_handler)(&tc);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("crypto module failed the operation");
+                return ACVP_CRYPTO_MODULE_FAIL;
+            }
+
+            /*
+             * Output the test case results using JSON
+            */
+            rv = acvp_kdf135_tpm_output_tc(ctx, &stc, r_tobj);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("JSON output failure in kdf135 tpm module");
+                return rv;
+            }
+            /*
+             * Release all the memory associated with the test case
+             */
+            acvp_kdf135_tpm_release_tc(&stc);
+
+            /* Append the test response value to array */
+            json_array_append_value(r_tarr, r_tval);
+        }
+    }
+
+    json_array_append_value(reg_arry, r_vs_val);
+
+    json_result = json_serialize_to_string_pretty(ctx->kat_resp);
+    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        printf("\n\n%s\n\n", json_result);
+    } else {
+        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
+    }
+    json_free_serialized_string(json_result);
+
+    return ACVP_SUCCESS;
+}

--- a/src/acvp_lcl.h
+++ b/src/acvp_lcl.h
@@ -138,6 +138,7 @@
 #define ACVP_ALG_KDF135_SRTP     "KDF-SRTP"
 #define ACVP_ALG_KDF135_IKEV2    "KDF-IKEV2"
 #define ACVP_ALG_KDF135_IKEV1    "KDF-IKEV1"
+#define ACVP_ALG_KDF135_TPM      "KDF-TPM"
 
 /*
  * The values that are supplied
@@ -261,7 +262,8 @@ typedef enum acvp_capability_type {
     ACVP_KDF135_SSH_TYPE,
     ACVP_KDF135_SRTP_TYPE,
     ACVP_KDF135_IKEV2_TYPE,
-    ACVP_KDF135_IKEV1_TYPE
+    ACVP_KDF135_IKEV1_TYPE,
+    ACVP_KDF135_TPM_TYPE
 } ACVP_CAP_TYPE;
 
 /*
@@ -324,6 +326,10 @@ typedef struct acvp_kdf135_tls_capability {
 typedef struct acvp_kdf135_snmp_capability {
 
 } ACVP_KDF135_SNMP_CAP;
+
+typedef struct acvp_kdf135_tpm_capability {
+
+} ACVP_KDF135_TPM_CAP;
 
 typedef struct acvp_kdf135_ssh_capability {
     int method[4];
@@ -517,6 +523,7 @@ typedef struct acvp_caps_list_t {
         ACVP_KDF135_SRTP_CAP *kdf135_srtp_cap;
         ACVP_KDF135_IKEV2_CAP *kdf135_ikev2_cap;
         ACVP_KDF135_IKEV1_CAP *kdf135_ikev1_cap;
+        ACVP_KDF135_TPM_CAP *kdf135_tpm_cap;
     } cap;
 
     ACVP_RESULT (*crypto_handler) (ACVP_TEST_CASE *test_case);
@@ -642,6 +649,8 @@ ACVP_RESULT acvp_kdf135_srtp_kat_handler (ACVP_CTX *ctx, JSON_Object *obj);
 ACVP_RESULT acvp_kdf135_ikev2_kat_handler (ACVP_CTX *ctx, JSON_Object *obj);
 
 ACVP_RESULT acvp_kdf135_ikev1_kat_handler (ACVP_CTX *ctx, JSON_Object *obj);
+
+ACVP_RESULT acvp_kdf135_tpm_kat_handler (ACVP_CTX *ctx, JSON_Object *obj);
 
 ACVP_RESULT acvp_dsa_kat_handler (ACVP_CTX *ctx, JSON_Object *obj);
 


### PR DESCRIPTION
- Library support to add kdf tpm to registration
- This does not include interop
**TPM (and a couple of other TPMs) spec's aren't up to date, so I haven't fixed JSON naming, etc in the registration since the consistency is still to be addressed :)