### PR TITLE
KAS-ECC Component mode and some info for non-Component mode

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1108,38 +1108,68 @@ static void enable_kas_ecc (ACVP_CTX *ctx) {
     /*
      * Enable KAS-ECC....
      */
-    rv = acvp_enable_kas_ecc_cap(ctx, ACVP_KAS_ECC, &app_kas_ecc_handler);
+    rv = acvp_enable_kas_ecc_cap(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_prereq_cap(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, value);
+    rv = acvp_enable_kas_ecc_prereq_cap(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_FUNCTION, ACVP_KAS_ECC_FUNC_PARTIAL);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_FUNCTION, ACVP_KAS_ECC_FUNC_PARTIAL);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_FUNCTION, ACVP_KAS_ECC_FUNC_DPGEN);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_P224);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_P224);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_P256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_P256);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_P384);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_P384);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_P521);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_P521);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_K233);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_K233);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_K283);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_K283);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_K409);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_K409);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_K571);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_K571);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_B233);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_B233);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_B283);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_B283);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_B409);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_B409);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_B571);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_ECDSA_CURVE_B571);
+
+    rv = acvp_enable_kas_ecc_cap(ctx, ACVP_KAS_ECC_COMP, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_prereq_cap(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_PREREQ_ECDSA, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_prereq_cap(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_PREREQ_SHA, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_prereq_cap(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_PREREQ_DRBG, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_prereq_cap(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_PREREQ_CCM, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_prereq_cap(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_PREREQ_CMAC, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_prereq_cap(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_PREREQ_HMAC, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_cap_parm(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_KAS_ECC_FUNCTION, ACVP_KAS_ECC_FUNC_PARTIAL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_cap_scheme(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_KAS_ECC_EPHEMERAL_UNIFIED,  ACVP_KAS_ECC_ROLE, 0, ACVP_KAS_ECC_ROLE_INITIATOR);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_cap_scheme(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_KAS_ECC_EPHEMERAL_UNIFIED,  ACVP_KAS_ECC_ROLE, 0, ACVP_KAS_ECC_ROLE_RESPONDER);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_cap_scheme(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_KAS_ECC_EPHEMERAL_UNIFIED,  ACVP_KAS_ECC_KDF, 0, ACVP_KAS_ECC_NOKDFNOKC);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_cap_scheme(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_KAS_ECC_EPHEMERAL_UNIFIED, ACVP_KAS_ECC_EB, ACVP_ECDSA_CURVE_P224, ACVP_SHA224);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_cap_scheme(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_KAS_ECC_EPHEMERAL_UNIFIED, ACVP_KAS_ECC_EC, ACVP_ECDSA_CURVE_P256, ACVP_SHA256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_cap_scheme(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_KAS_ECC_EPHEMERAL_UNIFIED, ACVP_KAS_ECC_ED, ACVP_ECDSA_CURVE_P384, ACVP_SHA384);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_enable_kas_ecc_cap_scheme(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_KAS_ECC_EPHEMERAL_UNIFIED, ACVP_KAS_ECC_EE, ACVP_ECDSA_CURVE_P521, ACVP_SHA512);
+    CHECK_ENABLE_CAP_RV(rv);
+
 }
 
 static void enable_dsa (ACVP_CTX *ctx) {
@@ -3462,17 +3492,11 @@ static EC_POINT *make_peer(EC_GROUP *group, BIGNUM *x, BIGNUM *y)
         return NULL;
     }
     if (EC_METHOD_get_field_type(EC_GROUP_method_of(group))
-        == NID_X9_62_prime_field)
+        == NID_X9_62_prime_field) {
         rv = EC_POINT_set_affine_coordinates_GFp(group, peer, x, y, c);
-    else
-#ifdef OPENSSL_NO_EC2M
-    {
-        printf("ERROR: GF2m not supported\n");
-        return NULL;
+    } else {
+        rv = EC_POINT_set_affine_coordinates_GF2m(group, peer, x, y, c);
     }
-#else
-    rv = EC_POINT_set_affine_coordinates_GF2m(group, peer, x, y, c);
-#endif
 
     BN_CTX_free(c);
     if (rv) {
@@ -3506,45 +3530,24 @@ static int ec_print_key(ACVP_KAS_ECC_TC *tc, EC_KEY *key, int add_e, int exout)
     }
     grp = EC_KEY_get0_group(key);
     pt = EC_KEY_get0_public_key(key);
-    if (exout)
-        d = EC_KEY_get0_private_key(key);
+    d = EC_KEY_get0_private_key(key);
     meth = EC_GROUP_method_of(grp);
-    if (EC_METHOD_get_field_type(meth) == NID_X9_62_prime_field)
+    if (EC_METHOD_get_field_type(meth) == NID_X9_62_prime_field) {
         rv = EC_POINT_get_affine_coordinates_GFp(grp, pt, tx, ty, ctx);
-    else
-#ifdef OPENSSL_NO_EC2M
-    {
-        BN_CTX_free(ctx);
-        printf("ERROR: GF2m not supported\n");
-        return 0;
-    }
-#else
-    rv = EC_POINT_get_affine_coordinates_GF2m(grp, pt, tx, ty, ctx);
-#endif
-
-
-    if (add_e) {
-        tc->pix = BN_bn2hex(tx);
-        tc->piy = BN_bn2hex(ty);
-        tc->pixlen = strnlen(tc->pix, ACVP_KAS_ECC_MAX_STR);
-        tc->piylen = strnlen(tc->piy, ACVP_KAS_ECC_MAX_STR);
-        if (d) {
-            tc->d = BN_bn2hex(d);
-            tc->dlen = strnlen(tc->d, ACVP_KAS_ECC_MAX_STR);
-        }
     } else {
+        rv = EC_POINT_get_affine_coordinates_GF2m(grp, pt, tx, ty, ctx);
+    }
 
+    if (tc->test_type == ACVP_KAS_ECC_TT_AFT) {
         tc->pix = BN_bn2hex(tx);
         tc->piy = BN_bn2hex(ty);
         tc->pixlen = strnlen(tc->pix, ACVP_KAS_ECC_MAX_STR);
         tc->piylen = strnlen(tc->piy, ACVP_KAS_ECC_MAX_STR);
-
-        if (d) {
+        if (tc->mode == ACVP_KAS_ECC_MODE_COMPONENT) {
             tc->d = BN_bn2hex(d);
             tc->dlen = strnlen(tc->d, ACVP_KAS_ECC_MAX_STR);
         }
     }
-
     BN_CTX_free(ctx);
     return rv;
 }
@@ -3558,7 +3561,8 @@ static ACVP_RESULT app_kas_ecc_handler(ACVP_TEST_CASE *test_case)
     EC_POINT *peerkey = NULL;
     unsigned char *Z;
     int Zlen;
-    BIGNUM *cx = NULL, *cy = NULL;
+    BIGNUM *cx = NULL, *cy = NULL, *ix = NULL, *iy = NULL, *id = NULL;
+    const EVP_MD *md = NULL;
 
     tc = test_case->tc.kas_ecc;
 
@@ -3606,6 +3610,27 @@ static ACVP_RESULT app_kas_ecc_handler(ACVP_TEST_CASE *test_case)
         break;
     }
 
+    if (tc->mode == ACVP_KAS_ECC_MODE_COMPONENT) {
+        switch (tc->md)
+        {
+        case ACVP_SHA224:
+            md = EVP_sha224();
+            break;
+        case ACVP_SHA256:
+            md = EVP_sha256();
+            break;
+        case ACVP_SHA384:
+            md = EVP_sha384();
+            break;
+        case ACVP_SHA512:
+            md = EVP_sha512();
+            break;
+        default:
+            printf("No valid hash name %d\n", tc->md);
+            return ACVP_CRYPTO_MODULE_FAIL;
+            break;
+        }
+    }
     group = EC_GROUP_new_by_curve_name(nid);
     if (group == NULL) {
         printf("No group from curve name %d\n", nid);
@@ -3627,14 +3652,14 @@ static ACVP_RESULT app_kas_ecc_handler(ACVP_TEST_CASE *test_case)
 
     if (!BN_hex2bn(&cx, (char *)tc->psx)) {
         EC_GROUP_free(group);
-        printf("BN_hex2bn failed\n");
+        printf("BN_hex2bn failed psx\n");
         return ACVP_CRYPTO_MODULE_FAIL;
     }
 
     if (!BN_hex2bn(&cy, (char *)tc->psy)) {
         EC_GROUP_free(group);
         BN_free(cx);
-        printf("BN_hex2bn failed\n");
+        printf("BN_hex2bn failed psy\n");
         return ACVP_CRYPTO_MODULE_FAIL;
     }
     peerkey = make_peer(group, cx, cy);
@@ -3645,16 +3670,50 @@ static ACVP_RESULT app_kas_ecc_handler(ACVP_TEST_CASE *test_case)
         printf("Peerkey failed\n");
         return ACVP_CRYPTO_MODULE_FAIL;
     }
-    if (!EC_KEY_generate_key(ec)) {
-        EC_POINT_free(peerkey);
-        EC_GROUP_free(group);
-        BN_free(cx);
-        BN_free(cy);
-        printf("EC_KEY_generate_key failed\n");
-        return ACVP_CRYPTO_MODULE_FAIL;
+    if (tc->test_type == ACVP_KAS_ECC_TT_VAL) {
+        if (!BN_hex2bn(&ix, (char *)tc->pix)) {
+            EC_GROUP_free(group);
+            BN_free(cx);
+            BN_free(cy);
+            printf("BN_hex2bn failed pix\n");
+            return ACVP_CRYPTO_MODULE_FAIL;
+        }
+
+        if (!BN_hex2bn(&iy, (char *)tc->piy)) {
+            EC_GROUP_free(group);
+            BN_free(cx);
+            BN_free(cy);
+            BN_free(ix);
+            printf("BN_hex2bn failed piy\n");
+            return ACVP_CRYPTO_MODULE_FAIL;
+        }
+        if (!BN_hex2bn(&id, (char *)tc->d)) {
+            EC_GROUP_free(group);
+            BN_free(cx);
+            BN_free(cy);
+            BN_free(ix);
+            BN_free(iy);
+            printf("BN_hex2bn failed id\n");
+            return ACVP_CRYPTO_MODULE_FAIL;
+        }
+        EC_KEY_set_public_key_affine_coordinates(ec, ix, iy);
+        EC_KEY_set_private_key(ec, id);
+    } else {
+        if (!EC_KEY_generate_key(ec)) {
+            EC_POINT_free(peerkey);
+            EC_GROUP_free(group);
+            BN_free(cx);
+            BN_free(cy);
+            BN_free(ix);
+            BN_free(iy);
+            BN_free(id);
+            printf("EC_KEY_generate_key failed\n");
+            return ACVP_CRYPTO_MODULE_FAIL;
+        }
     }
 
-    ec_print_key(tc, ec, 0, exout);
+    exout = md ? 1 : 0;
+    ec_print_key(tc, ec, md ? 1 : 0, exout);
     Zlen = (EC_GROUP_get_degree(group) + 7)/8;
     if (!Zlen) {
         EC_KEY_free(ec);
@@ -3662,6 +3721,9 @@ static ACVP_RESULT app_kas_ecc_handler(ACVP_TEST_CASE *test_case)
         EC_GROUP_free(group);
         BN_free(cx);
         BN_free(cy);
+        BN_free(ix);
+        BN_free(iy);
+        BN_free(id);
         printf("Zlen degree failure\n");
         return ACVP_CRYPTO_MODULE_FAIL;
     }
@@ -3672,6 +3734,9 @@ static ACVP_RESULT app_kas_ecc_handler(ACVP_TEST_CASE *test_case)
         EC_GROUP_free(group);
         BN_free(cx);
         BN_free(cy);
+        BN_free(ix);
+        BN_free(iy);
+        BN_free(id);
         printf("Malloc failure\n");
         return ACVP_CRYPTO_MODULE_FAIL;
     }
@@ -3681,13 +3746,21 @@ static ACVP_RESULT app_kas_ecc_handler(ACVP_TEST_CASE *test_case)
         EC_GROUP_free(group);
         BN_free(cx);
         BN_free(cy);
+        BN_free(ix);
+        BN_free(iy);
+        BN_free(id);
         printf("ECDH_compute_key failure\n");
         return ACVP_CRYPTO_MODULE_FAIL;
     }
 
-    memcpy(tc->z, Z, Zlen);
-    tc->zlen = Zlen;
-
+    if (tc->test_type == ACVP_KAS_ECC_TT_AFT) {
+        memcpy(tc->z, Z, Zlen);
+        tc->zlen = Zlen;
+    } 
+    if (tc->mode == ACVP_KAS_ECC_MODE_COMPONENT) {
+        FIPS_digest(Z, Zlen, (unsigned char *)tc->chash, NULL, md);
+        tc->chashlen = M_EVP_MD_size(md);
+    }
     OPENSSL_cleanse(Z, Zlen);
     OPENSSL_free(Z);
     EC_KEY_free(ec);
@@ -3695,6 +3768,9 @@ static ACVP_RESULT app_kas_ecc_handler(ACVP_TEST_CASE *test_case)
     EC_GROUP_free(group);
     BN_free(cx);
     BN_free(cy);
+    BN_free(ix);
+    BN_free(iy);
+    BN_free(id);
     return ACVP_SUCCESS;
 }
 
@@ -3772,7 +3848,7 @@ static ACVP_RESULT app_ecdsa_handler(ACVP_TEST_CASE *test_case)
     ACVP_ECDSA_TC    *tc;
     ACVP_RESULT rv = ACVP_CRYPTO_MODULE_FAIL;
     ACVP_CIPHER mode;
-    EVP_MD *md;
+    const EVP_MD *md;
 
     if (!test_case) {
         rv = ACVP_INVALID_ARG;

--- a/src/acvp.h
+++ b/src/acvp.h
@@ -162,7 +162,9 @@ typedef enum acvp_cipher {
     ACVP_KDF135_X963,
     ACVP_KDF135_TPM,
     ACVP_KDF108,
-    ACVP_KAS_ECC,
+    ACVP_KAS_ECC_CDH,
+    ACVP_KAS_ECC_COMP,
+    ACVP_KAS_ECC_NOCOMP,
     ACVP_CIPHER_END
 } ACVP_CIPHER;
 
@@ -1048,7 +1050,7 @@ typedef struct acvp_dsa_tc_t {
 typedef enum acvp_kas_ecc_mode {
     ACVP_KAS_ECC_MODE_COMPONENT = 1,
     ACVP_KAS_ECC_MODE_CDH,
-    ACVP_KAS_ECC_MODE_NONE,       /* actual mode, means not-component */
+    ACVP_KAS_ECC_MODE_NOCOMP,
     ACVP_KAS_ECC_MAX_MODES
 } ACVP_KAS_ECC_MODE;
 
@@ -1063,11 +1065,48 @@ typedef enum acvp_kas_ecc_func {
     ACVP_KAS_ECC_MAX_FUNCS
 } ACVP_KAS_ECC_FUNC;
 
-/*! @struct ACVP_KAS_ECC_PARM */
+/*! @struct ACVP_KAS_ECC_PARAM */
 typedef enum acvp_kas_ecc_param {
     ACVP_KAS_ECC_FUNCTION = 1,
-    ACVP_KAS_ECC_CURVE
-} ACVP_KAS_ECC_PARM;
+    ACVP_KAS_ECC_CURVE,
+    ACVP_KAS_ECC_ROLE,
+    ACVP_KAS_ECC_KDF,
+    ACVP_KAS_ECC_EB,
+    ACVP_KAS_ECC_EC,
+    ACVP_KAS_ECC_ED,
+    ACVP_KAS_ECC_EE
+} ACVP_KAS_ECC_PARAM;
+
+/*! @struct ACVP_KAS_ECC_ROLE */
+typedef enum acvp_kas_ecc_roles {
+    ACVP_KAS_ECC_ROLE_INITIATOR = 1,
+    ACVP_KAS_ECC_ROLE_RESPONDER
+} ACVP_KAS_ECC_ROLES;
+
+/*! @struct ACVP_KAS_ECC_SET */
+typedef enum acvp_kas_ecc_set {
+    ACVP_KAS_ECC_NOKDFNOKC = 1,
+    ACVP_KAS_ECC_KDFNOKC,
+    ACVP_KAS_ECC_KDFKC,
+    ACVP_KAS_ECC_PARMSET
+} ACVP_KAS_ECC_SET;
+
+/*! @struct ACVP_KAS_ECC_SCHEMES */
+typedef enum acvp_kas_ecc_schemes {
+    ACVP_KAS_ECC_EPHEMERAL_UNIFIED = 1,
+    ACVP_KAS_ECC_FULL_MQV,
+    ACVP_KAS_ECC_FULL_UNIFIED,
+    ACVP_KAS_ECC_ONEPASS_DH,
+    ACVP_KAS_ECC_ONEPASS_MQV,
+    ACVP_KAS_ECC_ONEPASS_UNIFIED,
+    ACVP_KAS_ECC_STATIC_UNIFIED
+} ACVP_KAS_ECC_SCHEMES;
+
+/*! @struct ACVP_KAS_ECC_TEST_TYPE */
+typedef enum acvp_kas_ecc_test_type {
+    ACVP_KAS_ECC_TT_AFT = 1,
+    ACVP_KAS_ECC_TT_VAL
+} ACVP_KAS_ECC_TEST_TYPE;
 
 /*!
  * @struct ACVP_KAS_ECC_TC
@@ -1079,18 +1118,22 @@ typedef enum acvp_kas_ecc_param {
 typedef struct acvp_kas_ecc_tc_t {
     ACVP_CIPHER cipher;
     ACVP_KAS_ECC_FUNC func; 
+    int test_type;
     int curve;
+    int md;
     char *psx;
     char *psy;
     char *pix;
     char *piy;
     char *d;
     char *z;
+    char *chash;
     int mode;
     int pixlen;
     int piylen;
     int dlen;
     int zlen;
+    int chashlen;
 } ACVP_KAS_ECC_TC;
 
 /*!
@@ -1536,7 +1579,7 @@ ACVP_RESULT acvp_enable_kas_ecc_prereq_cap (
     @param cipher ACVP_CIPHER enum value identifying the crypto capability.
     @param mode ACVP_KAS_ECC_MODE enum value specifying mode. An example would be
         ACVP_KAS_ECC_MODE_PARTIALVAL
-    @param param ACVP_KAS_ECC_PARM enum value identifying the algorithm parameter
+    @param param ACVP_KAS_ECC_PARAM enum value identifying the algorithm parameter
        that is being specified.  An example would be ACVP_KAS_ECC_????
     @param value the value corresponding to the parameter being set
 
@@ -1545,8 +1588,16 @@ ACVP_RESULT acvp_enable_kas_ecc_prereq_cap (
 ACVP_RESULT acvp_enable_kas_ecc_cap_parm (ACVP_CTX *ctx,
                                           ACVP_CIPHER cipher,
                                           ACVP_KAS_ECC_MODE mode,
-                                          ACVP_KAS_ECC_PARM param,
+                                          ACVP_KAS_ECC_PARAM param,
                                           int value);
+
+ACVP_RESULT acvp_enable_kas_ecc_cap_scheme (ACVP_CTX *ctx,
+                                            ACVP_CIPHER cipher,
+                                            ACVP_KAS_ECC_MODE mode,
+                                            ACVP_KAS_ECC_SCHEMES scheme,
+                                            ACVP_KAS_ECC_PARAM param,
+                                            int option,
+                                            int value);
 
 /*! @brief acvp_enable_rsa_*_cap()
 

--- a/src/acvp_kas_ecc.c
+++ b/src/acvp_kas_ecc.c
@@ -64,13 +64,66 @@ static ACVP_RESULT acvp_kas_ecc_output_cdh_tc (ACVP_CTX *ctx, ACVP_KAS_ECC_TC *s
     return rv;
 }
 
+
+/*
+ * After the test case has been processed by the DUT, the results
+ * need to be JSON formated to be included in the vector set results
+ * file that will be uploaded to the server.  This routine handles
+ * the JSON processing for a single test case.
+ */
+static ACVP_RESULT acvp_kas_ecc_output_comp_tc (ACVP_CTX *ctx, ACVP_KAS_ECC_TC *stc,
+                                               JSON_Object *tc_rsp) {
+    ACVP_RESULT rv;
+    char *tmp;
+
+    tmp = calloc(1, ACVP_KAS_ECC_MAX_STR);
+    if (!tmp) {
+        ACVP_LOG_ERR("Unable to malloc in acvp_aes_output_mct_tc");
+        return ACVP_MALLOC_FAIL;
+    }
+
+    if (stc->test_type == ACVP_KAS_ECC_TT_VAL) {
+        memset(tmp, 0x0, ACVP_KAS_ECC_MAX_STR);
+        rv = acvp_bin_to_hexstr((const unsigned char *)stc->chash, stc->chashlen, 
+                                (unsigned char *) tmp);
+        if (rv != ACVP_SUCCESS) {
+            free(tmp);
+            ACVP_LOG_ERR("hex conversion failure (Z)");
+            return rv;
+        }
+        if (!memcmp(stc->z, tmp, stc->zlen)) {    
+            json_object_set_string(tc_rsp, "result", "pass");
+        } else {
+            json_object_set_string(tc_rsp, "result", "fail");
+        }
+        free(tmp);
+        return ACVP_SUCCESS;
+    }
+
+    json_object_set_string(tc_rsp, "ephemeralPrivateIut", stc->d);
+    json_object_set_string(tc_rsp, "ephemeralPublicIutX", stc->pix);
+    json_object_set_string(tc_rsp, "ephemeralPublicIutY", stc->piy);
+
+    memset(tmp, 0x0, ACVP_KAS_ECC_MAX_STR);
+    rv = acvp_bin_to_hexstr((const unsigned char *)stc->chash, stc->chashlen, 
+                            (unsigned char *) tmp);
+    if (rv != ACVP_SUCCESS) {
+        free(tmp);
+        ACVP_LOG_ERR("hex conversion failure (Z)");
+        return rv;
+    }
+    json_object_set_string(tc_rsp, "hashZIut", tmp);
+    free(tmp);
+    return rv;
+}
+
 static ACVP_RESULT acvp_kas_ecc_init_cdh_tc (ACVP_CTX *ctx,
-                                            ACVP_KAS_ECC_TC *stc,
-                                            unsigned int tc_id,
-                                            const char *curve,
-                                            char *psx,
-                                            char *psy,
-                                            unsigned int mode
+                                             ACVP_KAS_ECC_TC *stc,
+                                             unsigned int tc_id,
+                                             const char *curve,
+                                             char *psx,
+                                             char *psy,
+                                             unsigned int mode
 ) {
 
     stc->mode = mode;
@@ -84,9 +137,90 @@ static ACVP_RESULT acvp_kas_ecc_init_cdh_tc (ACVP_CTX *ctx,
     if (!stc->z) { return ACVP_MALLOC_FAIL; }
     stc->d = calloc(1, ACVP_KAS_ECC_MAX_STR);
     if (!stc->d) { return ACVP_MALLOC_FAIL; }
+    stc->chash = calloc(1, ACVP_KAS_ECC_MAX_STR);
+    if (!stc->chash) { return ACVP_MALLOC_FAIL; }
 
     strncpy(stc->psx, psx, strnlen((char *)psx, ACVP_KAS_ECC_MAX_STR));
     strncpy(stc->psy, psy, strnlen((char *)psy, ACVP_KAS_ECC_MAX_STR));
+
+    if (!strcmp(curve, "b-233"))
+        stc->curve = ACVP_ECDSA_CURVE_B233;
+    if (!strcmp(curve, "b-283"))
+        stc->curve = ACVP_ECDSA_CURVE_B283;
+    if (!strcmp(curve, "b-409"))
+        stc->curve = ACVP_ECDSA_CURVE_B409;
+    if (!strcmp(curve, "b-571"))
+        stc->curve = ACVP_ECDSA_CURVE_B571;
+    if (!strcmp(curve, "k-233"))
+        stc->curve = ACVP_ECDSA_CURVE_K233;
+    if (!strcmp(curve, "k-283"))
+        stc->curve = ACVP_ECDSA_CURVE_K283;
+    if (!strcmp(curve, "k-409"))
+        stc->curve = ACVP_ECDSA_CURVE_K409;
+    if (!strcmp(curve, "k-571"))
+        stc->curve = ACVP_ECDSA_CURVE_K571;
+    if (!strcmp(curve, "p-224"))
+        stc->curve = ACVP_ECDSA_CURVE_P224;
+    if (!strcmp(curve, "p-256"))
+        stc->curve = ACVP_ECDSA_CURVE_P256;
+    if (!strcmp(curve, "p-384"))
+        stc->curve = ACVP_ECDSA_CURVE_P384;
+    if (!strcmp(curve, "p-521"))
+        stc->curve = ACVP_ECDSA_CURVE_P521;
+
+    return ACVP_SUCCESS;
+}
+
+static ACVP_RESULT acvp_kas_ecc_init_comp_tc (ACVP_CTX *ctx,
+                                              ACVP_KAS_ECC_TC *stc,
+                                              unsigned int tc_id,
+                                              const char *curve,
+                                              const char *hash,
+                                              char *psx,
+                                              char *psy,
+                                              char *d,
+                                              char *pix,
+                                              char *piy,
+                                              char *z,
+                                              unsigned int mode
+) {
+
+    stc->mode = mode;
+
+    stc->psx = calloc(1, ACVP_KAS_ECC_MAX_STR);
+    if (!stc->psx) { return ACVP_MALLOC_FAIL; }
+    stc->psy = calloc(1, ACVP_KAS_ECC_MAX_STR);
+    if (!stc->psy) { return ACVP_MALLOC_FAIL; }
+
+    stc->z = calloc(1, ACVP_KAS_ECC_MAX_STR);
+    if (!stc->z) { return ACVP_MALLOC_FAIL; }
+    stc->chash = calloc(1, ACVP_KAS_ECC_MAX_STR);
+    if (!stc->chash) { return ACVP_MALLOC_FAIL; }
+
+    strncpy(stc->psx, psx, strnlen((char *)psx, ACVP_KAS_ECC_MAX_STR));
+    strncpy(stc->psy, psy, strnlen((char *)psy, ACVP_KAS_ECC_MAX_STR));
+    if (stc->test_type == ACVP_KAS_ECC_TT_VAL) {
+        stc->pix = calloc(1, ACVP_KAS_ECC_MAX_STR);
+        if (!stc->pix) { return ACVP_MALLOC_FAIL; }
+        stc->piy = calloc(1, ACVP_KAS_ECC_MAX_STR);
+        if (!stc->piy) { return ACVP_MALLOC_FAIL; }
+        stc->d = calloc(1, ACVP_KAS_ECC_MAX_STR);
+        if (!stc->d) { return ACVP_MALLOC_FAIL; }
+
+        strncpy(stc->pix, pix, strnlen((char *)pix, ACVP_KAS_ECC_MAX_STR));
+        strncpy(stc->piy, piy, strnlen((char *)piy, ACVP_KAS_ECC_MAX_STR));
+        strncpy(stc->d, d, strnlen((char *)d, ACVP_KAS_ECC_MAX_STR));
+        strncpy(stc->z, z, strnlen((char *)z, ACVP_KAS_ECC_MAX_STR));
+        stc->zlen = strnlen((char *)z, ACVP_KAS_ECC_MAX_STR);
+    }
+    if (!strcmp(hash, "SHA2-224"))
+        stc->md = ACVP_SHA224;
+    if (!strcmp(hash, "SHA2-256"))
+        stc->md = ACVP_SHA256;
+    if (!strcmp(hash, "SHA2-384"))
+        stc->md = ACVP_SHA384;
+    if (!strcmp(hash, "SHA2-512"))
+        stc->md = ACVP_SHA512;
 
     if (!strcmp(curve, "b-233"))
         stc->curve = ACVP_ECDSA_CURVE_B233;
@@ -122,6 +256,7 @@ static ACVP_RESULT acvp_kas_ecc_init_cdh_tc (ACVP_CTX *ctx,
  */
 static ACVP_RESULT acvp_kas_ecc_release_tc (ACVP_KAS_ECC_TC *stc) {
 
+    free(stc->chash);
     free(stc->psx);
     free(stc->psy);
     free(stc->pix);
@@ -149,6 +284,7 @@ static ACVP_RESULT acvp_kas_ecc_cdh(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, ACVP_TES
     unsigned int i, g_cnt;
     int j, t_cnt, tc_id;
     ACVP_RESULT rv;
+    const char *test_type;
 
     groups = json_object_get_array(obj, "testGroups");
     g_cnt = json_array_get_count(groups);
@@ -159,6 +295,11 @@ static ACVP_RESULT acvp_kas_ecc_cdh(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, ACVP_TES
         groupobj = json_value_get_object(groupval);
 
         curve = json_object_get_string(groupobj, "curve");
+        test_type = json_object_get_string(groupobj, "testType");
+        if (!strncmp(test_type, "AFT", 3))
+            stc->test_type = ACVP_KAS_ECC_TT_AFT;
+        if (!strncmp(test_type, "VAL", 3))
+            stc->test_type = ACVP_KAS_ECC_TT_VAL;
 
         ACVP_LOG_INFO("    Test group: %d", i);
         ACVP_LOG_INFO("          curve: %s", curve);
@@ -193,10 +334,10 @@ static ACVP_RESULT acvp_kas_ecc_cdh(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, ACVP_TES
              * TODO: this does mallocs, we can probably do the mallocs once for
              *       the entire vector set to be more efficient
              */
-            acvp_kas_ecc_init_cdh_tc(ctx, stc, tc_id, curve, 
+            acvp_kas_ecc_init_cdh_tc(ctx, stc, tc_id, curve,
                                      psx, psy, mode);
 
-            /* Process the current AES KAT test vector... */
+            /* Process the current KAT test vector... */
             rv = (cap->crypto_handler)(tc);
             if (rv != ACVP_SUCCESS) {
                     return ACVP_CRYPTO_MODULE_FAIL;
@@ -207,7 +348,119 @@ static ACVP_RESULT acvp_kas_ecc_cdh(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, ACVP_TES
              */
             rv = acvp_kas_ecc_output_cdh_tc(ctx, stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in AES module");
+                ACVP_LOG_ERR("JSON output failure in KAS-ECC module");
+                return rv;
+            }
+
+            /*
+             * Release all the memory associated with the test case
+             */
+            acvp_kas_ecc_release_tc(stc);
+
+            /* Append the test response value to array */
+            json_array_append_value(r_tarr, r_tval);
+        }
+    }
+    return ACVP_SUCCESS;
+}
+
+static ACVP_RESULT acvp_kas_ecc_comp(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, ACVP_TEST_CASE *tc,
+                                     ACVP_KAS_ECC_TC *stc, JSON_Object *obj, int mode, 
+                                     JSON_Array *r_tarr)
+{
+    JSON_Value *groupval;
+    JSON_Object *groupobj = NULL;
+    JSON_Array *groups;
+    JSON_Value *testval;
+    JSON_Object *testobj = NULL;
+    JSON_Array *tests;
+    JSON_Value *r_tval = NULL; /* Response testval */
+    JSON_Object *r_tobj = NULL; /* Response testobj */
+    const char *curve;
+    const char *hash;
+    char *psx, *psy, *pix, *piy, *d, *z;
+    unsigned int i, g_cnt;
+    int j, t_cnt, tc_id;
+    ACVP_RESULT rv;
+    const char *test_type;
+
+    groups = json_object_get_array(obj, "testGroups");
+    g_cnt = json_array_get_count(groups);
+
+
+    for (i = 0; i < g_cnt; i++) {
+        groupval = json_array_get_value(groups, i);
+        groupobj = json_value_get_object(groupval);
+
+        curve = json_object_get_string(groupobj, "curve");
+        hash = json_object_get_string(groupobj, "hashAlg");
+        test_type = json_object_get_string(groupobj, "testType");
+        if (!strncmp(test_type, "AFT", 3))
+            stc->test_type = ACVP_KAS_ECC_TT_AFT;
+        if (!strncmp(test_type, "VAL", 3))
+            stc->test_type = ACVP_KAS_ECC_TT_VAL;
+    
+
+        ACVP_LOG_INFO("    Test group: %d", i);
+        ACVP_LOG_INFO("      test type: %s", test_type);
+        ACVP_LOG_INFO("          curve: %s", curve);
+        ACVP_LOG_INFO("           hash: %s", hash);
+
+
+        tests = json_object_get_array(groupobj, "tests");
+        t_cnt = json_array_get_count(tests);
+
+        for (j = 0; j < t_cnt; j++) {
+            ACVP_LOG_INFO("Found new KAS-ECC Component test vector...");
+            testval = json_array_get_value(tests, j);
+            testobj = json_value_get_object(testval);
+            tc_id = (unsigned int) json_object_get_number(testobj, "tcId");
+
+            /*
+             * Create a new test case in the response
+             */
+            r_tval = json_value_init_object();
+            r_tobj = json_value_get_object(r_tval);
+
+            json_object_set_number(r_tobj, "tcId", tc_id);
+
+            psx = (char *) json_object_get_string(testobj, "ephemeralPublicServerX");
+            psy = (char *) json_object_get_string(testobj, "ephemeralPublicServerY");
+            ACVP_LOG_INFO("            psx: %s", psx);
+            ACVP_LOG_INFO("            psy: %s", psy);
+
+            if (stc->test_type == ACVP_KAS_ECC_TT_VAL) {
+                pix = (char *) json_object_get_string(testobj, "ephemeralPublicIutX");
+                piy = (char *) json_object_get_string(testobj, "ephemeralPublicIutY");
+                d = (char *) json_object_get_string(testobj, "ephemeralPrivateIut");
+                z = (char *) json_object_get_string(testobj, "hashZIut");
+                ACVP_LOG_INFO("              d: %s", d);
+                ACVP_LOG_INFO("            pix: %s", pix);
+                ACVP_LOG_INFO("            piy: %s", piy);
+                ACVP_LOG_INFO("              z: %s", z);
+            }
+  
+            /*
+             * Setup the test case data that will be passed down to
+             * the crypto module.
+             * TODO: this does mallocs, we can probably do the mallocs once for
+             *       the entire vector set to be more efficient
+             */
+            acvp_kas_ecc_init_comp_tc(ctx, stc, tc_id, curve, hash,
+                                      psx, psy, d, pix, piy, z, mode);
+
+            /* Process the current KAT test vector... */
+            rv = (cap->crypto_handler)(tc);
+            if (rv != ACVP_SUCCESS) {
+                    return ACVP_CRYPTO_MODULE_FAIL;
+            }
+
+            /*
+             * Output the test case results using JSON
+             */
+            rv = acvp_kas_ecc_output_comp_tc(ctx, stc, r_tobj);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("JSON output failure in KAS-ECC module");
                 return rv;
             }
 
@@ -236,7 +489,6 @@ ACVP_RESULT acvp_kas_ecc_kat_handler (ACVP_CTX *ctx, JSON_Object *obj) {
     ACVP_KAS_ECC_TC stc;
     ACVP_RESULT rv;
     const char *alg_str = json_object_get_string(obj, "algorithm");
-    ACVP_CIPHER alg_id;
     int mode;
     char *json_result;
     const char *alg_mode;
@@ -246,17 +498,6 @@ ACVP_RESULT acvp_kas_ecc_kat_handler (ACVP_CTX *ctx, JSON_Object *obj) {
         return (ACVP_MALFORMED_JSON);
     }
 
-    alg_id = acvp_lookup_cipher_index(alg_str);
-    if (alg_id < ACVP_CIPHER_START) {
-        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
-        return (ACVP_UNSUPPORTED_OP);
-    }
-
-    cap = acvp_locate_cap_entry(ctx, alg_id);
-    if (!cap) {
-        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
-        return (ACVP_UNSUPPORTED_OP);
-    }
 
     /*
      * Get a reference to the abstracted test case
@@ -292,23 +533,42 @@ ACVP_RESULT acvp_kas_ecc_kat_handler (ACVP_CTX *ctx, JSON_Object *obj) {
     json_object_set_value(r_vs, "testResults", json_value_init_array());
     r_tarr = json_object_get_array(r_vs, "testResults");
 
-    stc.cipher = alg_id;
 
-    if (!strncmp(alg_mode, "CDH-Component", 13))
+    if (!strncmp(alg_mode, "CDH-Component", 13)) {
         mode = ACVP_KAS_ECC_MODE_CDH;
-    if (!strncmp(alg_mode, "Component", 9))
+        stc.cipher = ACVP_KAS_ECC_CDH;
+    }
+    if (!strncmp(alg_mode, "Component", 9)) {
         mode = ACVP_KAS_ECC_MODE_COMPONENT;
-    if (mode == 0)
-        mode = ACVP_KAS_ECC_MODE_NONE;
+        stc.cipher = ACVP_KAS_ECC_COMP;
+    }
+    if (mode == 0) {
+        mode = ACVP_KAS_ECC_MODE_NOCOMP;
+        stc.cipher = ACVP_KAS_ECC_NOCOMP;
+    }
 
     switch (mode)
     {
     case ACVP_KAS_ECC_MODE_CDH:
+        cap = acvp_locate_cap_entry(ctx, ACVP_KAS_ECC_CDH);
+        if (!cap) {
+            ACVP_LOG_ERR("ACVP server requesting unsupported capability");
+            return (ACVP_UNSUPPORTED_OP);
+        }
         rv = acvp_kas_ecc_cdh(ctx, cap, &tc, &stc, obj, mode, r_tarr);
         break;        
     case ACVP_KAS_ECC_MODE_COMPONENT:
-    case ACVP_KAS_ECC_MODE_NONE:
+        cap = acvp_locate_cap_entry(ctx, ACVP_KAS_ECC_COMP);
+        if (!cap) {
+            ACVP_LOG_ERR("ACVP server requesting unsupported capability");
+            return ACVP_UNSUPPORTED_OP;
+        }
+        rv = acvp_kas_ecc_comp(ctx, cap, &tc, &stc, obj, mode, r_tarr);
+        break;        
+    case ACVP_KAS_ECC_MODE_NOCOMP:
     default:
+        ACVP_LOG_ERR("ACVP server requesting unsupported KAS-ECC mode");
+        return ACVP_UNSUPPORTED_OP;
         break;
     }
     json_array_append_value(reg_arry, r_vs_val);

--- a/src/acvp_lcl.h
+++ b/src/acvp_lcl.h
@@ -118,6 +118,10 @@
 #define ACVP_ALG_DSA_SIGGEN          "sigGen"
 #define ACVP_ALG_DSA_SIGVER          "sigVer"
 
+#define ACVP_ALG_KAS_ECC_CDH         "CDH-Component"
+#define ACVP_ALG_KAS_ECC_COMP        "Component"
+#define ACVP_ALG_KAS_ECC_NOCOMP      ""
+
 #define ACVP_ALG_KAS_ECC             "KAS-ECC"
 #define ACVP_ALG_KAS_ECC_DPGEN       "dpGen"
 #define ACVP_ALG_KAS_ECC_DPVAL       "dpVal"
@@ -292,7 +296,9 @@ typedef enum acvp_capability_type {
     ACVP_KDF135_X963_TYPE,
     ACVP_KDF135_TPM_TYPE,
     ACVP_KDF108_TYPE,
-    ACVP_KAS_ECC_TYPE
+    ACVP_KAS_ECC_CDH_TYPE,
+    ACVP_KAS_ECC_COMP_TYPE,
+    ACVP_KAS_ECC_NOCOMP_TYPE
 } ACVP_CAP_TYPE;
 
 /*
@@ -539,9 +545,28 @@ typedef struct acvp_dsa_capability {
     ACVP_DSA_CAP_MODE *dsa_cap_mode;
 } ACVP_DSA_CAP;
 
-typedef struct acvp_kas_ecc_scheme {
-    int sha;
+typedef struct acvp_kas_ecc_mac {
+    int alg;
     int curve;
+    ACVP_PARAM_LIST *key;
+    int nonce;
+    int maclen;
+    struct acvp_kas_ecc_mac *next;
+} ACVP_KAS_ECC_MAC;
+
+typedef struct acvp_kas_ecc_pset {
+    int set;
+    int curve;
+    ACVP_PARAM_LIST *sha;
+    ACVP_KAS_ECC_MAC *mac;
+    struct acvp_kas_ecc_pset *next;
+} ACVP_KAS_ECC_PSET;
+
+typedef struct acvp_kas_ecc_scheme {
+    int scheme;
+    int kdf;
+    ACVP_PARAM_LIST *role;
+    ACVP_KAS_ECC_PSET *pset;
     struct acvp_kas_ecc_scheme *next;
 } ACVP_KAS_ECC_SCHEME;
 
@@ -550,8 +575,8 @@ typedef struct acvp_kas_ecc_cap_mode_t {
     ACVP_KAS_ECC_MODE cap_mode;
     ACVP_PREREQ_LIST *prereq_vals;
     ACVP_PARAM_LIST *curve;    /* CDH mode only */
-    ACVP_PARAM_LIST *function; /* CDH mode only */
-    ACVP_KAS_ECC_SCHEME *kas_ecc_sheme; /* other modes use schemes */
+    ACVP_PARAM_LIST *function;
+    ACVP_KAS_ECC_SCHEME *scheme; /* other modes use schemes */
 } ACVP_KAS_ECC_CAP_MODE;
 
 typedef struct acvp_kas_ecc_capability_t {


### PR DESCRIPTION
Plus fixed a bug in TOTP password generation when there was a NULL in the string which caused the key length to be wrong.