### PR TITLE
Add error handling for bad JSON in acvp_kas files

### DIFF
--- a/src/acvp_kas_ecc.c
+++ b/src/acvp_kas_ecc.c
@@ -296,6 +296,10 @@ static ACVP_RESULT acvp_kas_ecc_cdh(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, ACVP_TES
 
         curve = json_object_get_string(groupobj, "curve");
         test_type = json_object_get_string(groupobj, "testType");
+		if (!test_type) {
+			ACVP_LOG_ERR("Unable to parse testType from JSON");
+			return ACVP_MALFORMED_JSON;
+		}
         if (!strncmp(test_type, "AFT", 3))
             stc->test_type = ACVP_KAS_ECC_TT_AFT;
         if (!strncmp(test_type, "VAL", 3))
@@ -395,6 +399,10 @@ static ACVP_RESULT acvp_kas_ecc_comp(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, ACVP_TE
         curve = json_object_get_string(groupobj, "curve");
         hash = json_object_get_string(groupobj, "hashAlg");
         test_type = json_object_get_string(groupobj, "testType");
+		if (!test_type) {
+			ACVP_LOG_ERR("Unable to parse testType from JSON");
+			return ACVP_MALFORMED_JSON;
+		}
         if (!strncmp(test_type, "AFT", 3))
             stc->test_type = ACVP_KAS_ECC_TT_AFT;
         if (!strncmp(test_type, "VAL", 3))

--- a/src/acvp_kas_ffc.c
+++ b/src/acvp_kas_ffc.c
@@ -192,6 +192,10 @@ static ACVP_RESULT acvp_kas_ffc_comp(ACVP_CTX *ctx, ACVP_CAPS_LIST *cap, ACVP_TE
 
         hash = json_object_get_string(groupobj, "hashAlg");
         test_type = json_object_get_string(groupobj, "testType");
+		if (!test_type) {
+			ACVP_LOG_ERR("Unable to parse testType from JSON");
+			return ACVP_MALFORMED_JSON;
+		}
         if (!strncmp(test_type, "AFT", 3))
             stc->test_type = ACVP_KAS_FFC_TT_AFT;
         if (!strncmp(test_type, "VAL", 3))


### PR DESCRIPTION
This pull request adds null checks for several cases in which bad JSON input could cause a null dereference and program crash.
--
This issue was found by Muse, an automated code quality platform that uses advanced reasoning to find critical errors during development. Visit us at [musedev.io](http://musedev.io) to learn more and apply to join our private beta.