### PR TITLE
Prevent uninitialized return value in acvp.c

### DIFF
--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1302,8 +1302,10 @@ ACVP_RESULT acvp_check_test_results (ACVP_CTX *ctx) {
      * in the regisration response.  Attempt to download the result
      * for each vector set.
      */
-	rv = ACVP_NO_CTX;
     vs_entry = ctx->vs_list;
+    if (!vs_entry) {
+        return ACVP_MISSING_ARG;
+    }
     while (vs_entry) {
         rv = acvp_get_result_vsid(ctx, vs_entry->vs_id);
         if (ctx->is_sample) {

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1302,6 +1302,7 @@ ACVP_RESULT acvp_check_test_results (ACVP_CTX *ctx) {
      * in the regisration response.  Attempt to download the result
      * for each vector set.
      */
+	rv = ACVP_NO_CTX;
     vs_entry = ctx->vs_list;
     while (vs_entry) {
         rv = acvp_get_result_vsid(ctx, vs_entry->vs_id);


### PR DESCRIPTION
This pull request prevents an uninitialized return value in "acvp_check_test_results" in the case that the context contains no vector sets, hopefully preventing confusing error messages.
--
This issue was found by Muse, an automated code quality platform that uses advanced reasoning to find critical errors during development. Visit us at [musedev.io](http://musedev.io) to learn more and apply to join our private beta.