### PR TITLE
Prevent 2nd uninitialized return value in acvp.c

### DIFF
--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1255,8 +1255,10 @@ ACVP_RESULT acvp_process_tests (ACVP_CTX *ctx) {
      * in the regisration response.  Process each vector set and
      * return the results to the server.
      */
-	rv = ACVP_NO_CTX;
     vs_entry = ctx->vs_list;
+    if (!vs_entry) {
+        return ACVP_MISSING_ARG;
+    }
     while (vs_entry) {
         rv = acvp_process_vsid(ctx, vs_entry->vs_id);
         vs_entry = vs_entry->next;

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1243,7 +1243,7 @@ static ACVP_RESULT acvp_parse_register (ACVP_CTX *ctx) {
  * it should be run on a separate thread if needed.
  */
 ACVP_RESULT acvp_process_tests (ACVP_CTX *ctx) {
-    ACVP_RESULT rv;
+    ACVP_RESULT rv = ACVP_NO_CTX;
     ACVP_VS_LIST *vs_entry;
 
     if (!ctx) {

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1243,7 +1243,7 @@ static ACVP_RESULT acvp_parse_register (ACVP_CTX *ctx) {
  * it should be run on a separate thread if needed.
  */
 ACVP_RESULT acvp_process_tests (ACVP_CTX *ctx) {
-    ACVP_RESULT rv = ACVP_NO_CTX;
+    ACVP_RESULT rv;
     ACVP_VS_LIST *vs_entry;
 
     if (!ctx) {
@@ -1255,6 +1255,7 @@ ACVP_RESULT acvp_process_tests (ACVP_CTX *ctx) {
      * in the regisration response.  Process each vector set and
      * return the results to the server.
      */
+	rv = ACVP_NO_CTX;
     vs_entry = ctx->vs_list;
     while (vs_entry) {
         rv = acvp_process_vsid(ctx, vs_entry->vs_id);


### PR DESCRIPTION
This pull request prevents an uninitialized return value in "acvp_process_tests" in the case that the context contains no vector sets, hopefully preventing confusing error messages.
--
This issue was found by Muse, an automated code quality platform that uses advanced reasoning to find critical errors during development. Visit us at [musedev.io](http://musedev.io) to learn more and apply to join our private beta.