### PR TITLE
Prevent Null Dereference in acvp.c

### DIFF
--- a/src/acvp.c
+++ b/src/acvp.c
@@ -922,6 +922,7 @@ static ACVP_RESULT acvp_build_login (ACVP_CTX *ctx, char **login, int refresh) {
     JSON_Object *pw_obj = NULL;
     JSON_Array *reg_arry = NULL;
     char *token = malloc(ACVP_TOTP_TOKEN_MAX);
+	if (!token) return ACVP_MALLOC_FAIL;
     memset(token, 0, ACVP_TOTP_TOKEN_MAX);
 
     /*


### PR DESCRIPTION
This pull request prevents a null value being dereferenced and a possible program crash by adding a check after a call to malloc().
--
This issue was found by Muse, an automated code quality platform that uses advanced reasoning to find critical errors during development. Visit us at [musedev.io](http://musedev.io) to learn more and apply to join our private beta.