### PR TITLE
NULL sample_buf to prevent re-use after free

### DIFF
--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1996,6 +1996,7 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
                             ACVP_LOG_ERR("%s", ctx->sample_buf);
                         }
                         free(ctx->sample_buf);
+                        ctx->sample_buf = NULL;
                     }
                 }
             }


### PR DESCRIPTION
Can cause a segfault, at least it does on my server.