### PR TITLE
Interop with DES CFB1

### DIFF
--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -291,7 +291,6 @@ static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx,
                 goto err;
             }
             json_object_set_string(r_tobj, "pt", tmp_pt);
-            json_object_set_number(r_tobj, "payloadLen", 1);
         } else {
             rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp_pt, ACVP_SYM_PT_MAX);
             if (rv != ACVP_SUCCESS) {
@@ -318,7 +317,6 @@ static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx,
                 goto err;
             }
             json_object_set_string(r_tobj, "ct", tmp_ct);
-            json_object_set_number(r_tobj, "payloadLen", 1);
         } else {
             rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, tmp_ct, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
@@ -955,14 +953,13 @@ static ACVP_RESULT acvp_des_output_tc(ACVP_CTX *ctx,
     if (stc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
         memset(tmp, 0x0, ACVP_SYM_CT_MAX);
         if (stc->cipher == ACVP_TDES_CFB1) {
-            rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, tmp, ACVP_SYM_CT_MAX);
+            rv = acvp_bin_to_hexstr(stc->ct, (stc->ct_len+7)/8, tmp, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
                 ACVP_LOG_ERR("hex conversion failure (ct)");
                 free(tmp);
                 return rv;
             }
             json_object_set_string(tc_rsp, "ct", tmp);
-            json_object_set_number(tc_rsp, "payloadLen", stc->ct_len);
         } else {
             rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, tmp, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
@@ -995,14 +992,13 @@ static ACVP_RESULT acvp_des_output_tc(ACVP_CTX *ctx,
 
         memset(tmp, 0x0, ACVP_SYM_CT_MAX);
         if (stc->cipher == ACVP_TDES_CFB1) {
-            rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp, ACVP_SYM_CT_MAX);
+            rv = acvp_bin_to_hexstr(stc->pt, (stc->pt_len+7)/8, tmp, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
                 ACVP_LOG_ERR("hex conversion failure (pt)");
                 free(tmp);
                 return rv;
             }
             json_object_set_string(tc_rsp, "pt", tmp);
-            json_object_set_number(tc_rsp, "payloadLen", stc->pt_len);
         } else {
             rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {


### PR DESCRIPTION
This works today, but I opened an issue on the ACVP github because AES and TDES operate a bit differently. Will wait on AES until after I get that issue resolved.