### PR TITLE
Port CTR changes to external and PQGVER interoperability fix

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -4018,7 +4018,7 @@ static ACVP_RESULT app_dsa_handler(ACVP_TEST_CASE *test_case) {
 #endif
 
             if (BN_cmp(p2, p) || BN_cmp(q2, q))
-                r = -1;
+                r = 0;
             else
                 r = 1;
 

--- a/src/acvp.h
+++ b/src/acvp.h
@@ -642,6 +642,8 @@ typedef struct acvp_sym_cipher_tc_t {
     unsigned int ct_len;
     unsigned int tag_len;
     unsigned int mct_index;  /* used to identify init vs. update */
+    unsigned int incr_ctr;
+    unsigned int ovrflw_ctr;
 } ACVP_SYM_CIPHER_TC;
 
 /*!


### PR DESCRIPTION
Note that DSA PQGVER will still not pass due to issue #509 and #494 so further testing will be required once NIST fixes those.