### PR TITLE
Add a configuration to aid analysis

### DIFF
--- a/.muse/config
+++ b/.muse/config
@@ -1,0 +1,3 @@
+setup = ".muse/setup.sh"
+build = "make"
+verifiers = [ "infer" ]

--- a/.muse/setup.sh
+++ b/.muse/setup.sh
@@ -1,0 +1,8 @@
+if [ $(whoami) = "root" ]; then
+    apt install -y libssl1.0-dev libcurl4-gnutls-dev
+fi
+
+cd $1
+sed -i 's/gcc_z_support=yes/gcc_z_support=no/' configure
+sed -i 's/-z,noexecstack//' configure
+./configure LIBS=-lcurl


### PR DESCRIPTION
libacvp folks,

This patch adds minor configuration and setup files which aid automated analysis of libacvp code.  These files are in a hidden directory, unneeded by any part of the project or normal build system, and thought to be sufficiently uninteresting so that normal development can proceed as though they don't exist.  I'm happy to address any issues.

As in the past, the analyzer is there to find issues such as memory leaks, dead stores, and pointer exceptions.

In more detail:

In the past libacvp had a committed a `Makefile` which was automatically detected.  Modern libacvp branches include both a build.gradle and autotools (configure) with an assumption of gcc when on linux. With these changes the analyzer's current auto-detection of the build system is not sufficiently smart.  The configuration file (`.muse/config`) instructs the analyzer to use `make` and a setup script.  The setup script uses a quick-and-dirty sed to remove flags not currently supported by clang, which is used in part of the analysis.