### PR TITLE
Remove defaults for ca, client cert/key, and set default for path_seg

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -97,11 +97,11 @@ static void print_usage(int err) {
     printf("environment variables.  The following variables can be set:\n\n");
     printf("    ACV_SERVER (when not set, defaults to %s)\n", DEFAULT_SERVER);
     printf("    ACV_PORT (when not set, defaults to %d)\n", DEFAULT_PORT);
-    printf("    ACV_URI_PREFIX (when not set, defaults to null)\n");
-    printf("    ACV_CA_FILE (when not set, defaults to %s)\n", DEFAULT_CA_CHAIN);
-    printf("    ACV_CERT_FILE (when not set, defaults to %s)\n", DEFAULT_CERT);
-    printf("    ACV_KEY_FILE (when not set, defaults to %s)\n", DEFAULT_KEY);
-    printf("    ACV_TOTP_SEED (when not set, client will not use Two-factor authentication)\n\n");
+    printf("    ACV_URI_PREFIX (when not set, defaults to %s)\n", DEFAULT_URI_PREFIX);
+    printf("    ACV_TOTP_SEED (when not set, client will not use Two-factor authentication)\n");
+    printf("    ACV_CA_FILE\n");
+    printf("    ACV_CERT_FILE\n");
+    printf("    ACV_KEY_FILE\n\n");
     printf("The CA certificates, cert and key should be PEM encoded. There should be no\n");
     printf("password on the key file.\n");
 }

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -39,9 +39,7 @@ extern "C"
  */
 #define DEFAULT_SERVER "127.0.0.1"
 #define DEFAULT_PORT 443
-#define DEFAULT_CA_CHAIN "certs/acvp-private-root-ca.crt.pem"
-#define DEFAULT_CERT "certs/my-client-cert.pem"
-#define DEFAULT_KEY "certs/my-client-key.pem"
+#define DEFAULT_URI_PREFIX "acvp/v1/"
 #define JSON_FILENAME_LENGTH 24
 
 typedef struct app_config {
@@ -73,7 +71,7 @@ typedef struct app_config {
 
 
 int ingest_cli(APP_CONFIG *cfg, int argc, char **argv);
-ACVP_RESULT totp(char **token, int token_max);
+int app_setup_two_factor_auth(ACVP_CTX *ctx);
 
 void app_aes_cleanup(void);
 void app_des_cleanup(void);

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -97,21 +97,16 @@ static void setup_session_parameters() {
     if (!api_context) api_context = "";
 
     ca_chain_file = getenv("ACV_CA_FILE");
-    if (!ca_chain_file) ca_chain_file = DEFAULT_CA_CHAIN;
-
     cert_file = getenv("ACV_CERT_FILE");
-    if (!cert_file) cert_file = DEFAULT_CERT;
-
     key_file = getenv("ACV_KEY_FILE");
-    if (!key_file) key_file = DEFAULT_KEY;
 
     printf("Using the following parameters:\n\n");
     printf("    ACV_SERVER:     %s\n", server);
     printf("    ACV_PORT:       %d\n", port);
     printf("    ACV_URI_PREFIX: %s\n", path_segment);
-    printf("    ACV_CA_FILE:    %s\n", ca_chain_file);
-    printf("    ACV_CERT_FILE:  %s\n", cert_file);
-    printf("    ACV_KEY_FILE:   %s\n\n", key_file);
+    if (ca_chain_file) printf("    ACV_CA_FILE:    %s\n", ca_chain_file);
+    if (cert_file) printf("    ACV_CERT_FILE:  %s\n", cert_file);
+    if (key_file) printf("    ACV_KEY_FILE:   %s\n\n", key_file);
 }
 
 /*
@@ -240,33 +235,35 @@ int main(int argc, char **argv) {
         goto end;
     }
 
-    /*
-     * Next we provide the CA certs to be used by libacvp
-     * to verify the ACVP TLS certificate.
-     */
-    rv = acvp_set_cacerts(ctx, ca_chain_file);
-    if (rv != ACVP_SUCCESS) {
-        printf("Failed to set CA certs\n");
-        goto end;
+    if (ca_chain_file) {
+        /*
+         * Next we provide the CA certs to be used by libacvp
+         * to verify the ACVP TLS certificate.
+         */
+        rv = acvp_set_cacerts(ctx, ca_chain_file);
+        if (rv != ACVP_SUCCESS) {
+            printf("Failed to set CA certs\n");
+            goto end;
+        }
+    }
+
+    if (cert_file && key_file) {
+        /*
+         * Specify the certificate and private key the client should used
+         * for TLS client auth.
+         */
+        rv = acvp_set_certkey(ctx, cert_file, key_file);
+        if (rv != ACVP_SUCCESS) {
+            printf("Failed to set TLS cert/key\n");
+            goto end;
+        }
     }
 
     /*
-     * Specify the certificate and private key the client should used
-     * for TLS client auth.
+     * Setup the Two-factor authentication
+     * This may or may not be turned on...
      */
-    rv = acvp_set_certkey(ctx, cert_file, key_file);
-    if (rv != ACVP_SUCCESS) {
-        printf("Failed to set TLS cert/key\n");
-        goto end;
-    }
-
-    /*
-     * Specify the callback to be used for 2-FA to perform
-     * TOTP calculation
-     */
-    rv = acvp_set_2fa_callback(ctx, &totp);
-    if (rv != ACVP_SUCCESS) {
-        printf("Failed to set Two-factor authentication callback\n");
+    if (app_setup_two_factor_auth(ctx)) {
         goto end;
     }
 

--- a/app/app_utils.c
+++ b/app/app_utils.c
@@ -156,27 +156,27 @@ end:
     return len;
 }
 
-ACVP_RESULT totp(char **token, int token_max) {
+static ACVP_RESULT totp(char **token, int token_max) {
     char hash[MAX_LEN] = {0};
     int os, bin, otp;
     int md_len;
     char format[5];
     time_t t;
     unsigned char token_buff[T_LEN + 1] = {0};
-    char *new_seed = calloc(ACVP_TOTP_TOKEN_MAX, sizeof(char));
+    char *new_seed = NULL;
     char *seed = NULL;
     int seed_len = 0;
 
+    seed = getenv("ACV_TOTP_SEED");
+    if (!seed) {
+        /* Not required to use 2-factor auth */
+        return ACVP_SUCCESS;
+    }
+
+    new_seed = calloc(ACVP_TOTP_TOKEN_MAX, sizeof(char));
     if (!new_seed) {
         printf("Failed to malloc new_seed\n");
         return ACVP_MALLOC_FAIL;
-    }
-
-    seed = getenv("ACV_TOTP_SEED");
-    if (!seed) {
-        printf("Failed to get TOTP seed\n");
-        free(new_seed);
-        return ACVP_TOTP_MISSING_SEED;
     }
 
     t = time(NULL);
@@ -224,5 +224,23 @@ ACVP_RESULT totp(char **token, int token_max) {
     memcpy_s((char *)*token, token_max, token_buff, ACVP_TOTP_LENGTH);
     free(new_seed);
     return ACVP_SUCCESS;
+}
+
+int app_setup_two_factor_auth(ACVP_CTX *ctx) {
+    ACVP_RESULT rv = 0;
+
+    if (getenv("ACV_TOTP_SEED")) {
+        /*
+         * Specify the callback to be used for 2-FA to perform
+         * TOTP calculation
+         */
+        rv = acvp_set_2fa_callback(ctx, &totp);
+        if (rv != ACVP_SUCCESS) {
+            printf("Failed to set Two-factor authentication callback\n");
+            return 1;
+        }
+    }
+
+    return 0;
 }
 

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1121,11 +1121,6 @@ ACVP_RESULT acvp_set_cacerts(ACVP_CTX *ctx, char *ca_file) {
     ctx->cacerts_file = calloc(ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, sizeof(char));
     strcpy_s(ctx->cacerts_file, ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, ca_file);
 
-    /*
-     * Enable peer verification when CA certs are provided.
-     */
-    ctx->verify_peer = 1;
-
     return ACVP_SUCCESS;
 }
 
@@ -1171,9 +1166,9 @@ ACVP_RESULT acvp_mark_as_sample(ACVP_CTX *ctx) {
 
 /*
  * This function builds the JSON login message that
- * will be sent to the ACVP server to perform the
- * second of the two-factor authentications using
- * a TOTP.
+ * will be sent to the ACVP server. If enabled,
+ * it will perform the second of the two-factor
+ * authentications using a TOTP.
  */
 static ACVP_RESULT acvp_build_login(ACVP_CTX *ctx, char **login, int *login_len, int refresh) {
     ACVP_RESULT rv = ACVP_SUCCESS;
@@ -1183,9 +1178,8 @@ static ACVP_RESULT acvp_build_login(ACVP_CTX *ctx, char **login, int *login_len,
     JSON_Value *pw_val = NULL;
     JSON_Object *pw_obj = NULL;
     JSON_Array *reg_arry = NULL;
-    char *token = calloc(ACVP_TOTP_TOKEN_MAX, sizeof(char));
+    char *token = NULL;
 
-    if (!token) return ACVP_MALLOC_FAIL;
     if (!login_len) return ACVP_INVALID_ARG;
 
     /*
@@ -1200,27 +1194,33 @@ static ACVP_RESULT acvp_build_login(ACVP_CTX *ctx, char **login, int *login_len,
     json_object_set_string(ver_obj, "acvVersion", ACVP_VERSION);
     json_array_append_value(reg_arry, ver_val);
 
-    pw_val = json_value_init_object();
-    pw_obj = json_value_get_object(pw_val);
-
-    ctx->totp_cb(&token, ACVP_TOTP_TOKEN_MAX);
-    if (strnlen_s(token, ACVP_TOTP_TOKEN_MAX + 1) > ACVP_TOTP_TOKEN_MAX) {
-        ACVP_LOG_ERR("totp cb generated a token that is too long");
-        json_value_free(pw_val);
-        rv = ACVP_INVALID_ARG;
-        goto err;
+    if (ctx->totp_cb || refresh) {
+        pw_val = json_value_init_object();
+        pw_obj = json_value_get_object(pw_val);
     }
 
-    json_object_set_string(pw_obj, "password", token);
+    if (ctx->totp_cb) {
+        if (!token) return ACVP_MALLOC_FAIL;
+
+        ctx->totp_cb(&token, ACVP_TOTP_TOKEN_MAX);
+        if (strnlen_s(token, ACVP_TOTP_TOKEN_MAX + 1) > ACVP_TOTP_TOKEN_MAX) {
+            ACVP_LOG_ERR("totp cb generated a token that is too long");
+            json_value_free(pw_val);
+            rv = ACVP_INVALID_ARG;
+            goto err;
+        }
+
+        json_object_set_string(pw_obj, "password", token);
+    }
 
     if (refresh) {
         json_object_set_string(pw_obj, "accessToken", ctx->jwt_token);
     }
-    json_array_append_value(reg_arry, pw_val);
+    if (pw_val) json_array_append_value(reg_arry, pw_val);
 
 err:
     *login = json_serialize_to_string(reg_arry_val, login_len);
-    free(token);
+    if (token) free(token);
     json_value_free(reg_arry_val);
     return rv;
 }
@@ -1248,27 +1248,25 @@ ACVP_RESULT acvp_register(ACVP_CTX *ctx) {
     /*
      * Construct the login message
      */
-    if (ctx->totp_cb) {
-        rv = acvp_build_login(ctx, &login, &login_len, 0);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Unable to build login message");
-            goto end;
-        }
+    rv = acvp_build_login(ctx, &login, &login_len, 0);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Unable to build login message");
+        goto end;
+    }
 
-        /*
-         * Send the login to the ACVP server and get the response,
-         */
-        rv = acvp_send_login(ctx, login, login_len);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_STATUS("Login Send Failed");
-            goto end;
-        }
+    /*
+     * Send the login to the ACVP server and get the response,
+     */
+    rv = acvp_send_login(ctx, login, login_len);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_STATUS("Login Send Failed");
+        goto end;
+    }
 
-        rv = acvp_parse_login(ctx);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Unable to parse login response");
-            goto end;
-        }
+    rv = acvp_parse_login(ctx);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Unable to parse login response");
+        goto end;
     }
 
     if (ctx->use_json != 1) {
@@ -1816,26 +1814,24 @@ ACVP_RESULT acvp_refresh(ACVP_CTX *ctx) {
         return ACVP_NO_CTX;
     }
 
-    if (ctx->totp_cb) {
-        rv = acvp_build_login(ctx, &login, &login_len, 1);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Unable to build login message");
-            goto end;
-        }
+    rv = acvp_build_login(ctx, &login, &login_len, 1);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Unable to build login message");
+        goto end;
+    }
 
-        /*
-         * Send the login to the ACVP server and get the response,
-         */
-        rv = acvp_send_login(ctx, login, login_len);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_STATUS("Login Send Failed");
-            goto end;
-        }
+    /*
+     * Send the login to the ACVP server and get the response,
+     */
+    rv = acvp_send_login(ctx, login, login_len);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_STATUS("Login Send Failed");
+        goto end;
+    }
 
-        rv = acvp_parse_login(ctx);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_STATUS("Login Response Failed, %d", rv);
-        }
+    rv = acvp_parse_login(ctx);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_STATUS("Login Response Failed, %d", rv);
     }
 end:
     free(login);

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -162,19 +162,24 @@ static long acvp_curl_http_get(ACVP_CTX *ctx, char *url) {
     curl_easy_setopt(hnd, CURLOPT_URL, url);
     curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 1L);
     curl_easy_setopt(hnd, CURLOPT_USERAGENT, user_agent_str);
+    curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
     curl_easy_setopt(hnd, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
     if (slist) {
         curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, slist);
     }
-    if (ctx->verify_peer && ctx->cacerts_file) {
+
+    /*
+     * Always verify the server
+     */
+    curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 1L);
+    if (ctx->cacerts_file) {
         curl_easy_setopt(hnd, CURLOPT_CAINFO, ctx->cacerts_file);
-        curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 1L);
         curl_easy_setopt(hnd, CURLOPT_CERTINFO, 1L);
-    } else {
-        curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
-        ACVP_LOG_WARN("TLS peer verification has not been enabled.\n");
     }
-    curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
+
+    /*
+     * Mutual-auth
+     */
     if (ctx->tls_cert && ctx->tls_key) {
         curl_easy_setopt(hnd, CURLOPT_SSLCERTTYPE, "PEM");
         curl_easy_setopt(hnd, CURLOPT_SSLCERT, ctx->tls_cert);
@@ -261,17 +266,21 @@ static long acvp_curl_http_post(ACVP_CTX *ctx, char *url, char *data, int data_l
     curl_easy_setopt(hnd, CURLOPT_POST, 1L);
     curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, data);
     curl_easy_setopt(hnd, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)data_len);
-    curl_easy_setopt(hnd, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
-    //FIXME: we should always to TLS peer auth
-    if (ctx->verify_peer && ctx->cacerts_file) {
-        curl_easy_setopt(hnd, CURLOPT_CAINFO, ctx->cacerts_file);
-        curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 1L);
-        curl_easy_setopt(hnd, CURLOPT_CERTINFO, 1L);
-    } else {
-        curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
-        ACVP_LOG_WARN("TLS peer verification has not been enabled.");
-    }
     curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
+    curl_easy_setopt(hnd, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+
+    /*
+     * Always verify the server
+     */
+    curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 1L);
+    if (ctx->cacerts_file) {
+        curl_easy_setopt(hnd, CURLOPT_CAINFO, ctx->cacerts_file);
+        curl_easy_setopt(hnd, CURLOPT_CERTINFO, 1L);
+    }
+
+    /*
+     * Mutual-auth
+     */
     if (ctx->tls_cert && ctx->tls_key) {
         curl_easy_setopt(hnd, CURLOPT_SSLCERTTYPE, "PEM");
         curl_easy_setopt(hnd, CURLOPT_SSLCERT, ctx->tls_cert);


### PR DESCRIPTION
- Don't require mutual-authentication.
- Don't require a custom CA file (will use system store as default)
- Don't require 2fa
- Sets the default path segment