### PR TITLE
remove extra / on some URI strings

### DIFF
--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -471,7 +471,7 @@ ACVP_RESULT acvp_submit_vector_responses(ACVP_CTX *ctx, char *vsid_url) {
     }
 
     snprintf(url, ACVP_ATTR_URL_MAX - 1,
-            "https://%s:%d/%s/results",
+            "https://%s:%d%s/results",
             ctx->server_name, ctx->server_port, vsid_url);
 
     return acvp_network_action(ctx, ACVP_NET_POST_VS_RESP, url, NULL, 0);
@@ -514,7 +514,7 @@ ACVP_RESULT acvp_retrieve_vector_set(ACVP_CTX *ctx, char *vsid_url) {
     }
 
     snprintf(url, ACVP_ATTR_URL_MAX - 1,
-            "https://%s:%d/%s",
+            "https://%s:%d%s",
             ctx->server_name, ctx->server_port, vsid_url);
 
     return acvp_network_action(ctx, ACVP_NET_GET_VS, url, NULL, 0);
@@ -539,7 +539,7 @@ ACVP_RESULT acvp_retrieve_vector_set_result(ACVP_CTX *ctx, char *api_url) {
     }
 
     snprintf(url, ACVP_ATTR_URL_MAX - 1,
-            "https://%s:%d/%s/results",
+            "https://%s:%d%s/results",
             ctx->server_name, ctx->server_port, api_url);
 
     return acvp_network_action(ctx, ACVP_NET_GET_VS_RESULT, url, NULL, 0);
@@ -558,7 +558,7 @@ ACVP_RESULT acvp_retrieve_expected_result(ACVP_CTX *ctx, char *api_url) {
     }
 
     snprintf(url, ACVP_ATTR_URL_MAX - 1,
-            "https://%s:%d/%s/expected",
+            "https://%s:%d%s/expected",
             ctx->server_name, ctx->server_port, api_url);
 
     return acvp_network_action(ctx, ACVP_NET_GET_VS_SAMPLE, url, NULL, 0);
@@ -577,7 +577,7 @@ ACVP_RESULT acvp_transport_get(ACVP_CTX *ctx, const char *url) {
     }
 
     snprintf(constructed_url, ACVP_ATTR_URL_MAX - 1,
-             "https://%s:%d/%s",
+             "https://%s:%d%s",
              ctx->server_name, ctx->server_port, url);
 
     return acvp_network_action(ctx, ACVP_NET_GET, constructed_url, NULL, 0);


### PR DESCRIPTION
Those that use path_segment need the / when building the URI, these that were changed do not.