### PR TITLE
Re-enable SigGen and address missing 00 at start of signature

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1550,7 +1550,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
      */
     rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
     CHECK_ENABLE_CAP_RV(rv);
-#ifdef NOT_SUPPORTED_BY_OPENSSL
     // RSA w/ sigType: X9.31
     rv = acvp_cap_rsa_siggen_set_type(ctx, ACVP_RSA_SIG_TYPE_X931);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1573,7 +1572,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 4096, ACVP_SHA512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-#endif
 #endif
 
     // RSA w/ sigType: PKCS1v1.5

--- a/scripts/nist_setup.bat
+++ b/scripts/nist_setup.bat
@@ -5,6 +5,6 @@ set ACV_KEY_FILE=<procure from nist>
 set ACV_CERT_FILE=<procure from nist>
 set ACV_TOTP_SEED=<procure from nist>
 set ACV_PORT=443
-set ACV_SERVER=acvp.nist.gov
+set ACV_SERVER=demo.acvts.nist.gov
 set PATH=%PATH%;.\windows
 

--- a/scripts/nist_setup.sh
+++ b/scripts/nist_setup.sh
@@ -6,5 +6,5 @@ export ACV_KEY_FILE=<procure from nist>
 export ACV_CERT_FILE=<procure from nist>
 export ACV_TOTP_SEED=<procure from nist>
 export ACV_PORT=443
-export ACV_SERVER=demo.acvp.nist.gov
+export ACV_SERVER=demo.acvts.nist.gov
 

--- a/src/acvp_rsa_sig.c
+++ b/src/acvp_rsa_sig.c
@@ -200,11 +200,11 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
 
     ACVP_CIPHER alg_id;
     char *json_result = NULL, *mode_str;
-    unsigned int mod = 0;
-    char *msg, *signature = NULL;
+    unsigned int mod = 0, padding = 0;
+    char *msg, *signature = NULL, *tmp_signature = NULL;
     char *e_str = NULL, *n_str = NULL;
     char *salt = NULL, *alg_str;
-    int salt_len = 0, json_msglen, json_siglen;
+    int salt_len = 0, json_msglen, json_siglen, p;
     ACVP_RESULT rv;
 
     if (!ctx) {
@@ -399,26 +399,42 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
 
 
             if (alg_id == ACVP_RSA_SIGVER) {
-                signature = (char *)json_object_get_string(testobj, "signature");
-                if (!signature) {
+                tmp_signature = (char *)json_object_get_string(testobj, "signature");
+                if (!tmp_signature) {
                     ACVP_LOG_ERR("Missing 'signature' from server json");
                     rv = ACVP_MISSING_ARG;
                     json_value_free(r_tval);
                     goto err;
                 }
-                json_siglen = strnlen_s(signature, ACVP_RSA_SIGNATURE_MAX + 1);
+                json_siglen = strnlen_s(tmp_signature, ACVP_RSA_SIGNATURE_MAX + 1);
                 if (json_siglen > ACVP_RSA_SIGNATURE_MAX) {
                     ACVP_LOG_ERR("'signature' too long in server json");
                     rv = ACVP_INVALID_ARG;
                     json_value_free(r_tval);
                     goto err;
                 }
+
+                if (json_siglen != mod/4) {
+                    signature = calloc(mod/4 +1, sizeof(char));                    
+                    padding = mod/4 - json_siglen;
+                    for (p=0;p<padding;p++) {
+                        signature[p] = 0x30;
+                    }
+                    memcpy_s(signature + padding, mod/4, tmp_signature, json_siglen);
+                } else {
+                    padding = 0;
+                    signature = tmp_signature;
+                }
+
                 salt = (char *)json_object_get_string(testobj, "salt");
             }
 
             rv = acvp_rsa_sig_init_tc(ctx, alg_id, &stc, tgId, tc_id,
                                       sig_type, mod, hash_alg, e_str,
                                       n_str, msg, signature, salt, salt_len);
+            if (padding) {
+                free(signature);
+            }
 
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {

--- a/src/acvp_rsa_sig.c
+++ b/src/acvp_rsa_sig.c
@@ -416,6 +416,11 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
 
                 if (json_siglen != mod/4) {
                     signature = calloc(mod/4 +1, sizeof(char));                    
+                    if (!signature) {
+                        ACVP_LOG_ERR("Unable to malloc for signature");
+                        rv = ACVP_MALLOC_FAIL;
+                        goto err;
+                    }
                     padding = mod/4 - json_siglen;
                     for (p=0;p<padding;p++) {
                         signature[p] = 0x30;


### PR DESCRIPTION
This is merely a single workaround for a bigger problem documented as an issue on the ACVP github.
If they don't fix it and there are other instances, we will need to create a common utility to pad strings when they are not fully qualified.