### PR TITLE
Make status request a generic GET and add generic POST commands

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -434,7 +434,8 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
         }
     }
 
-    if (empty_alg) {
+    /* allopw post and get without algs defined */
+    if (empty_alg && !cfg->post && !cfg->get) {
         /* The user needs to select at least 1 algorithm */
         printf(ANSI_COLOR_RED "Requires at least 1 Algorithm Test Suite\n"ANSI_COLOR_RESET);
         print_usage(1);

--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -72,8 +72,12 @@ static void print_usage(int err) {
     printf("To process kat vectors from a JSON file use:\n");
     printf("      --kat <file>\n");
     printf("\n");
-    printf("To GET status of request, such as validation:\n");
-    printf("      --req_status <request string URL including ID>\n");
+    printf("To GET status of request, such as validation or metadata:\n");
+    printf("      --get <request string URL including ID>\n");
+    printf("\n");
+    printf("\n");
+    printf("To POST metadata for vendor, person, etc.:\n");
+    printf("      --post <metadata file>\n");
     printf("\n");
     printf("If you are running a sample registration (querying for correct answers\n");
     printf("in addition to the normal registration flow) use:\n");
@@ -154,7 +158,8 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
         { "vector_req", ko_required_argument, 403 },
         { "vector_rsp", ko_required_argument, 404 },
         { "vector_upload", ko_required_argument, 405 },
-        { "req_status", ko_required_argument, 406 },
+        { "get", ko_required_argument, 406 },
+        { "post", ko_required_argument, 407 },
         { NULL, 0, 0 }
     };
 
@@ -381,22 +386,39 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
             continue;
         }
 
-
         if (c == 406) {
-            int status_string_len = 0;
-            cfg->req_status = 1;
+            int get_string_len = 0;
+            cfg->get = 1;
 
-            status_string_len = strnlen_s(opt.arg, JSON_REQUEST_LENGTH + 1);
-            if (status_string_len > JSON_REQUEST_LENGTH) {
+            get_string_len = strnlen_s(opt.arg, JSON_REQUEST_LENGTH + 1);
+            if (get_string_len > JSON_REQUEST_LENGTH) {
                 printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
                        "\nThe <string> \"%s\", is too long."
                        "\nMax allowed <string> length is (%d).\n",
-                       "--req_status", opt.arg, JSON_REQUEST_LENGTH);
+                       "--get", opt.arg, JSON_REQUEST_LENGTH);
                 print_usage(1);
                 return 1;
             }
 
-            strcpy_s(cfg->status_string, JSON_REQUEST_LENGTH + 1, opt.arg);
+            strcpy_s(cfg->get_string, JSON_REQUEST_LENGTH + 1, opt.arg);
+            continue;
+        }
+
+        if (c == 407) {
+            int post_filename_len = 0;
+            cfg->post = 1;
+
+            post_filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
+            if (post_filename_len > JSON_REQUEST_LENGTH) {
+                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
+                       "\nThe <file> \"%s\", has a name that is too long."
+                       "\nMax allowed <file> name length is (%d).\n",
+                       "--post", opt.arg, JSON_FILENAME_LENGTH);
+                print_usage(1);
+                return 1;
+            }
+
+            strcpy_s(cfg->post_filename, JSON_FILENAME_LENGTH + 1, opt.arg);
             continue;
         }
 

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -33,14 +33,16 @@ typedef struct app_config {
     int vector_req;
     int vector_rsp;
     int vector_upload;
-    int req_status;
+    int get;
+    int post;
     int kat;
     int fips_validation;
     char json_file[JSON_FILENAME_LENGTH + 1];
     char vector_req_file[JSON_FILENAME_LENGTH + 1];
     char vector_rsp_file[JSON_FILENAME_LENGTH + 1];
     char vector_upload_file[JSON_FILENAME_LENGTH + 1];
-    char status_string[JSON_REQUEST_LENGTH + 1];
+    char get_string[JSON_REQUEST_LENGTH + 1];
+    char post_filename[JSON_FILENAME_LENGTH + 1];
     char kat_file[JSON_FILENAME_LENGTH + 1];
     char validation_metadata_file[JSON_FILENAME_LENGTH + 1];
 

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -207,8 +207,12 @@ int main(int argc, char **argv) {
         acvp_mark_as_sample(ctx);
     }
 
-    if (cfg.req_status) {
-        acvp_mark_as_status_only(ctx, cfg.status_string);
+    if (cfg.get) {
+        acvp_mark_as_get_only(ctx, cfg.get_string);
+    }
+
+    if (cfg.post) {
+        acvp_mark_as_post_only(ctx, cfg.post_filename);
     }
 
     if (cfg.vector_req && !cfg.vector_rsp) {

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -2525,17 +2525,29 @@ ACVP_RESULT acvp_mark_as_sample(ACVP_CTX *ctx);
  */
 ACVP_RESULT acvp_mark_as_request_only(ACVP_CTX *ctx, char *filename);
 
-/*! @brief acvp_mark_as_status_only() marks the registration as a GET status only.
+/*! @brief acvp_mark_as_get_only() marks the operation as a GET only.
 
     This function will take the string parameter and perform a GET to check
-    the status of a specific request.  The request ID must be part of the string.
+    the get of a specific request.  The request ID must be part of the string.
 
     @param ctx Pointer to ACVP_CTX that was previously created by
         calling acvp_create_test_session.
-    @param string used for the request, such as '/acvp/v1/requests/383'
+    @param string used for the get, such as '/acvp/v1/requests/383'
 
  */
-ACVP_RESULT acvp_mark_as_status_only(ACVP_CTX *ctx, char *string);
+ACVP_RESULT acvp_mark_as_get_only(ACVP_CTX *ctx, char *string);
+
+/*! @brief acvp_mark_as_post_only() marks the operation as a POST only.
+
+    This function will take the filename and perform a POST of the data
+    in the file to the URL /acvp/v1/<first field in file>
+
+    @param ctx Pointer to ACVP_CTX that was previously created by
+        calling acvp_create_test_session.
+    @param filename
+
+ */
+ACVP_RESULT acvp_mark_as_post_only(ACVP_CTX *ctx, char *filename);
 
 
 /*! @brief Performs the ACVP testing procedures.

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1271,8 +1271,10 @@ struct acvp_ctx_t {
     char *vector_req_file;  /* filename to use to store vector request JSON */
     int vector_req;         /* flag to indicate we are storing vector request JSON in a file */
     int vector_rsp;         /* flag to indicate we are storing vector responses JSON in a file */
-    int req_status;         /* flag to indicate we are only requesting validation status */
-    char *status_string;    /* string used for status request */
+    int get;                /* flag to indicate we are only getting status or metadata */
+    char *get_string;       /* string used for get request */
+    int post;               /* flag to indicate we are only posting metadata */
+    char *post_filename;    /* string used for post */
 
     ACVP_FIPS fips; /* Information related to a FIPS validation */
 
@@ -1473,7 +1475,10 @@ void acvp_free_str_list(ACVP_STRING_LIST **list);
 
 ACVP_RESULT acvp_json_serialize_to_file_pretty_a(const JSON_Value *value, const char *filename);
 ACVP_RESULT acvp_json_serialize_to_file_pretty_w(const JSON_Value *value, const char *filename);
-ACVP_RESULT acvp_get_request_status (ACVP_CTX *ctx, const char *url);
+ACVP_RESULT acvp_get(ACVP_CTX *ctx, const char *url);
+ACVP_RESULT acvp_post(ACVP_CTX *ctx, 
+                      const char *url,
+                      char *data);
 
 
 #endif

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1475,10 +1475,6 @@ void acvp_free_str_list(ACVP_STRING_LIST **list);
 
 ACVP_RESULT acvp_json_serialize_to_file_pretty_a(const JSON_Value *value, const char *filename);
 ACVP_RESULT acvp_json_serialize_to_file_pretty_w(const JSON_Value *value, const char *filename);
-ACVP_RESULT acvp_get(ACVP_CTX *ctx, const char *url);
-ACVP_RESULT acvp_post(ACVP_CTX *ctx, 
-                      const char *url,
-                      char *data);
 
 
 #endif

--- a/metadata/person.json
+++ b/metadata/person.json
@@ -1,0 +1,22 @@
+[
+    {
+      "url": "persons"
+    }, 
+    {
+      "fullName": "Jane Smithers",
+      "vendorUrl": "/acvp/v1/vendors/11175",
+      "emails": [
+        "jane.smithers@acme.acme"
+      ],
+      "phoneNumbers": [
+        {
+          "number": "555-555-0001",
+          "type": "fax"
+        },
+        {
+          "number": "555-555-0002",
+          "type": "voice"
+        }
+      ]
+    }
+]

--- a/metadata/vendor.json
+++ b/metadata/vendor.json
@@ -1,0 +1,22 @@
+[
+    {
+      "url": "vendors"
+    }, 
+    {
+      "name": "Acme Fictional",
+      "website": "http:fictional-acme.com",
+      "emails" : [ "acme@acme.com" ],
+      "phoneNumbers": [
+        { "number": "1-800-000-0000", "type": "voice" }
+      ],
+      "addresses" : [{
+          "street1": "Beach Dr.",
+          "locality": "Acme Town",
+          "region": "NC",
+          "country": "USA",
+          "postalCode": "00000"
+      }]
+    }
+]
+
+

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1166,6 +1166,9 @@ ACVP_RESULT acvp_set_json_filename(ACVP_CTX *ctx, const char *json_filename) {
     }
 
     ctx->json_filename = calloc(ACVP_JSON_FILENAME_MAX + 1, sizeof(char));
+    if (!ctx->json_filename) {
+        return ACVP_MALLOC_FAIL;
+    }
     strcpy_s(ctx->json_filename, ACVP_JSON_FILENAME_MAX + 1, json_filename);
 
     ctx->use_json = 1;
@@ -1192,6 +1195,9 @@ ACVP_RESULT acvp_set_server(ACVP_CTX *ctx, char *server_name, int port) {
         free(ctx->server_name);
     }
     ctx->server_name = calloc(ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, sizeof(char));
+    if (!ctx->server_name) {
+        return ACVP_MALLOC_FAIL;
+    }
     strcpy_s(ctx->server_name, ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, server_name);
 
     ctx->server_port = port;
@@ -1216,6 +1222,9 @@ ACVP_RESULT acvp_set_path_segment(ACVP_CTX *ctx, char *path_segment) {
     }
     if (ctx->path_segment) { free(ctx->path_segment); }
     ctx->path_segment = calloc(ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, sizeof(char));
+    if (!ctx->path_segment) {
+        return ACVP_MALLOC_FAIL;
+    }
     strcpy_s(ctx->path_segment, ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, path_segment);
 
     return ACVP_SUCCESS;
@@ -1238,6 +1247,9 @@ ACVP_RESULT acvp_set_api_context(ACVP_CTX *ctx, char *api_context) {
     }
     if (ctx->api_context) { free(ctx->api_context); }
     ctx->api_context = calloc(ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, sizeof(char));
+    if (!ctx->api_context) {
+        return ACVP_MALLOC_FAIL;
+    }
     strcpy_s(ctx->api_context, ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, api_context);
 
     return ACVP_SUCCESS;
@@ -1267,6 +1279,9 @@ ACVP_RESULT acvp_set_cacerts(ACVP_CTX *ctx, char *ca_file) {
 
     if (ctx->cacerts_file) { free(ctx->cacerts_file); }
     ctx->cacerts_file = calloc(ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, sizeof(char));
+    if (!ctx->cacerts_file) {
+        return ACVP_MALLOC_FAIL;
+    }
     strcpy_s(ctx->cacerts_file, ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, ca_file);
 
     return ACVP_SUCCESS;
@@ -1295,10 +1310,18 @@ ACVP_RESULT acvp_set_certkey(ACVP_CTX *ctx, char *cert_file, char *key_file) {
     }
     if (ctx->tls_cert) { free(ctx->tls_cert); }
     ctx->tls_cert = calloc(ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, sizeof(char));
+    if (!ctx->tls_cert) {
+        return ACVP_MALLOC_FAIL;
+    }
     strcpy_s(ctx->tls_cert, ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, cert_file);
 
     if (ctx->tls_key) { free(ctx->tls_key); }
     ctx->tls_key = calloc(ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, sizeof(char));
+    if (!ctx->tls_key) {
+        free(ctx->tls_cert);
+        ctx->tls_cert = NULL;
+        return ACVP_MALLOC_FAIL;
+    }
     strcpy_s(ctx->tls_key, ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, key_file);
 
     return ACVP_SUCCESS;
@@ -1326,6 +1349,9 @@ ACVP_RESULT acvp_mark_as_request_only(ACVP_CTX *ctx, char *filename) {
 
     if (ctx->vector_req_file) { free(ctx->vector_req_file); }
     ctx->vector_req_file = calloc(ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, sizeof(char));
+    if (!ctx->vector_req_file) {
+        return ACVP_MALLOC_FAIL;
+    }
     strcpy_s(ctx->vector_req_file, ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, filename);
     ctx->vector_req = 1;
     return ACVP_SUCCESS;
@@ -1346,6 +1372,10 @@ ACVP_RESULT acvp_mark_as_get_only(ACVP_CTX *ctx, char *string) {
 
     if (ctx->get_string) { free(ctx->get_string); }
     ctx->get_string = calloc(ACVP_REQUEST_STR_LEN_MAX + 1, sizeof(char));
+    if (!ctx->get_string) {
+        return ACVP_MALLOC_FAIL;
+    }
+
     strcpy_s(ctx->get_string, ACVP_REQUEST_STR_LEN_MAX + 1, string);
     ctx->get = 1;
     return ACVP_SUCCESS;
@@ -1366,6 +1396,10 @@ ACVP_RESULT acvp_mark_as_post_only(ACVP_CTX *ctx, char *filename) {
 
     if (ctx->post_filename) { free(ctx->post_filename); }
     ctx->post_filename = calloc(ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, sizeof(char));
+    if (!ctx->post_filename) {
+        return ACVP_MALLOC_FAIL;
+    }
+
     strcpy_s(ctx->post_filename, ACVP_SESSION_PARAMS_STR_LEN_MAX + 1, filename);
     ctx->post = 1;
     return ACVP_SUCCESS;

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2307,6 +2307,7 @@ ACVP_RESULT acvp_post_data(ACVP_CTX *ctx, char *filename) {
     JSON_Value *raw_val = NULL;
     const char *path = NULL;
     char *json_result = NULL;
+    int len;
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -2347,7 +2348,7 @@ ACVP_RESULT acvp_post_data(ACVP_CTX *ctx, char *filename) {
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     json_array_append_value(reg_arry, post_val);
 
-    json_result = json_serialize_to_string_pretty(reg_arry_val, NULL);
+    json_result = json_serialize_to_string_pretty(reg_arry_val, &len);
     if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
         printf("\nPOST Data: %s\n\n", json_result);
     } else {
@@ -2362,7 +2363,7 @@ ACVP_RESULT acvp_post_data(ACVP_CTX *ctx, char *filename) {
         goto end;
     }
 
-    rv = acvp_post(ctx, path, json_result);
+    rv = acvp_transport_post(ctx, path, json_result, len);
     json_free_serialized_string(json_result);
 
 end:
@@ -2384,7 +2385,7 @@ ACVP_RESULT acvp_run(ACVP_CTX *ctx, int fips_validation) {
 
 
     if (ctx->get) { 
-        rv = acvp_get(ctx, ctx->get_string);
+        rv = acvp_transport_get(ctx, ctx->get_string, NULL);
         if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
             printf("\nGET Response: %s\n\n", ctx->curl_buf);
         }

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -756,8 +756,8 @@ end:
 #endif
 }
 
-ACVP_RESULT acvp_get_request_status (ACVP_CTX *ctx, 
-                                     const char *url) {
+ACVP_RESULT acvp_get(ACVP_CTX *ctx, 
+                     const char *url) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     if (!ctx) {
@@ -771,6 +771,26 @@ ACVP_RESULT acvp_get_request_status (ACVP_CTX *ctx,
     }
 
     rv = acvp_transport_get(ctx, url, NULL);
+    return rv;
+}
+
+
+ACVP_RESULT acvp_post(ACVP_CTX *ctx, 
+                      const char *url,
+                      char *data) {
+    ACVP_RESULT rv = ACVP_SUCCESS;
+
+    if (!ctx) {
+        ACVP_LOG_ERR("Missing ctx");
+        return ACVP_NO_CTX;
+    }
+
+    if (!url) {
+        ACVP_LOG_ERR("Missing url");
+        return ACVP_MISSING_ARG;
+    }
+
+    rv = acvp_transport_post(ctx, url, data, strnlen_s(data, ACVP_CURL_BUF_MAX));
     return rv;
 }
 

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -756,45 +756,6 @@ end:
 #endif
 }
 
-ACVP_RESULT acvp_get(ACVP_CTX *ctx, 
-                     const char *url) {
-    ACVP_RESULT rv = ACVP_SUCCESS;
-
-    if (!ctx) {
-        ACVP_LOG_ERR("Missing ctx");
-        return ACVP_NO_CTX;
-    }
-
-    if (!url) {
-        ACVP_LOG_ERR("Missing url");
-        return ACVP_MISSING_ARG;
-    }
-
-    rv = acvp_transport_get(ctx, url, NULL);
-    return rv;
-}
-
-
-ACVP_RESULT acvp_post(ACVP_CTX *ctx, 
-                      const char *url,
-                      char *data) {
-    ACVP_RESULT rv = ACVP_SUCCESS;
-
-    if (!ctx) {
-        ACVP_LOG_ERR("Missing ctx");
-        return ACVP_NO_CTX;
-    }
-
-    if (!url) {
-        ACVP_LOG_ERR("Missing url");
-        return ACVP_MISSING_ARG;
-    }
-
-    rv = acvp_transport_post(ctx, url, data, strnlen_s(data, ACVP_CURL_BUF_MAX));
-    return rv;
-}
-
-
 #ifndef ACVP_OFFLINE
 #define JWT_EXPIRED_STR "JWT expired"
 #define JWT_EXPIRED_STR_LEN 11


### PR DESCRIPTION
added metadata examples that can be used with POST
Will need to add some README updates with metadata format and examples such as:

app/.libs/acvp_app --all_algs  --get '/acvp/v1/vendors?vendorId[0]=lt:20' --verbose
app/.libs/acvp_app --all_algs --get '/acvp/v1/vendors?name[0]=contains:acme' --verbose
app/.libs/acvp_app --all_algs  --post person.json --verbose
app/.libs/acvp_app --all_algs  --post vendor.json --verbose