### PR TITLE
--put, deprecate large, save JWT and testSession ID

### DIFF
--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -35,7 +35,9 @@ typedef struct app_config {
     int vector_upload;
     int get;
     int post;
+    int put;
     int kat;
+    int empty_alg;
     int fips_validation;
     char json_file[JSON_FILENAME_LENGTH + 1];
     char vector_req_file[JSON_FILENAME_LENGTH + 1];
@@ -43,6 +45,7 @@ typedef struct app_config {
     char vector_upload_file[JSON_FILENAME_LENGTH + 1];
     char get_string[JSON_REQUEST_LENGTH + 1];
     char post_filename[JSON_FILENAME_LENGTH + 1];
+    char put_filename[JSON_FILENAME_LENGTH + 1];
     char kat_file[JSON_FILENAME_LENGTH + 1];
     char validation_metadata_file[JSON_FILENAME_LENGTH + 1];
 

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -331,6 +331,15 @@ int main(int argc, char **argv) {
        goto end;
     }
 
+    /* PUT without algorithms submits put_filename for validation using save JWT and testSession ID */
+    if (cfg.empty_alg && cfg.put) {
+         rv = acvp_put_data_from_file(ctx, cfg.put_filename);
+         goto end;
+    }
+    /* PUT with alg testing will submit put_filename with module/oe information */
+    if (!cfg.empty_alg && cfg.put) {
+        acvp_mark_as_put_after_test(ctx, cfg.put_filename);
+    }
     /*
      * Run the test session.
      * Perform a FIPS validation on this test session if specified.

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -2548,6 +2548,7 @@ ACVP_RESULT acvp_mark_as_get_only(ACVP_CTX *ctx, char *string);
 
  */
 ACVP_RESULT acvp_mark_as_post_only(ACVP_CTX *ctx, char *filename);
+ACVP_RESULT acvp_mark_as_put_after_test(ACVP_CTX *ctx, char *filename);
 
 
 /*! @brief Performs the ACVP testing procedures.
@@ -2631,6 +2632,7 @@ ACVP_RESULT acvp_set_json_filename(ACVP_CTX *ctx, const char *json_filename);
 ACVP_RESULT acvp_load_kat_filename(ACVP_CTX *ctx, const char *kat_filename);
 ACVP_RESULT acvp_upload_vectors_from_file(ACVP_CTX *ctx, const char *rsp_filename, int fips_validation);
 ACVP_RESULT acvp_run_vectors_from_file(ACVP_CTX *ctx, const char *req_filename, const char *rsp_filename);
+ACVP_RESULT acvp_put_data_from_file(ACVP_CTX *ctx, const char *put_filename);
 
 /*! @brief acvp_set_2fa_callback() sets a callback function which
     will create or obtain a TOTP password for the second part of

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1275,6 +1275,8 @@ struct acvp_ctx_t {
     char *get_string;       /* string used for get request */
     int post;               /* flag to indicate we are only posting metadata */
     char *post_filename;    /* string used for post */
+    int put;                /* flag to indicate we are only putting metadata  for post test validation*/
+    char *put_filename;     /* string used for put */
 
     ACVP_FIPS fips; /* Information related to a FIPS validation */
 
@@ -1319,6 +1321,8 @@ ACVP_RESULT acvp_transport_put_validation(ACVP_CTX *ctx, const char *data, int d
 ACVP_RESULT acvp_transport_get(ACVP_CTX *ctx, const char *url, const ACVP_KV_LIST *parameters);
 
 ACVP_RESULT acvp_transport_post(ACVP_CTX *ctx, const char *uri, char *data, int data_len);
+
+ACVP_RESULT acvp_transport_put(ACVP_CTX *ctx, const char *endpoint, const char *data, int data_len);
 
 ACVP_RESULT acvp_retrieve_vector_set(ACVP_CTX *ctx, char *vsid_url);
 

--- a/metadata/module.json
+++ b/metadata/module.json
@@ -1,0 +1,14 @@
+[
+    {
+      "url": "/acvp/v1/modules"
+    }, 
+    {
+        "name": "OpenSSL FOM Algorithms",
+        "version": "6.3",
+        "type": "Firmware",
+        "vendorUrl": "/acvp/v1/vendors/11175",
+        "addressUrl": "/acvp/v1/vendors/11175/addresses/11138",
+        "contactUrls": ["/acvp/v1/persons/14941" ],
+        "description" : "Software FOM"
+    }
+]

--- a/metadata/oe.json
+++ b/metadata/oe.json
@@ -1,0 +1,13 @@
+[
+    {
+      "url": "/acvp/v1/oes"
+    }, 
+    {
+      "name": "Ubuntu Linux 3.1 on AMD 6272 Opteron Processor with Acme package installed",
+      "dependencies" : [ {
+          "type": "software", 
+          "name": "Linux 3.1",
+          "description" : "Ubuntu Linux Distribution 3.1" }
+       ]
+    }
+]

--- a/metadata/person.json
+++ b/metadata/person.json
@@ -1,6 +1,6 @@
 [
     {
-      "url": "persons"
+      "url": "/acvp/v1/persons"
     }, 
     {
       "fullName": "Jane Smithers",

--- a/metadata/vendor.json
+++ b/metadata/vendor.json
@@ -1,6 +1,6 @@
 [
     {
-      "url": "vendors"
+      "url": "/acvp/v1/vendors"
     }, 
     {
       "name": "Acme Fictional",


### PR DESCRIPTION
Deprecated large URL support
Test runs now create a json file that has the JWT and testSession URL that can be used for validation PUTs
Added --put command line option for:
      validation request PUT
      metadata modification PUT


