### PR TITLE
Feature/aes gcm siv

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -749,6 +749,43 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_AADLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
+#if 0 //not currently supported by openSSL
+    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM_SIV, &app_aes_handler_aead);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM_SIV, ACVP_PREREQ_AES, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM_SIV, ACVP_PREREQ_DRBG, value);
+    CHECK_ENABLE_CAP_RV(rv);
+
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_NA);
+    CHECK_ENABLE_CAP_RV(rv);
+
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_KEYLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_KEYLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_PTLEN, 16);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_PTLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_PTLEN, 136);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_PTLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_PTLEN, 264);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_AADLEN, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_AADLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_AADLEN, 136);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_AADLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+#endif
+
 end:
 
     return rv;

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -74,6 +74,7 @@ typedef enum acvp_result ACVP_RESULT;
 typedef enum acvp_cipher {
     ACVP_CIPHER_START = 0,
     ACVP_AES_GCM,
+    ACVP_AES_GCM_SIV,
     ACVP_AES_CCM,
     ACVP_AES_ECB,
     ACVP_AES_CBC,

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -92,6 +92,7 @@
 #define ACVP_REV_AES_OFB             ACVP_REVISION_LATEST
 #define ACVP_REV_AES_CTR             ACVP_REVISION_LATEST
 #define ACVP_REV_AES_GCM             ACVP_REVISION_LATEST
+#define ACVP_REV_AES_GCM_SIV         ACVP_REVISION_LATEST
 #define ACVP_REV_AES_CCM             ACVP_REVISION_LATEST
 #define ACVP_REV_AES_XTS             ACVP_REVISION_LATEST
 #define ACVP_REV_AES_KW              ACVP_REVISION_LATEST
@@ -194,6 +195,7 @@
 #define ACVP_ALG_AES_OFB             "ACVP-AES-OFB"
 #define ACVP_ALG_AES_CTR             "ACVP-AES-CTR"
 #define ACVP_ALG_AES_GCM             "ACVP-AES-GCM"
+#define ACVP_ALG_AES_GCM_SIV         "ACVP-AES-GCM-SIV"
 #define ACVP_ALG_AES_CCM             "ACVP-AES-CCM"
 #define ACVP_ALG_AES_XTS             "ACVP-AES-XTS"
 #define ACVP_ALG_AES_KW              "ACVP-AES-KW"

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -391,11 +391,13 @@
 #define ACVP_SYM_IV_BIT_MAX 1024                        /**< 1024 bits */
 #define ACVP_SYM_IV_MAX (ACVP_SYM_IV_BIT_MAX >> 2)      /**< 256 characters */
 #define ACVP_SYM_IV_BYTE_MAX (ACVP_SYM_IV_BIT_MAX >> 3) /**< 128 bytes */
+#define ACVP_AES_GCM_SIV_IVLEN 96
 
 #define ACVP_SYM_TAG_BIT_MIN 4                            /**< 128 bits */
 #define ACVP_SYM_TAG_BIT_MAX 128                          /**< 128 bits */
 #define ACVP_SYM_TAG_MAX (ACVP_SYM_TAG_BIT_MAX >> 2)      /**< 32 characters */
 #define ACVP_SYM_TAG_BYTE_MAX (ACVP_SYM_TAG_BIT_MAX >> 3) /**< 16 bytes */
+#define ACVP_AES_GCM_SIV_TAGLEN 128
 
 #define ACVP_SYM_AAD_BIT_MAX 65536                        /**< 65536 bits */
 #define ACVP_SYM_AAD_MAX (ACVP_SYM_AAD_BIT_MAX >> 2)      /**< 16384 characters */

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -65,6 +65,7 @@ static ACVP_RESULT acvp_put_data_from_ctx(ACVP_CTX *ctx);
  */
 ACVP_ALG_HANDLER alg_tbl[ACVP_ALG_MAX] = {
     { ACVP_AES_GCM,           &acvp_aes_kat_handler,          ACVP_ALG_AES_GCM,           NULL, ACVP_REV_AES_GCM},
+    { ACVP_AES_GCM_SIV,       &acvp_aes_kat_handler,          ACVP_ALG_AES_GCM_SIV,       NULL, ACVP_REV_AES_GCM_SIV},
     { ACVP_AES_CCM,           &acvp_aes_kat_handler,          ACVP_ALG_AES_CCM,           NULL, ACVP_REV_AES_CCM},
     { ACVP_AES_ECB,           &acvp_aes_kat_handler,          ACVP_ALG_AES_ECB,           NULL, ACVP_REV_AES_ECB},
     { ACVP_AES_CBC,           &acvp_aes_kat_handler,          ACVP_ALG_AES_CBC,           NULL, ACVP_REV_AES_CBC},

--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -733,11 +733,17 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             (alg_id != ACVP_AES_KWP)) {
             ivlen = 128;
         }
-        if (alg_id == ACVP_AES_GCM || alg_id == ACVP_AES_CCM || alg_id == ACVP_AES_GCM_SIV 
-                                                             || alg_id == ACVP_AES_GMAC) {
+
+        /* TODO: This value is supposed to be included in server JSON, but is not currently.
+         * Update when fixed on server end. */
+        if(alg_id == ACVP_AES_GCM_SIV) {
+            ivlen = ACVP_AES_GCM_SIV_IVLEN;
+        }
+        
+        if (alg_id == ACVP_AES_GCM || alg_id == ACVP_AES_CCM || alg_id == ACVP_AES_GMAC) {
             ivlen = (unsigned int)json_object_get_number(groupobj, "ivLen");
             if (!ivlen) {
-                ACVP_LOG_ERR("Server JSON missing 'ivlen'");
+                ACVP_LOG_ERR("Server JSON missing 'ivLen'");
                 rv = ACVP_MISSING_ARG;
                 goto err;
             }
@@ -745,7 +751,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             if (alg_id == ACVP_AES_GCM || alg_id == ACVP_AES_GMAC) {
                 if (!(ivlen >= ACVP_AES_GCM_IV_BIT_MIN &&
                       ivlen <= ACVP_AES_GCM_IV_BIT_MAX)) {
-                    ACVP_LOG_ERR("Server JSON invalid 'ivlen', (%u)", ivlen);
+                    ACVP_LOG_ERR("Server JSON invalid 'ivLen', (%u)", ivlen);
                     rv = ACVP_INVALID_ARG;
                     goto err;
                 }
@@ -782,18 +788,18 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                     ivlen <= ACVP_AES_CCM_IV_BIT_MAX) {
                     if (ivlen % 8 != 0) {
                         // Only increments of 8 allowed
-                        ACVP_LOG_ERR("Server JSON 'ivlen' (%u) mod 8 != 0", ivlen);
+                        ACVP_LOG_ERR("Server JSON 'ivLen' (%u) mod 8 != 0", ivlen);
                         rv = ACVP_INVALID_ARG;
                         goto err;
                     }
                 } else {
-                    ACVP_LOG_ERR("Server JSON invalid 'ivlen', (%u)", ivlen);
+                    ACVP_LOG_ERR("Server JSON invalid 'ivLen', (%u)", ivlen);
                     rv = ACVP_INVALID_ARG;
                     goto err;
                 }
             } else if (alg_id == ACVP_AES_GCM_SIV) {
-                if (ivlen != 96) {
-                    ACVP_LOG_ERR("Server JSON invalid 'ivlen', (%u)", ivlen);
+                if (ivlen != ACVP_AES_GCM_SIV_IVLEN) {
+                    ACVP_LOG_ERR("Server JSON invalid 'ivLen', (%u)", ivlen);
                     rv = ACVP_INVALID_ARG;
                     goto err;
                 }
@@ -808,7 +814,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             }
 
             taglen = (unsigned int)json_object_get_number(groupobj, "tagLen");
-            if (alg_id == ACVP_AES_GCM_SIV && taglen != 128) {
+            if (alg_id == ACVP_AES_GCM_SIV && taglen != ACVP_AES_GCM_SIV_TAGLEN) {
                 ACVP_LOG_ERR("Incorrect server JSON value 'taglen' for AES-GCM-SIV (%u)", taglen);
                 rv = ACVP_INVALID_ARG;
                 goto err;

--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -736,7 +736,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         /* TODO: This value is supposed to be included in server JSON, but is not currently.
          * Update when fixed on server end. */
-        if(alg_id == ACVP_AES_GCM_SIV) {
+        if (alg_id == ACVP_AES_GCM_SIV) {
             ivlen = ACVP_AES_GCM_SIV_IVLEN;
         }
         

--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -808,8 +808,11 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             }
 
             taglen = (unsigned int)json_object_get_number(groupobj, "tagLen");
-            if (!(taglen >= ACVP_SYM_TAG_BIT_MIN &&
-                  taglen <= ACVP_SYM_TAG_BIT_MAX)) {
+            if (alg_id == ACVP_AES_GCM_SIV && taglen != 128) {
+                ACVP_LOG_ERR("Incorrect server JSON value 'taglen' for AES-GCM-SIV (%u)", taglen);
+                rv = ACVP_INVALID_ARG;
+                goto err;
+            } else if (!(taglen >= ACVP_SYM_TAG_BIT_MIN && taglen <= ACVP_SYM_TAG_BIT_MAX)) {
                 ACVP_LOG_ERR("Server JSON invalid 'taglen', (%u)", taglen);
                 rv = ACVP_INVALID_ARG;
                 goto err;

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -509,7 +509,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
      * Set the supported AAD lengths (for AEAD ciphers)
      */
     if ((cap_entry->cipher == ACVP_AES_GCM) || (cap_entry->cipher == ACVP_AES_CCM)
-                                            || (cap_entry->cipher == ACVP_AES_GMAC)) {
+            || (cap_entry->cipher == ACVP_AES_GMAC || (cap_entry->cipher == ACVP_AES_GCM_SIV))) {
         json_object_set_value(cap_obj, "aadLen", json_value_init_array());
         opts_arr = json_object_get_array(cap_obj, "aadLen");
         sl_list = sym_cap->aadlen;
@@ -2549,6 +2549,7 @@ ACVP_RESULT acvp_build_test_session(ACVP_CTX *ctx, char **reg, int *out_len) {
              */
             switch (cap_entry->cipher) {
             case ACVP_AES_GCM:
+            case ACVP_AES_GCM_SIV:
             case ACVP_AES_CCM:
             case ACVP_AES_ECB:
             case ACVP_AES_CFB1:

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -773,6 +773,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
     case ACVP_SYM_CIPH_AADLEN:
         switch (cipher) {
         case ACVP_AES_GCM:
+        case ACVP_AES_GCM_SIV:
         case ACVP_AES_CCM:
         case ACVP_AES_ECB:
         case ACVP_AES_CBC:
@@ -811,6 +812,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
 static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG pre_req) {
     switch (cipher) {
     case ACVP_AES_GCM:
+    case ACVP_AES_GCM_SIV:
     case ACVP_AES_CCM:
     case ACVP_AES_ECB:
     case ACVP_AES_CFB1:
@@ -1059,6 +1061,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
 
     switch (cipher) {
     case ACVP_AES_GCM:
+    case ACVP_AES_GCM_SIV:
     case ACVP_AES_CCM:
     case ACVP_AES_ECB:
     case ACVP_AES_CBC:
@@ -1226,6 +1229,7 @@ ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
 
     switch (cipher) {
     case ACVP_AES_GCM:
+    case ACVP_AES_GCM_SIV:
     case ACVP_AES_CCM:
     case ACVP_AES_ECB:
     case ACVP_AES_CBC:

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -760,8 +760,14 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         }
         break;
     case ACVP_SYM_CIPH_IVLEN:
-        if (value >= 8 && value <= 1024) {
-            retval = ACVP_SUCCESS;
+        switch (cipher) {
+        case ACVP_AES_GCM_SIV:
+            break;
+        default:
+            if (value >= 8 && value <= 1024) {
+                retval = ACVP_SUCCESS;
+            }
+            break;
         }
         break;
     case ACVP_SYM_CIPH_TWEAK:
@@ -793,13 +799,13 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         break;
     case ACVP_SYM_CIPH_PTLEN:
         switch(cipher) {
-            case ACVP_AES_GMAC:
-                break;
-            default:
-                if (value >= 0 && value <= 65536) {
-                    retval = ACVP_SUCCESS;
-                }
-                break;
+        case ACVP_AES_GMAC:
+            break;
+        default:
+            if (value >= 0 && value <= 65536) {
+                retval = ACVP_SUCCESS;
+            }
+            break;
          }
         break;
     default:


### PR DESCRIPTION
-Completed library implementation of aes-gcm-siv.
-Currently not supported by OpenSSL, unable to implement in sample app
-Not currently tested with ACVP server due to lack of openSSL support
-Tested to build with 1.0.2 and 1.1.1, and to run other AES tests without issue