### PR TITLE
Server Request Retry Backoff

### DIFF
--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -675,7 +675,9 @@
  */
 
 #define ACVP_CURL_BUF_MAX       (1024 * 1024 * 16) /**< 16 MB */
-#define ACVP_RETRY_TIME_MAX     60 /* seconds */
+#define ACVP_RETRY_TIME_MAX     300 /* seconds */
+#define ACVP_MAX_WAIT_TIME      3600
+#define ACVP_RETRY_TIME         30
 #define ACVP_JWT_TOKEN_MAX      1024
 #define ACVP_ATTR_URL_MAX       2083 /* MS IE's limit - arbitrary */
 
@@ -1269,7 +1271,6 @@ struct acvp_ctx_t {
     int verify_peer;        /* enables TLS peer verification via Curl */
     char *tls_cert;         /* Location of PEM encoded X509 cert to use for TLS client auth */
     char *tls_key;          /* Location of PEM encoded priv key to use for TLS client auth */
-    
     ACVP_OPERATING_ENV op_env; /**< The Operating Environment resources available */
     ACVP_STRING_LIST *vsid_url_list;
     char *session_url;

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1272,6 +1272,7 @@ struct acvp_ctx_t {
     int verify_peer;        /* enables TLS peer verification via Curl */
     char *tls_cert;         /* Location of PEM encoded X509 cert to use for TLS client auth */
     char *tls_key;          /* Location of PEM encoded priv key to use for TLS client auth */
+    
     ACVP_OPERATING_ENV op_env; /**< The Operating Environment resources available */
     ACVP_STRING_LIST *vsid_url_list;
     char *session_url;

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -678,6 +678,7 @@
 #define ACVP_RETRY_TIME_MAX     300 /* seconds */
 #define ACVP_MAX_WAIT_TIME      3600
 #define ACVP_RETRY_TIME         30
+#define ACVP_RETRY_MODIFIER_MAX 10
 #define ACVP_JWT_TOKEN_MAX      1024
 #define ACVP_ATTR_URL_MAX       2083 /* MS IE's limit - arbitrary */
 

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2059,8 +2059,7 @@ static ACVP_RESULT acvp_process_vsid(ACVP_CTX *ctx, char *vsid_url, int count) {
             /*
              * Wait and try again to retrieve the VectorSet
              */
-            if (acvp_retry_handler(ctx, (unsigned int *)&retry_period, (unsigned int *)&time_waited_so_far, 1)
-                    != ACVP_KAT_DOWNLOAD_RETRY) {
+            if (acvp_retry_handler(ctx, &retry_period, &time_waited_so_far, 1) != ACVP_KAT_DOWNLOAD_RETRY) {
                 ACVP_LOG_STATUS("Maximum wait time with server reached! (Max: %d seconds)", ACVP_MAX_WAIT_TIME);
                 rv = ACVP_TRANSPORT_FAIL;
                 goto end;
@@ -2242,8 +2241,7 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
              * Retry
              */
             ACVP_LOG_STATUS("TestSession results incomplete...");
-            if (acvp_retry_handler(ctx, (unsigned int *)&retry_interval, (unsigned int *)&time_waited_so_far, 2)
-                    != ACVP_KAT_DOWNLOAD_RETRY) {
+            if (acvp_retry_handler(ctx, &retry_interval, &time_waited_so_far, 2) != ACVP_KAT_DOWNLOAD_RETRY) {
                 ACVP_LOG_STATUS("Maximum wait time with server reached! (Max: %d seconds)", ACVP_MAX_WAIT_TIME);
                 rv = ACVP_TRANSPORT_FAIL;
                 goto end;

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1894,6 +1894,10 @@ ACVP_RESULT acvp_process_tests(ACVP_CTX *ctx) {
     }
     while (vs_entry) {
         rv = acvp_process_vsid(ctx, vs_entry->string, count);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("Unable to process vector set! Error: %d", rv);
+            return rv;
+        }
         vs_entry = vs_entry->next;
         count++;
     }
@@ -1905,21 +1909,45 @@ ACVP_RESULT acvp_process_tests(ACVP_CTX *ctx) {
 }
 
 /*
- * This is a minimal retry handler, which pauses for a specific time.
+ * This is a retry handler, which pauses for a specific time.
  * This allows the server time to generate the vectors on behalf of
- * the client.
+ * the client and to process the vector responses. This caller of this function
+ * can choose to implement a retry backoff using 'modifier'. Additionally, this
+ * function will ensure that retry periods will sum to no longer than ACVP_MAX_WAIT_TIME.
  */
-static ACVP_RESULT acvp_retry_handler(ACVP_CTX *ctx, unsigned int retry_period) {
-    ACVP_LOG_STATUS("200 OK KAT values not ready, server requests we wait %u seconds and try again...", retry_period);
-    if (retry_period <= 0 || retry_period > ACVP_RETRY_TIME_MAX) {
-        retry_period = ACVP_RETRY_TIME_MAX;
+static ACVP_RESULT acvp_retry_handler(ACVP_CTX *ctx, unsigned int *retry_period, unsigned int *waited_so_far, int modifier) {
+    /* perform check at beginning of function call, so library can check one more time when max
+     * time is reached to see if server status has changed */
+    if (*waited_so_far >= ACVP_MAX_WAIT_TIME) {
+        return ACVP_TRANSPORT_FAIL;
+    }
+    
+    if(*waited_so_far + *retry_period > ACVP_MAX_WAIT_TIME) {
+        *retry_period = ACVP_MAX_WAIT_TIME - *waited_so_far;
+    }
+    if (*retry_period <= 0 || *retry_period > ACVP_RETRY_TIME_MAX) {
+        *retry_period = ACVP_RETRY_TIME_MAX;
         ACVP_LOG_WARN("retry_period not found, using max retry period!");
     }
+
+    ACVP_LOG_STATUS("200 OK KAT values not ready, server requests we wait %u seconds and try again...", *retry_period);
+
     #ifdef WIN32
-    Sleep(retry_period);
+    Sleep(*retry_period);
     #else
-    sleep(retry_period);
+    sleep(*retry_period);
     #endif
+
+    /* ensure that all parameters are valid and that we do not wait longer than ACVP_MAX_WAIT_TIME */
+    if(modifier < 1 || modifier > ACVP_RETRY_MODIFIER_MAX) {
+        ACVP_LOG_WARN("retry modifier not valid, defaulting to 1 (no change)");
+        modifier = 1;
+    }
+    if((*retry_period *= modifier) > ACVP_RETRY_TIME_MAX) {
+        *retry_period = ACVP_RETRY_TIME_MAX;
+    }
+
+    *waited_so_far += *retry_period;
 
     return ACVP_KAT_DOWNLOAD_RETRY;
 }
@@ -2007,8 +2035,7 @@ static ACVP_RESULT acvp_process_vsid(ACVP_CTX *ctx, char *vsid_url, int count) {
     ACVP_STRING_LIST *vs_entry = NULL;
     unsigned int retry_period = 0;
     int retry = 1;
-
-    //TODO: do we want to limit the number of retries?
+    unsigned int time_waited_so_far = 0;
     while (retry) {
         /*
          * Get the KAT vector set
@@ -2032,7 +2059,11 @@ static ACVP_RESULT acvp_process_vsid(ACVP_CTX *ctx, char *vsid_url, int count) {
             /*
              * Wait and try again to retrieve the VectorSet
              */
-            acvp_retry_handler(ctx, retry_period);
+            if (acvp_retry_handler(ctx, (unsigned int *)&retry_period, (unsigned int *)&time_waited_so_far, 1) != ACVP_KAT_DOWNLOAD_RETRY) {
+                ACVP_LOG_STATUS("Maximum wait time with server reached! (Max: %d seconds)", ACVP_MAX_WAIT_TIME);
+                rv = ACVP_TRANSPORT_FAIL;
+                goto end;
+            };
             retry = 1;
         } else {
 
@@ -2182,8 +2213,8 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
     JSON_Object *current = NULL;
     const char *status = NULL;
 
-    int time_waited_so_far = 0;
-    int retry_interval = ACVP_RETRY_TIME;
+    unsigned int time_waited_so_far = 0;
+    unsigned int retry_interval = ACVP_RETRY_TIME;
 
     while (1) {
         /*
@@ -2209,20 +2240,14 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
             /*
              * Retry
              */
-            if(time_waited_so_far + retry_interval > ACVP_MAX_WAIT_TIME) {
-                retry_interval = ACVP_MAX_WAIT_TIME - time_waited_so_far;
-            }
             ACVP_LOG_STATUS("TestSession results incomplete...");
-            acvp_retry_handler(ctx, retry_interval);
-            time_waited_so_far += retry_interval;
-            if ((retry_interval *= 2) > ACVP_RETRY_TIME_MAX) {
-                retry_interval = ACVP_RETRY_TIME_MAX;
-            }
-            if(time_waited_so_far >= ACVP_MAX_WAIT_TIME) {
+            if (acvp_retry_handler(ctx, (unsigned int *)&retry_interval, (unsigned int *)&time_waited_so_far, 2)
+                    != ACVP_KAT_DOWNLOAD_RETRY) {
                 ACVP_LOG_STATUS("Maximum wait time with server reached! (Max: %d seconds)", ACVP_MAX_WAIT_TIME);
                 rv = ACVP_TRANSPORT_FAIL;
                 goto end;
             }
+
             if (val) json_value_free(val);
             continue;
         } else if (passed == 1) {

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1911,7 +1911,7 @@ ACVP_RESULT acvp_process_tests(ACVP_CTX *ctx) {
 /*
  * This is a retry handler, which pauses for a specific time.
  * This allows the server time to generate the vectors on behalf of
- * the client and to process the vector responses. This caller of this function
+ * the client and to process the vector responses. The caller of this function
  * can choose to implement a retry backoff using 'modifier'. Additionally, this
  * function will ensure that retry periods will sum to no longer than ACVP_MAX_WAIT_TIME.
  */
@@ -1922,7 +1922,7 @@ static ACVP_RESULT acvp_retry_handler(ACVP_CTX *ctx, unsigned int *retry_period,
         return ACVP_TRANSPORT_FAIL;
     }
     
-    if(*waited_so_far + *retry_period > ACVP_MAX_WAIT_TIME) {
+    if (*waited_so_far + *retry_period > ACVP_MAX_WAIT_TIME) {
         *retry_period = ACVP_MAX_WAIT_TIME - *waited_so_far;
     }
     if (*retry_period <= 0 || *retry_period > ACVP_RETRY_TIME_MAX) {
@@ -1939,11 +1939,11 @@ static ACVP_RESULT acvp_retry_handler(ACVP_CTX *ctx, unsigned int *retry_period,
     #endif
 
     /* ensure that all parameters are valid and that we do not wait longer than ACVP_MAX_WAIT_TIME */
-    if(modifier < 1 || modifier > ACVP_RETRY_MODIFIER_MAX) {
+    if (modifier < 1 || modifier > ACVP_RETRY_MODIFIER_MAX) {
         ACVP_LOG_WARN("retry modifier not valid, defaulting to 1 (no change)");
         modifier = 1;
     }
-    if((*retry_period *= modifier) > ACVP_RETRY_TIME_MAX) {
+    if ((*retry_period *= modifier) > ACVP_RETRY_TIME_MAX) {
         *retry_period = ACVP_RETRY_TIME_MAX;
     }
 
@@ -2059,7 +2059,8 @@ static ACVP_RESULT acvp_process_vsid(ACVP_CTX *ctx, char *vsid_url, int count) {
             /*
              * Wait and try again to retrieve the VectorSet
              */
-            if (acvp_retry_handler(ctx, (unsigned int *)&retry_period, (unsigned int *)&time_waited_so_far, 1) != ACVP_KAT_DOWNLOAD_RETRY) {
+            if (acvp_retry_handler(ctx, (unsigned int *)&retry_period, (unsigned int *)&time_waited_so_far, 1)
+                    != ACVP_KAT_DOWNLOAD_RETRY) {
                 ACVP_LOG_STATUS("Maximum wait time with server reached! (Max: %d seconds)", ACVP_MAX_WAIT_TIME);
                 rv = ACVP_TRANSPORT_FAIL;
                 goto end;


### PR DESCRIPTION
- All instances of waiting for server to create or process vector sets now have a maximum wait time (1 hour for now)
- There is now a retry backoff for waiting for the server to complete processing at vector sets (starts at 30 seconds, doubles until it reaches max of 5 minutes, easy to change as needed)
- Tested w/ NIST server by using arbitrarily low retry and max wait times
- Note: There is no retry backoff for waiting on the server to CREATE vector sets currently, as that retry time is provided by the server as per the spec
- Note: Fixed bug where error return values from acvp_process_vsid would not be handled properly if acvp_json_serialize_to_file_pretty_a (called afterwards) had no errors
- Note: todo: create sample app solution for reconnecting and retrieving vector set results at a later time
