### PR TITLE
New CL argument for acvp_app: --get_results <file>

### DIFF
--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -34,6 +34,7 @@ typedef struct app_config {
     int vector_rsp;
     int vector_upload;
     int get;
+    int get_results;
     int post;
     int put;
     int kat;
@@ -44,6 +45,7 @@ typedef struct app_config {
     char vector_rsp_file[JSON_FILENAME_LENGTH + 1];
     char vector_upload_file[JSON_FILENAME_LENGTH + 1];
     char get_string[JSON_REQUEST_LENGTH + 1];
+    char get_results_file[JSON_FILENAME_LENGTH + 1];
     char post_filename[JSON_FILENAME_LENGTH + 1];
     char put_filename[JSON_FILENAME_LENGTH + 1];
     char kat_file[JSON_FILENAME_LENGTH + 1];

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -340,6 +340,12 @@ int main(int argc, char **argv) {
     if (!cfg.empty_alg && cfg.put) {
         acvp_mark_as_put_after_test(ctx, cfg.put_filename);
     }
+
+    if (cfg.get_results) {
+        rv = acvp_get_results_from_server(ctx, cfg.get_results_file);
+        goto end;
+    }
+    
     /*
      * Run the test session.
      * Perform a FIPS validation on this test session if specified.

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -2638,6 +2638,7 @@ ACVP_RESULT acvp_load_kat_filename(ACVP_CTX *ctx, const char *kat_filename);
 ACVP_RESULT acvp_upload_vectors_from_file(ACVP_CTX *ctx, const char *rsp_filename, int fips_validation);
 ACVP_RESULT acvp_run_vectors_from_file(ACVP_CTX *ctx, const char *req_filename, const char *rsp_filename);
 ACVP_RESULT acvp_put_data_from_file(ACVP_CTX *ctx, const char *put_filename);
+ACVP_RESULT acvp_get_results_from_server(ACVP_CTX *ctx, const char *request_filename);
 
 /*! @brief acvp_set_2fa_callback() sets a callback function which
     will create or obtain a TOTP password for the second part of

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1174,7 +1174,7 @@ ACVP_RESULT acvp_get_results_from_server(ACVP_CTX *ctx, const char *request_file
     }
     
     if (strnlen_s(request_filename, ACVP_JSON_FILENAME_MAX + 1) > ACVP_JSON_FILENAME_MAX) {
-        ACVP_LOG_ERR("Provided rsp_filename length > max(%d)", ACVP_JSON_FILENAME_MAX);
+        ACVP_LOG_ERR("Provided request_filename length > max(%d)", ACVP_JSON_FILENAME_MAX);
         return ACVP_INVALID_ARG;
     }
     
@@ -1216,7 +1216,9 @@ ACVP_RESULT acvp_get_results_from_server(ACVP_CTX *ctx, const char *request_file
         goto end;
     }
     strcpy_s(ctx->jwt_token, ACVP_JWT_TOKEN_MAX + 1, jwt);
+
     rv = acvp_check_test_results(ctx);
+    
     if (rv != ACVP_SUCCESS) {
         ACVP_LOG_ERR("Unable to retrieve test results");
     }

--- a/test/json/getResults.json
+++ b/test/json/getResults.json
@@ -1,0 +1,1 @@
+invalid json

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -782,6 +782,6 @@ Test(PROCESS_TESTS, acvp_get_results_from_server, .init = setup_full_ctx, .fini 
     rv = acvp_get_results_from_server(ctx, "testFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLong");
     cr_assert(rv == ACVP_INVALID_ARG);
 
-    rv = acvp_get_results_from_server(ctx, "noFileHere.json");
+    rv = acvp_get_results_from_server(ctx, "json/getResults.json");
     cr_assert(rv = ACVP_MALFORMED_JSON);
 }

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -768,3 +768,20 @@ Test(PROCESS_TESTS, mark_as_put_after_test, .init = setup_full_ctx, .fini = tear
     cr_assert(rv == ACVP_SUCCESS);
 }
 
+/*
+ * Test acvp_get_results_from_server
+ */
+Test(PROCESS_TESTS, acvp_get_results_from_server, .init = setup_full_ctx, .fini = teardown) {
+   
+    rv = acvp_get_results_from_server(NULL, "test");
+    cr_assert(rv == ACVP_NO_CTX);
+
+    rv = acvp_get_results_from_server(ctx, NULL);
+    cr_assert(rv == ACVP_MISSING_ARG);
+
+    rv = acvp_get_results_from_server(ctx, "testFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLong");
+    cr_assert(rv == ACVP_INVALID_ARG);
+
+    rv = acvp_get_results_from_server(ctx, "noFileHere.json");
+    cr_assert(rv = ACVP_MALFORMED_JSON);
+}


### PR DESCRIPTION
- acvp_app now has an argument for --get_results <file>, where file is a json file containing the session URL and JWT.
- New API function acvp_get_results_from_server which takes a CTX and filename as parameters
- This can be used to retrieve results from previous sessions, including ones where the client timed out or lost connection while waiting for the server to finish processing
- Created tests
- Tested with 1.1.1; closed the process while server was returning "incomplete" messages and requesting retries, and successfully reconnected and obtained results
- Made vector_upload argument no longer require an argument for an algorithm suite (unused)
