### PR TITLE
Repair app code so it uses FOM directly

### DIFF
--- a/app/app_aes.c
+++ b/app/app_aes.c
@@ -12,6 +12,9 @@
 #include "acvp/acvp.h"
 #include "app_lcl.h"
 #include "safe_lib.h"
+#ifdef ACVP_NO_RUNTIME
+# include "app_fips_lcl.h"
+#endif
 
 static EVP_CIPHER_CTX *glb_cipher_ctx = NULL; /* need to maintain across calls for MCT */
 
@@ -24,7 +27,6 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
     ACVP_SYM_CIPHER_TC      *tc;
     EVP_CIPHER_CTX *cipher_ctx;
     const EVP_CIPHER        *cipher;
-    int ct_len, pt_len;
     unsigned char *iv = 0;
     /* assume fail at first */
     int rv = 1;
@@ -211,24 +213,24 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
     if (tc->test_type == ACVP_SYM_TEST_TYPE_MCT) {
         if (tc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
             if (tc->mct_index == 0) {
-                EVP_EncryptInit_ex(cipher_ctx, cipher, NULL, tc->key, iv);
+                EVP_CipherInit_ex(cipher_ctx, cipher, NULL, tc->key, iv, 1);
                 EVP_CIPHER_CTX_set_padding(cipher_ctx, 0);
                 if (tc->cipher == ACVP_AES_CFB1) {
                     EVP_CIPHER_CTX_set_flags(cipher_ctx, EVP_CIPH_FLAG_LENGTH_BITS);
                 }
             }
-            EVP_EncryptUpdate(cipher_ctx, tc->ct, &ct_len, tc->pt, tc->pt_len);
-            tc->ct_len = ct_len;
+            EVP_Cipher(cipher_ctx, tc->ct, tc->pt, tc->pt_len);
+            tc->ct_len = tc->pt_len;
         } else if (tc->direction == ACVP_SYM_CIPH_DIR_DECRYPT) {
             if (tc->mct_index == 0) {
-                EVP_DecryptInit_ex(cipher_ctx, cipher, NULL, tc->key, iv);
+                EVP_CipherInit_ex(cipher_ctx, cipher, NULL, tc->key, iv, 0);
                 EVP_CIPHER_CTX_set_padding(cipher_ctx, 0);
                 if (tc->cipher == ACVP_AES_CFB1) {
                     EVP_CIPHER_CTX_set_flags(cipher_ctx, EVP_CIPH_FLAG_LENGTH_BITS);
                 }
             }
-            EVP_DecryptUpdate(cipher_ctx, tc->pt, &pt_len, tc->ct, tc->ct_len);
-            tc->pt_len = pt_len;
+            EVP_Cipher(cipher_ctx, tc->pt, tc->ct, tc->ct_len);
+            tc->pt_len = tc->ct_len;
         } else {
             printf("Unsupported direction\n");
             return rv;
@@ -238,25 +240,21 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
         }
     } else {
         if (tc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
-            EVP_EncryptInit_ex(cipher_ctx, cipher, NULL, tc->key, iv);
+            EVP_CipherInit_ex(cipher_ctx, cipher, NULL, tc->key, iv, 1);
             EVP_CIPHER_CTX_set_padding(cipher_ctx, 0);
             if (tc->cipher == ACVP_AES_CFB1) {
                 EVP_CIPHER_CTX_set_flags(cipher_ctx, EVP_CIPH_FLAG_LENGTH_BITS);
             }
-            EVP_EncryptUpdate(cipher_ctx, tc->ct, &ct_len, tc->pt, tc->pt_len);
-            tc->ct_len = ct_len;
-            EVP_EncryptFinal_ex(cipher_ctx, tc->ct + ct_len, &ct_len);
-            tc->ct_len += ct_len;
+            EVP_Cipher(cipher_ctx, tc->ct, tc->pt, tc->pt_len);
+            tc->ct_len = tc->pt_len;
         } else if (tc->direction == ACVP_SYM_CIPH_DIR_DECRYPT) {
-            EVP_DecryptInit_ex(cipher_ctx, cipher, NULL, tc->key, iv);
+            EVP_CipherInit_ex(cipher_ctx, cipher, NULL, tc->key, iv, 0);
             EVP_CIPHER_CTX_set_padding(cipher_ctx, 0);
             if (tc->cipher == ACVP_AES_CFB1) {
                 EVP_CIPHER_CTX_set_flags(cipher_ctx, EVP_CIPH_FLAG_LENGTH_BITS);
             }
-            EVP_DecryptUpdate(cipher_ctx, tc->pt, &pt_len, tc->ct, tc->ct_len);
-            tc->pt_len = pt_len;
-            EVP_DecryptFinal_ex(cipher_ctx, tc->pt + pt_len, &pt_len);
-            tc->pt_len += pt_len;
+            EVP_Cipher(cipher_ctx, tc->pt, tc->ct, tc->ct_len);
+            tc->pt_len = tc->ct_len;
         } else {
             printf("Unsupported direction\n");
             return rv;

--- a/app/app_cmac.c
+++ b/app/app_cmac.c
@@ -14,6 +14,10 @@
 #include "app_lcl.h"
 #include "safe_lib.h"
 
+#ifdef ACVP_NO_RUNTIME
+# include "app_fips_lcl.h"
+#endif
+
 int app_cmac_handler(ACVP_TEST_CASE *test_case) {
     ACVP_CMAC_TC    *tc;
     int rv = 1;

--- a/app/app_fips_lcl.h
+++ b/app/app_fips_lcl.h
@@ -121,6 +121,10 @@ int dsa_builtin_paramgen2(DSA *ret, size_t L, size_t N,
  * These are here so that the app knows about
  * the FOM specific API's being used
  */
+#define M_EVP_CIPHER_CTX_set_flags(ctx,flgs) ((ctx)->flags|=(flgs))
+
+#define EVP_CIPHER_CTX_set_padding(ctx, pad) {}
+
 EVP_CIPHER_CTX *FIPS_cipher_ctx_new(void);
 void FIPS_cipher_ctx_init(EVP_CIPHER_CTX *ctx);
 void FIPS_cipher_ctx_free(EVP_CIPHER_CTX *a);

--- a/app/app_hmac.c
+++ b/app/app_hmac.c
@@ -12,6 +12,9 @@
 #include <openssl/hmac.h>
 #include "acvp/acvp.h"
 #include "app_lcl.h"
+#ifdef ACVP_NO_RUNTIME
+# include "app_fips_lcl.h"
+#endif
 
 int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     ACVP_HMAC_TC    *tc;

--- a/app/app_kas.c
+++ b/app/app_kas.c
@@ -16,6 +16,9 @@
 #include "app_fips_lcl.h" /* All regular OpenSSL headers must come before here */
 #include "app_lcl.h"
 #include "safe_mem_lib.h"
+#ifdef ACVP_NO_RUNTIME
+# include "app_fips_lcl.h"
+#endif
 
 static EC_POINT *make_peer(EC_GROUP *group, BIGNUM *x, BIGNUM *y) {
     EC_POINT *peer = NULL;

--- a/app/app_kdf.c
+++ b/app/app_kdf.c
@@ -14,6 +14,9 @@
 #include <openssl/bn.h>
 #include <openssl/kdf.h>
 #include "app_lcl.h"
+#ifdef ACVP_NO_RUNTIME
+# include "app_fips_lcl.h"
+#endif
 
 #define TLS_MD_MASTER_SECRET_CONST              "master secret"
 #define TLS_MD_MASTER_SECRET_CONST_SIZE         13

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -996,6 +996,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
+#ifndef ACVP_NO_RUNTIME  /* Waiting for FOM support */
     /* SHA3 and SHAKE */
     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1054,6 +1055,7 @@ static int enable_hash(ACVP_CTX *ctx) {
 #endif
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHAKE_256, ACVP_HASH_OUT_LENGTH, 16, 1024, 8);
     CHECK_ENABLE_CAP_RV(rv);
+#endif
 #endif
 
 end:
@@ -2198,12 +2200,6 @@ static int enable_drbg(ACVP_CTX *ctx) {
      * Register DRBG
      */
     ERR_load_crypto_strings();
-
-    int fips_rc = FIPS_mode_set(1);
-    if (!fips_rc) {
-        (printf("Failed to enable FIPS mode.\n"));
-        return 1;
-    }
 
     //ACVP_HASHDRBG
     rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &app_drbg_handler);

--- a/app/app_sha.c
+++ b/app/app_sha.c
@@ -12,6 +12,9 @@
 
 #include "acvp/acvp.h"
 #include "app_lcl.h"
+#ifdef ACVP_NO_RUNTIME
+# include "app_fips_lcl.h"
+#endif
 
 int app_sha_handler(ACVP_TEST_CASE *test_case) {
     ACVP_HASH_TC    *tc;


### PR DESCRIPTION
Somewhere during the restructuring of the app code we stopped using fipssyms.h to map calls directly to the FOM. AES and TDES required changes to the functions they used, but others just needed to include the header files to remap.  Also don't seem to need FIPS_mode_set(1) for drbg, works without it.