### PR TITLE
minor cleanup found during cross compiles

### DIFF
--- a/app/app_cmac.c
+++ b/app/app_cmac.c
@@ -26,7 +26,7 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
     int key_len, i;
     unsigned char mac_compare[16] = { 0 };
     char full_key[32] = { 0 };
-    int mac_cmp_len;
+    size_t mac_cmp_len;
 
     if (!test_case) {
         return rv;
@@ -172,7 +172,7 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
     if (tc->verify) {
         int diff = 0;
 
-        if (!CMAC_Final(cmac_ctx, mac_compare, (size_t *)&mac_cmp_len)) {
+        if (!CMAC_Final(cmac_ctx, mac_compare, &mac_cmp_len)) {
             printf("\nCrypto module error, CMAC_Final failed\n");
             goto cleanup;
         }
@@ -184,10 +184,11 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
             tc->ver_disposition = ACVP_TEST_DISPOSITION_FAIL;
         }
     } else {
-        if (!CMAC_Final(cmac_ctx, tc->mac, (size_t *)&tc->mac_len)) {
+        if (!CMAC_Final(cmac_ctx, tc->mac, &mac_cmp_len)) {
             printf("\nCrypto module error, CMAC_Final failed\n");
             goto cleanup;
         }
+        tc->mac_len = (int)mac_cmp_len;
     }
     rv = 0;
 

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -391,8 +391,6 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_TAGLEN, 96);
-    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_TAGLEN, 128);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_IVLEN, 96);
@@ -740,8 +738,6 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_KEYLEN, 192);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_KEYLEN, 256);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_TAGLEN, 96);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_TAGLEN, 128);
     CHECK_ENABLE_CAP_RV(rv);

--- a/scripts/nist_setup.bat
+++ b/scripts/nist_setup.bat
@@ -1,7 +1,7 @@
 set ACV_URI_PREFIX=/acvp/v1/
 set ACV_API_CONTEXT=acvp/
 set ACV_CA_FILE=certs/acvp.nist.gov.crt
-set ACV_KEY_FILE=<procure from nist>
+set ACV_KEY_FILE=<user generated>
 set ACV_CERT_FILE=<procure from nist>
 set ACV_TOTP_SEED=<procure from nist>
 set ACV_PORT=443

--- a/scripts/nist_setup.sh
+++ b/scripts/nist_setup.sh
@@ -2,7 +2,7 @@
 export ACV_URI_PREFIX=/acvp/v1/
 export ACV_API_CONTEXT=acvp/
 export ACV_CA_FILE=certs/acvp.nist.gov.crt
-export ACV_KEY_FILE=<procure from nist>
+export ACV_KEY_FILE=<user generated>
 export ACV_CERT_FILE=<procure from nist>
 export ACV_TOTP_SEED=<procure from nist>
 export ACV_PORT=443

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -1371,7 +1371,7 @@ static void log_network_status(ACVP_CTX *ctx,
         }
         break;
     case ACVP_NET_GET_VS_RESULT:
-        if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        if (ctx->debug >= ACVP_LOG_LVL_STATUS) {
             printf("GET Vector Set Result...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                    curl_code, url, ctx->curl_buf);
         } else {


### PR DESCRIPTION
1. CMAC: Can't pass size_t back from FOM into an int.
2. GCM: Not all FOM implementatoins support 96 bit tag len
3. Scripts: point out the user generates the key, not NIST
4. VS Results should be fully printed at a STATUS level or higher.