### PR TITLE
Sha3 hmac registration, Removed many tab characters, adjusted AES-GCM-SIV, small other changes

### DIFF
--- a/app/app_fips_init_lcl.h
+++ b/app/app_fips_init_lcl.h
@@ -55,49 +55,49 @@ void FINGERPRINT_premain(void) {}
 
 static int no_err;
 static void put_err_cb(int lib, int func,int reason,const char *file,int line)
-	{
-	if (no_err)
-		return;
+    {
+    if (no_err)
+        return;
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-	fprintf(stderr, "ERROR:%08lX:lib=%d,func=%d,reason=%d"
-				":file=%s:line=%d\n",
-			ERR_PACK(lib, func, reason),
-			lib, func, reason, file, line);
+    fprintf(stderr, "ERROR:%08lX:lib=%d,func=%d,reason=%d"
+                ":file=%s:line=%d\n",
+            ERR_PACK(lib, func, reason),
+            lib, func, reason, file, line);
 #else
     fprintf(stderr, "ERROR:%08X:lib=%d,func=%d,reason=%d"
-				":file=%s:line=%d\n",
-			ERR_PACK(lib, func, reason),
-			lib, func, reason, file, line);
+                ":file=%s:line=%d\n",
+            ERR_PACK(lib, func, reason),
+            lib, func, reason, file, line);
 #endif
-	}
+    }
 
 static void add_err_cb(int num, va_list args)
-	{
-	int i;
-	char *str;
-	if (no_err)
-		return;
-	fputs("\t", stderr);
-	for (i = 0; i < num; i++)
-		{
-		str = va_arg(args, char *);
-		if (str)
-			fputs(str, stderr);
-		}
-	fputs("\n", stderr);
-	}
+    {
+    int i;
+    char *str;
+    if (no_err)
+        return;
+    fputs("\t", stderr);
+    for (i = 0; i < num; i++)
+        {
+        str = va_arg(args, char *);
+        if (str)
+            fputs(str, stderr);
+        }
+    fputs("\n", stderr);
+    }
 
 static unsigned char dummy_entropy[1024];
 
 static size_t dummy_cb(DRBG_CTX *ctx, unsigned char **pout,
                                 int entropy, size_t min_len, size_t max_len)
-	{
+    {
         if (!ctx || !entropy || !max_len) {
             return min_len;
         }
-	*pout = dummy_entropy;
-	return min_len;
-	}
+    *pout = dummy_entropy;
+    return min_len;
+    }
 
 static int entropy_stick = 0;
 
@@ -114,40 +114,40 @@ void FIPS_set_locking_callbacks(CRYPTO_RWLOCK *(*FIPS_thread_lock_new)(void),
 /* Dummy lock CBs*/
 static int dummy_alg_testing_lock = 5;
 static CRYPTO_RWLOCK* fips_test_suite_dummy_new_lock(void) {
-	return (CRYPTO_RWLOCK*) &dummy_alg_testing_lock;
+    return (CRYPTO_RWLOCK*) &dummy_alg_testing_lock;
 }
 static void fips_test_suite_dummy_free_lock(CRYPTO_RWLOCK* lock){
-	// do nothing
-	(void)lock;
+    // do nothing
+    (void)lock;
 }
 #endif
 #ifdef ACVP_NO_RUNTIME
 static void fips_algtest_init_nofips(void)
-	{
-	DRBG_CTX *ctx;
-	size_t i;
-	FIPS_set_error_callbacks(put_err_cb, add_err_cb);
-	for (i = 0; i < sizeof(dummy_entropy); i++)
-		dummy_entropy[i] = i & 0xff;
-	if (entropy_stick)
-		memcpy_s(dummy_entropy + 32, (sizeof(dummy_entropy) - 32), dummy_entropy + 16, 16);
-	ctx = FIPS_get_default_drbg();
-	FIPS_drbg_init(ctx, NID_aes_256_ctr, DRBG_FLAG_CTR_USE_DF);
-	FIPS_drbg_set_callbacks(ctx, dummy_cb, 0, 16, dummy_cb, 0);
-	FIPS_drbg_instantiate(ctx, dummy_entropy, 10);
-	FIPS_rand_set_method(FIPS_drbg_method());
+    {
+    DRBG_CTX *ctx;
+    size_t i;
+    FIPS_set_error_callbacks(put_err_cb, add_err_cb);
+    for (i = 0; i < sizeof(dummy_entropy); i++)
+        dummy_entropy[i] = i & 0xff;
+    if (entropy_stick)
+        memcpy_s(dummy_entropy + 32, (sizeof(dummy_entropy) - 32), dummy_entropy + 16, 16);
+    ctx = FIPS_get_default_drbg();
+    FIPS_drbg_init(ctx, NID_aes_256_ctr, DRBG_FLAG_CTR_USE_DF);
+    FIPS_drbg_set_callbacks(ctx, dummy_cb, 0, 16, dummy_cb, 0);
+    FIPS_drbg_instantiate(ctx, dummy_entropy, 10);
+    FIPS_rand_set_method(FIPS_drbg_method());
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-        FIPS_set_locking_callbacks(&fips_test_suite_dummy_new_lock,
-                                   NULL,
-                                   NULL,
-                                   NULL,
-                                   &fips_test_suite_dummy_free_lock,
-                                   NULL,
-                                   NULL,
-                                   NULL);
+    FIPS_set_locking_callbacks(&fips_test_suite_dummy_new_lock,
+                               NULL,
+                               NULL,
+                               NULL,
+                               &fips_test_suite_dummy_free_lock,
+                               NULL,
+                               NULL,
+                               NULL);
 #endif
 
-	}
+    }
 #endif
 #ifdef __cplusplus
 }

--- a/app/app_fips_lcl.h
+++ b/app/app_fips_lcl.h
@@ -151,7 +151,7 @@ void FIPS_bn_free(BIGNUM *a);
 int fips_BN_hex2bn(BIGNUM **bn, const char *a);
 char *fips_BN_bn2hex(const BIGNUM *a);
 BIGNUM *FIPS_bn_bin2bn(const unsigned char *s,int len,BIGNUM *ret);
-int	FIPS_bn_bn2bin(const BIGNUM *a, unsigned char *to);
+int FIPS_bn_bn2bin(const BIGNUM *a, unsigned char *to);
 int fips_bn_set_word(BIGNUM *a, BN_ULONG w);
 int rsa_generate_key_internal(BIGNUM **p, BIGNUM **q, BIGNUM **n, BIGNUM **d,
                               void *seed, unsigned int seed_len,
@@ -164,12 +164,12 @@ int fips_RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
 void fips_RSA_get0_key(const RSA *r,
                   const BIGNUM **n, const BIGNUM **e, const BIGNUM **d);
 
-DSA *	FIPS_dsa_new(void);
-void	FIPS_dsa_free (DSA *r);
+DSA * FIPS_dsa_new(void);
+void FIPS_dsa_free(DSA *r);
 int FIPS_dsa_verify(DSA *dsa, const unsigned char *msg, size_t msglen,
-			const EVP_MD *mhash, DSA_SIG *s);
+            const EVP_MD *mhash, DSA_SIG *s);
 DSA_SIG * FIPS_dsa_sign(DSA *dsa, const unsigned char *msg, size_t msglen,
-			const EVP_MD *mhash);
+            const EVP_MD *mhash);
 void fips_DSA_get0_key(const DSA *d,
                        const BIGNUM **pub_key, const BIGNUM **priv_key);
 void FIPS_dsa_sig_get0(const DSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
@@ -178,7 +178,7 @@ DSA_SIG *FIPS_dsa_sig_new(void);
 void FIPS_dsa_sig_free(DSA_SIG *sig);
 BIGNUM *fips_bn_ctx_get(BN_CTX *ctx);
 void FIPS_bn_clear_free(BIGNUM *a);
-int	fips_bn_cmp(const BIGNUM *a, const BIGNUM *b);
+int fips_bn_cmp(const BIGNUM *a, const BIGNUM *b);
 BIGNUM *fips_bn_dup(const BIGNUM *a);
 int FIPS_bn_num_bits(const BIGNUM *a);
 EC_POINT *FIPS_ec_point_new(const EC_GROUP *group);
@@ -229,12 +229,12 @@ ECDSA_SIG * FIPS_ecdsa_sign(EC_KEY *key,
                             const unsigned char *msg, size_t msglen,
                             const EVP_MD *mhash);
 int FIPS_ecdsa_verify(EC_KEY *key, const unsigned char *msg, size_t msglen,
-			          const EVP_MD *mhash, ECDSA_SIG *s);
+                      const EVP_MD *mhash, ECDSA_SIG *s);
 ECDSA_SIG * FIPS_ecdsa_sign_md(EC_KEY *key,
                                const unsigned char *msg, size_t msglen,
                                const EVP_MD *mhash);
 int FIPS_ecdsa_verify_md(EC_KEY *key, const unsigned char *msg, size_t msglen,
-			 const EVP_MD *mhash, ECDSA_SIG *s);
+             const EVP_MD *mhash, ECDSA_SIG *s);
 int FIPS_ecdh_compute_key(void *out, size_t outlen, const EC_POINT *pub_key,
                           EC_KEY *ecdh, void *(*KDF) (const void *in, size_t inlen,
                                                       void *out, size_t *outlen));

--- a/app/app_hmac.c
+++ b/app/app_hmac.c
@@ -57,6 +57,25 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_HMAC_SHA2_512_256:
         md = EVP_sha512_256();
         break;
+    case ACVP_HMAC_SHA3_224:
+        md = EVP_sha3_224();
+        break;
+    case ACVP_HMAC_SHA3_256:
+        md = EVP_sha3_256();
+        break;
+    case ACVP_HMAC_SHA3_384:
+        md = EVP_sha3_384();
+        break;
+    case ACVP_HMAC_SHA3_512:
+        md = EVP_sha3_512();
+        break;
+#else
+    case ACVP_HMAC_SHA2_512_224:
+    case ACVP_HMAC_SHA2_512_256:
+    case ACVP_HMAC_SHA3_224:
+    case ACVP_HMAC_SHA3_256:
+    case ACVP_HMAC_SHA3_384:
+    case ACVP_HMAC_SHA3_512:
 #endif
     case ACVP_CIPHER_START:
     case ACVP_AES_GCM:
@@ -102,10 +121,6 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_HASHDRBG:
     case ACVP_HMACDRBG:
     case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
     case ACVP_CMAC_AES:
     case ACVP_CMAC_TDES:
     case ACVP_DSA_KEYGEN:
@@ -134,10 +149,6 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_KAS_FFC_COMP:
     case ACVP_KAS_FFC_NOCOMP:
     case ACVP_CIPHER_END:
-#if OPENSSL_VERSION_NUMBER< 0x10101010L /* Less than OpenSSL 1.1.1 */
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-#endif
     default:
         printf("Error: Unsupported hash algorithm requested by ACVP server\n");
         return rc;

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -978,8 +978,8 @@ static int enable_hash(ACVP_CTX *ctx) {
 
 #if OPENSSL_VERSION_NUMBER >= 0x10101010L /* OpenSSL 1.1.1 or greater */
 
-/* SHA2-512/224 and SHA2-512/256 */
 #ifndef ACVP_NO_RUNTIME //currently no FIPS support
+    /* SHA2-512/224 and SHA2-512/256 */
     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_224, ACVP_HASH_MESSAGE_LEN,
@@ -991,9 +991,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_256, ACVP_HASH_MESSAGE_LEN,
                                   0, 65528, 8);
     CHECK_ENABLE_CAP_RV(rv);
-#endif
 
-#ifndef ACVP_NO_RUNTIME  /* Waiting for FOM support */
     /* SHA3 and SHAKE */
     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1056,7 +1054,6 @@ static int enable_hash(ACVP_CTX *ctx) {
 #endif
 
 end:
-
     return rv;
 }
 
@@ -1171,6 +1168,42 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_256, ACVP_HMAC_MACLEN, 32, 256, 8);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_256, ACVP_PREREQ_SHA, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    
+    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_224, ACVP_HMAC_KEYLEN, 256, 448, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_224, ACVP_HMAC_MACLEN, 32, 224, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_224, ACVP_PREREQ_SHA, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    
+    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_256, ACVP_HMAC_KEYLEN, 256, 448, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_256, ACVP_HMAC_MACLEN, 32, 256, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_256, ACVP_PREREQ_SHA, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    
+    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_384, ACVP_HMAC_KEYLEN, 256, 448, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_384, ACVP_HMAC_MACLEN, 32, 384, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_384, ACVP_PREREQ_SHA, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    
+    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_512, ACVP_HMAC_KEYLEN, 256, 448, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_512, ACVP_HMAC_MACLEN, 32, 512, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_512, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
     #endif
     #endif

--- a/app/app_sha.c
+++ b/app/app_sha.c
@@ -78,6 +78,15 @@ int app_sha_handler(ACVP_TEST_CASE *test_case) {
         md = EVP_shake256();
         shake = 1;
         break;
+#else
+    case ACVP_HASH_SHA512_224:
+    case ACVP_HASH_SHA512_256:
+    case ACVP_HASH_SHA3_224:
+    case ACVP_HASH_SHA3_256:
+    case ACVP_HASH_SHA3_384:
+    case ACVP_HASH_SHA3_512:
+    case ACVP_HASH_SHAKE_128:
+    case ACVP_HASH_SHAKE_256:
 #endif
     case ACVP_CIPHER_START:
     case ACVP_AES_GCM:
@@ -149,16 +158,6 @@ int app_sha_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_KAS_FFC_COMP:
     case ACVP_KAS_FFC_NOCOMP:
     case ACVP_CIPHER_END:
-#if OPENSSL_VERSION_NUMBER < 0x10101010L /* Less than OpenSSL 1.1.1 */
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-#endif
     default:
         printf("Error: Unsupported hash algorithm requested by ACVP server\n");
         return ACVP_NO_CAP;

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2094,11 +2094,11 @@ ACVP_RESULT acvp_refresh(ACVP_CTX *ctx) {
  * list of vs_id's that need to be processed during the test
  * session.  This routine will execute the test flow for a single
  * vs_id.  The flow is:
- *	a) Download the KAT vector set from the server using the vs_id
- *	b) Parse the KAT vectors
- *	c) Process each test case in the KAT vector set
- *	d) Generate the response data
- *	e) Send the response data back to the ACVP server
+ *    a) Download the KAT vector set from the server using the vs_id
+ *    b) Parse the KAT vectors
+ *    c) Process each test case in the KAT vector set
+ *    d) Generate the response data
+ *    e) Send the response data back to the ACVP server
  */
 static ACVP_RESULT acvp_process_vsid(ACVP_CTX *ctx, char *vsid_url, int count) {
     ACVP_RESULT rv = ACVP_SUCCESS;
@@ -2261,10 +2261,10 @@ static ACVP_RESULT acvp_dispatch_vector_set(ACVP_CTX *ctx, JSON_Object *obj) {
  * here to know which vectors need to be processed.
  *
  * The processing logic is:
- *	a) JSON parse the data
- *	b) Identify the ACVP operation to be performed (e.g. AES encrypt)
- *	c) Dispatch the vectors to the handler for the
- *	   specified ACVP operation.
+ *    a) JSON parse the data
+ *    b) Identify the ACVP operation to be performed (e.g. AES encrypt)
+ *    c) Dispatch the vectors to the handler for the
+ *       specified ACVP operation.
  */
 static ACVP_RESULT acvp_process_vector_set(ACVP_CTX *ctx, JSON_Object *obj) {
     ACVP_RESULT rv;

--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -817,17 +817,21 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             ivlen = 128;
         }
 
-        /* TODO: This value is supposed to be included in server JSON, but is not currently.
-         * Update when fixed on server end. */
-        if (alg_id == ACVP_AES_GCM_SIV) {
-            ivlen = ACVP_AES_GCM_SIV_IVLEN;
-        }
-        
-        if (alg_id == ACVP_AES_GCM || alg_id == ACVP_AES_CCM || alg_id == ACVP_AES_GMAC) {
+        if (alg_id == ACVP_AES_GCM || alg_id == ACVP_AES_CCM || alg_id == ACVP_AES_GMAC || alg_id == ACVP_AES_GCM_SIV) {
             ivlen = json_object_get_number(groupobj, "ivLen");
             if (!ivlen) {
+                if (alg_id == ACVP_AES_GCM_SIV) {
+                    //GCM-SIV has a static ivlen of 96, not required to be sent by server
+                    ivlen = ACVP_AES_GCM_SIV_IVLEN;
+                }
                 ACVP_LOG_ERR("Server JSON missing 'ivLen'");
                 rv = ACVP_MISSING_ARG;
+                goto err;
+            }
+            
+            if (alg_id == ACVP_AES_GCM_SIV && ivlen != ACVP_AES_GCM_SIV_IVLEN) {
+                ACVP_LOG_ERR("Server JSON invalid 'ivLen', (%u)", ivlen);
+                rv = ACVP_INVALID_ARG;
                 goto err;
             }
 
@@ -897,12 +901,20 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             }
 
             taglen = json_object_get_number(groupobj, "tagLen");
-            if (alg_id == ACVP_AES_GCM_SIV && taglen != ACVP_AES_GCM_SIV_TAGLEN) {
-                ACVP_LOG_ERR("Incorrect server JSON value 'taglen' for AES-GCM-SIV (%u)", taglen);
+            if (!taglen) {
+                if (alg_id == ACVP_AES_GCM_SIV) {
+                    //GCM-SIV has a static taglen of 128, not required to be sent by server
+                    ivlen = ACVP_AES_GCM_SIV_TAGLEN;
+                }
+                ACVP_LOG_ERR("Server JSON missing 'tagLen'");
+                rv = ACVP_MISSING_ARG;
+                goto err;
+            } else if (alg_id == ACVP_AES_GCM_SIV && taglen != ACVP_AES_GCM_SIV_TAGLEN) {
+                ACVP_LOG_ERR("Server JSON invalid 'tagLen', (%u)", taglen);
                 rv = ACVP_INVALID_ARG;
                 goto err;
             } else if (!(taglen >= ACVP_SYM_TAG_BIT_MIN && taglen <= ACVP_SYM_TAG_BIT_MAX)) {
-                ACVP_LOG_ERR("Server JSON invalid 'taglen', (%u)", taglen);
+                ACVP_LOG_ERR("Server JSON invalid 'tagLen', (%u)", taglen);
                 rv = ACVP_INVALID_ARG;
                 goto err;
             }
@@ -910,7 +922,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         ptlen = json_object_get_number(groupobj, "payloadLen");
         if (alg_id == ACVP_AES_GMAC && ptlen != 0) {
-            ACVP_LOG_ERR("'ptlen' not allowed for AES-GMAC");
+            ACVP_LOG_ERR("Server provided 'ptlen' not allowed for AES-GMAC");
             rv = ACVP_INVALID_ARG;
             goto err;
         }

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -2749,6 +2749,10 @@ ACVP_RESULT acvp_build_test_session(ACVP_CTX *ctx, char **reg, int *out_len) {
             case ACVP_HMAC_SHA2_512:
             case ACVP_HMAC_SHA2_512_224:
             case ACVP_HMAC_SHA2_512_256:
+            case ACVP_HMAC_SHA3_224:
+            case ACVP_HMAC_SHA3_256:
+            case ACVP_HMAC_SHA3_384:
+            case ACVP_HMAC_SHA3_512:
                 rv = acvp_build_hmac_register_cap(cap_obj, cap_entry);
                 break;
             case ACVP_CMAC_AES:
@@ -2828,10 +2832,6 @@ ACVP_RESULT acvp_build_test_session(ACVP_CTX *ctx, char **reg, int *out_len) {
            case ACVP_TDES_CFBP1:
            case ACVP_TDES_CFBP8:
            case ACVP_TDES_CFBP64:
-           case ACVP_HMAC_SHA3_224:
-           case ACVP_HMAC_SHA3_256:
-           case ACVP_HMAC_SHA3_384:
-           case ACVP_HMAC_SHA3_512:
            case ACVP_CIPHER_END:
             default:
                 ACVP_LOG_ERR("Cap entry not found, %d.", cap_entry->cipher);

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -1174,6 +1174,12 @@ static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG 
     case ACVP_HASH_SHA512:
     case ACVP_HASH_SHA512_224:
     case ACVP_HASH_SHA512_256:
+    case ACVP_HASH_SHA3_224:
+    case ACVP_HASH_SHA3_256:
+    case ACVP_HASH_SHA3_384:
+    case ACVP_HASH_SHA3_512:
+    case ACVP_HASH_SHAKE_128:
+    case ACVP_HASH_SHAKE_256:
         return ACVP_INVALID_ARG;
 
         break;
@@ -1201,6 +1207,10 @@ static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG 
     case ACVP_HMAC_SHA2_512:
     case ACVP_HMAC_SHA2_512_224:
     case ACVP_HMAC_SHA2_512_256:
+    case ACVP_HMAC_SHA3_224:
+    case ACVP_HMAC_SHA3_256:
+    case ACVP_HMAC_SHA3_384:
+    case ACVP_HMAC_SHA3_512:
         if (pre_req == ACVP_PREREQ_SHA) {
             return ACVP_SUCCESS;
         }
@@ -1304,16 +1314,6 @@ static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG 
     case ACVP_TDES_CFBP8:
     case ACVP_TDES_CFBP64:
     case ACVP_TDES_CTR:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
     case ACVP_CIPHER_END:
     default:
         break;

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -496,7 +496,7 @@ end:
  * url: URL to use for the GET request
  *
  * Return value is the HTTP status value from the server
- *	    (e.g. 200 for HTTP OK)
+ * (e.g. 200 for HTTP OK)
  */
 static long acvp_curl_http_get(ACVP_CTX *ctx, const char *url) {
     long http_code = 0;
@@ -599,7 +599,7 @@ static long acvp_curl_http_get(ACVP_CTX *ctx, const char *url) {
  *            from the HTTP body received from the server.
  *
  * Return value is the HTTP status value from the server
- *	    (e.g. 200 for HTTP OK)
+ * (e.g. 200 for HTTP OK)
  */
 static long acvp_curl_http_post(ACVP_CTX *ctx, const char *url, const char *data, int data_len) {
     long http_code = 0;
@@ -711,7 +711,7 @@ static long acvp_curl_http_post(ACVP_CTX *ctx, const char *url, const char *data
  * @param data_len: Length of \p data (in bytes)
  *
  * @return HTTP status value from the server
- *	       (e.g. 200 for HTTP OK)
+ * (e.g. 200 for HTTP OK)
  */
 static long acvp_curl_http_put(ACVP_CTX *ctx, const char *url, const char *data, int data_len) {
     long http_code = 0;


### PR DESCRIPTION
All HMAC_SHA3 algorithms now register fully with the library. All HMAC_SHA3 registrations are now enabled in the sample app if a high enough openSSL version is used.

Many tab characters were scattered throughout several source files in random places. These have been replaced with spaces (Note: external header files with tabs and makefiles are not adjusted)

AES-GCM-SIV now handles its static ivLen and tagLen values in accordance with the spec clarification - if the server JSON provides those values, it uses and checks them, otherwise it just uses the static 96 and 128 values the algorithm requires. 

Added a few words of clarification to an error or two.