### PR TITLE
Feature/logging improvements

### DIFF
--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1244,6 +1244,11 @@ typedef enum acvp_resource_status {
     ACVP_RESOURCE_STATUS_INCOMPLETE,
 } ACVP_RESOURCE_STATUS;
 
+typedef enum acvp_waiting_status {
+    ACVP_WAITING_FOR_TESTS = 1,
+    ACVP_WAITING_FOR_RESULTS,
+} ACVP_WAITING_STATUS;
+
 typedef struct acvp_oe_dependencies_t {
     ACVP_DEPENDENCY *deps[LIBACVP_DEPENDENCIES_MAX]; /* Array to pointers of linked dependencies */
     unsigned int count;

--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -73,7 +73,9 @@ static unsigned char ctext[TEXT_COL_LEN][TEXT_ROW_LEN];
 static ACVP_RESULT acvp_aes_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, int i) {
     int j = stc->mct_index;
 
-    ACVP_LOG_INFO("MCT interation %d", j);
+    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        ACVP_LOG_INFO("MCT Iteration %d", j);
+    }
     if (stc->cipher != ACVP_AES_CFB1) {
         memcpy_s(ctext[j], TEXT_ROW_LEN, stc->ct, stc->ct_len);
         memcpy_s(ptext[j], TEXT_ROW_LEN, stc->pt, stc->pt_len);

--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -86,7 +86,7 @@ static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx,
     int j = stc->mct_index;
     int n;
     if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("MCT Interation %d", i);
+        ACVP_LOG_INFO("MCT Iteration %d", i);
     }
     memcpy_s(ctext[j], TEXT_ROW_LEN,  stc->ct, stc->ct_len);
     memcpy_s(ptext[j], TEXT_ROW_LEN, stc->pt, stc->pt_len);

--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -85,8 +85,9 @@ static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx,
                                            int i) {
     int j = stc->mct_index;
     int n;
-
-    ACVP_LOG_INFO("MCT Interation %d", i);
+    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        printf("MCT Interation %d", i);
+    }
     memcpy_s(ctext[j], TEXT_ROW_LEN,  stc->ct, stc->ct_len);
     memcpy_s(ptext[j], TEXT_ROW_LEN, stc->pt, stc->pt_len);
 

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -47,7 +47,9 @@ static ACVP_RESULT acvp_hash_mct_iterate_tc(ACVP_CTX *ctx,
                                             ACVP_HASH_TC *stc,
                                             int i) {
 
-    ACVP_LOG_INFO("MCT Interation %d", i);
+    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        ACVP_LOG_INFO("MCT Iteration %d", i);
+    }
     /* feed hash into the next message for MCT */
     memcpy_s(stc->m1, ACVP_HASH_MD_BYTE_MAX, stc->m2, stc->md_len);
     memcpy_s(stc->m2, ACVP_HASH_MD_BYTE_MAX, stc->m3, stc->md_len);

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -792,6 +792,10 @@ static long acvp_curl_http_put(ACVP_CTX *ctx, const char *url, const char *data,
         memzero_s(ctx->curl_buf, ACVP_CURL_BUF_MAX);
     }
 
+    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        printf("\nHTTP PUT:\n\n%s\n", data);
+    }
+
     /*
      * Send the HTTP PUT request
      */


### PR DESCRIPTION
Retry message now clarifies between waiting for vector sets, or waiting for test results.
Moved some MCT iteration logging to verbose to make --info logging more palatable. 
http PUT now prints the data being PUT in verbose.