### PR TITLE
Failed Algorithm Reporting, Logging Changes

### DIFF
--- a/app/app_aes.c
+++ b/app/app_aes.c
@@ -548,13 +548,13 @@ int app_aes_handler_aead(ACVP_TEST_CASE *test_case) {
         }
         switch (tc->key_len) {
         case 128:
-            cipher = EVP_aes_128_ccm();
+            cipher = EVP_aes_128_gcm();
             break;
         case 192:
-            cipher = EVP_aes_192_ccm();
+            cipher = EVP_aes_192_gcm();
             break;
         case 256:
-            cipher = EVP_aes_256_ccm();
+            cipher = EVP_aes_256_gcm();
             break;
         default:
             printf("Unsupported AES-GCM key length\n");

--- a/app/app_aes.c
+++ b/app/app_aes.c
@@ -548,13 +548,13 @@ int app_aes_handler_aead(ACVP_TEST_CASE *test_case) {
         }
         switch (tc->key_len) {
         case 128:
-            cipher = EVP_aes_128_gcm();
+            cipher = EVP_aes_128_ccm();
             break;
         case 192:
-            cipher = EVP_aes_192_gcm();
+            cipher = EVP_aes_192_ccm();
             break;
         case 256:
-            cipher = EVP_aes_256_gcm();
+            cipher = EVP_aes_256_ccm();
             break;
         default:
             printf("Unsupported AES-GCM key length\n");

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -707,6 +707,8 @@
 #define ACVP_USER_AGENT_PROC_STR_MAX 64
 #define ACVP_USER_AGENT_COMP_STR_MAX 32
 
+#define ACVP_STRING_LIST_MAX_LEN 256 //arbitrary max character count for a string in ACVP_STRING_LIST
+
 /*
  * If library cannot detect hardware or software info for HTTP user-agent string, we can check for them
  * in environmental variables, which are defined here
@@ -815,6 +817,16 @@ typedef struct acvp_string_list_t {
     char *string;
     struct acvp_string_list_t *next;
 } ACVP_STRING_LIST;
+
+/*
+ * A list that maintains a list of vector set URLs next to 
+ * which algorithm that vector set is for
+ */
+typedef struct acvp_vector_algname_list_t {
+    char *vs_url;
+    char *alg_name;
+    struct acvp_vector_algname_list_t *next;
+} ACVP_VECTOR_ALGNAME_LIST;
 
 /**
  * @struct ACVP_KV_LIST
@@ -1513,6 +1525,7 @@ ACVP_RESULT acvp_kv_list_append(ACVP_KV_LIST **kv_list,
 void acvp_kv_list_free(ACVP_KV_LIST *kv_list);
 
 void acvp_free_str_list(ACVP_STRING_LIST **list);
+ACVP_RESULT acvp_append_str_list(ACVP_STRING_LIST **list, char *string);
 
 ACVP_RESULT acvp_json_serialize_to_file_pretty_a(const JSON_Value *value, const char *filename);
 ACVP_RESULT acvp_json_serialize_to_file_pretty_w(const JSON_Value *value, const char *filename);

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -15,19 +15,6 @@
 #define ACVP_VERSION    "1.0"
 #define ACVP_LIBRARY_VERSION    "libacvp-1.0.0"
 
-#ifndef ACVP_LOG_INFO
-#ifdef WIN32
-#define ACVP_LOG_INFO(format, ...) do { \
-        acvp_log_msg(ctx, ACVP_LOG_LVL_INFO, "***ACVP [INFO][%s:%d]--> " format "\n", \
-                     __func__, __LINE__, __VA_ARGS__); \
-} while (0)
-#else
-#define ACVP_LOG_INFO(format, args ...) do { \
-        acvp_log_msg(ctx, ACVP_LOG_LVL_INFO, "***ACVP [INFO][%s:%d]--> " format "\n", \
-                     __func__, __LINE__, ##args); \
-} while (0)
-#endif
-#endif
 
 #ifndef ACVP_LOG_ERR
 #ifdef WIN32
@@ -38,6 +25,20 @@
 #else
 #define ACVP_LOG_ERR(format, args ...) do { \
         acvp_log_msg(ctx, ACVP_LOG_LVL_ERR, "***ACVP [ERR][%s:%d]--> " format "\n", \
+                     __func__, __LINE__, ##args); \
+} while (0)
+#endif
+#endif
+
+#ifndef ACVP_LOG_WARN
+#ifdef WIN32
+#define ACVP_LOG_WARN(format, ...) do { \
+        acvp_log_msg(ctx, ACVP_LOG_LVL_WARN, "***ACVP [WARN][%s:%d]--> " format "\n", \
+                     __func__, __LINE__, __VA_ARGS__); \
+} while (0)
+#else
+#define ACVP_LOG_WARN(format, args ...) do { \
+        acvp_log_msg(ctx, ACVP_LOG_LVL_WARN, "***ACVP [WARN][%s:%d]--> " format "\n", \
                      __func__, __LINE__, ##args); \
 } while (0)
 #endif
@@ -57,15 +58,15 @@
 #endif
 #endif
 
-#ifndef ACVP_LOG_WARN
+#ifndef ACVP_LOG_INFO
 #ifdef WIN32
-#define ACVP_LOG_WARN(format, ...) do { \
-        acvp_log_msg(ctx, ACVP_LOG_LVL_WARN, "***ACVP [WARN][%s:%d]--> " format "\n", \
+#define ACVP_LOG_INFO(format, ...) do { \
+        acvp_log_msg(ctx, ACVP_LOG_LVL_INFO, "***ACVP [INFO][%s:%d]--> " format "\n", \
                      __func__, __LINE__, __VA_ARGS__); \
 } while (0)
 #else
-#define ACVP_LOG_WARN(format, args ...) do { \
-        acvp_log_msg(ctx, ACVP_LOG_LVL_WARN, "***ACVP [WARN][%s:%d]--> " format "\n", \
+#define ACVP_LOG_INFO(format, args ...) do { \
+        acvp_log_msg(ctx, ACVP_LOG_LVL_INFO, "***ACVP [INFO][%s:%d]--> " format "\n", \
                      __func__, __LINE__, ##args); \
 } while (0)
 #endif
@@ -818,16 +819,6 @@ typedef struct acvp_string_list_t {
     struct acvp_string_list_t *next;
 } ACVP_STRING_LIST;
 
-/*
- * A list that maintains a list of vector set URLs next to 
- * which algorithm that vector set is for
- */
-typedef struct acvp_vector_algname_list_t {
-    char *vs_url;
-    char *alg_name;
-    struct acvp_vector_algname_list_t *next;
-} ACVP_VECTOR_ALGNAME_LIST;
-
 /**
  * @struct ACVP_KV_LIST
  * @brief This struct is a list of key/value pairs.
@@ -1525,7 +1516,8 @@ ACVP_RESULT acvp_kv_list_append(ACVP_KV_LIST **kv_list,
 void acvp_kv_list_free(ACVP_KV_LIST *kv_list);
 
 void acvp_free_str_list(ACVP_STRING_LIST **list);
-ACVP_RESULT acvp_append_str_list(ACVP_STRING_LIST **list, char *string);
+ACVP_RESULT acvp_append_str_list(ACVP_STRING_LIST **list, const char *string);
+int acvp_lookup_str_list(ACVP_STRING_LIST **list, const char *string);
 
 ACVP_RESULT acvp_json_serialize_to_file_pretty_a(const JSON_Value *value, const char *filename);
 ACVP_RESULT acvp_json_serialize_to_file_pretty_w(const JSON_Value *value, const char *filename);

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2327,7 +2327,7 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
 
     while (1) {
         int testsCompleted = 0;
-        
+
         /*
          * Get the KAT vector set
          */
@@ -2428,7 +2428,6 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
         }
         if(testsCompleted >= count) {
             passed = json_object_get_boolean(obj, "passed");
-            ACVP_LOG_STATUS("%d", passed);
             if (passed == 1) {
                 /*
                  * Pass, exit loop
@@ -2458,7 +2457,7 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
                 rv = ACVP_TRANSPORT_FAIL;
                 goto end;
             }
-            
+
             if (val) json_value_free(val);
             continue;
         }
@@ -2479,7 +2478,6 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
                     rv = acvp_retrieve_vector_set_result(ctx, vs_url);
                     if (rv != ACVP_SUCCESS) goto end;
                 }
-                
                 /*
                  * Get the sample results if the user had requested them.
                  */
@@ -2490,6 +2488,7 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
                 }
             }
         }
+        
         /* If we got here, the testSession failed, exit loop*/
         break;
     }

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -213,7 +213,7 @@ static void acvp_http_user_agent_check_env_for_var(ACVP_CTX *ctx, char *var_stri
 
 static void acvp_http_user_agent_check_compiler_ver(ACVP_CTX *ctx, char *comp_string) {
     char versionBuffer[16];
-    
+
 #ifdef __GNUC__
     strncpy_s(comp_string, ACVP_USER_AGENT_COMP_STR_MAX + 1, "GCC/", ACVP_USER_AGENT_COMP_STR_MAX);
 

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -213,8 +213,7 @@ static void acvp_http_user_agent_check_env_for_var(ACVP_CTX *ctx, char *var_stri
 
 static void acvp_http_user_agent_check_compiler_ver(ACVP_CTX *ctx, char *comp_string) {
     char versionBuffer[16];
-
-    ACVP_LOG_INFO("Checking compiler version");
+    
 #ifdef __GNUC__
     strncpy_s(comp_string, ACVP_USER_AGENT_COMP_STR_MAX + 1, "GCC/", ACVP_USER_AGENT_COMP_STR_MAX);
 
@@ -1283,13 +1282,13 @@ static ACVP_RESULT execute_network_action(ACVP_CTX *ctx,
              * This should not ever happen during "login"...
              * and we need to avoid an infinite loop (via acvp_refesh).
              */
-            ACVP_LOG_ERR("JWT authorization has timed out, curl rc=%d.\n"
-                         "Refreshing session...", rc);
-
+            ACVP_LOG_WARN("JWT authorization has timed out, curl rc=%d. Refreshing session...", rc);
             result = acvp_refresh(ctx);
             if (result != ACVP_SUCCESS) {
                 ACVP_LOG_ERR("JWT refresh failed.");
                 goto end;
+            } else {
+                ACVP_LOG_STATUS("Refresh successful, attempting to continue...");
             }
 
             /* Try action again after the refresh */
@@ -1366,47 +1365,47 @@ static void log_network_status(ACVP_CTX *ctx,
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_GET_VS:
-        if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-            printf("GET Vector Set...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
-                   curl_code, url, ctx->curl_buf);
-        } else {
+        if (ctx->debug >= ACVP_LOG_LVL_INFO) {
             ACVP_LOG_STATUS("GET Vector Set...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                             curl_code, url, ctx->curl_buf);
+        } else {
+            ACVP_LOG_STATUS("GET Vector Set...\n\tStatus: %d\n\tUrl: %s\n",
+                            curl_code, url);
         }
         break;
     case ACVP_NET_GET_VS_RESULT:
-        if (ctx->debug >= ACVP_LOG_LVL_STATUS) {
-            printf("GET Vector Set Result...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
-                   curl_code, url, ctx->curl_buf);
-        } else {
-            ACVP_LOG_STATUS("GET Vector Set Result...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
-                            curl_code, url, ctx->curl_buf);
-        }
+        ACVP_LOG_STATUS("GET Vector Set Result...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+                        curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_GET_VS_SAMPLE:
-        if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-            printf("GET Vector Set Sample...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
-                   curl_code, url, ctx->curl_buf);
-        } else {
-            ACVP_LOG_STATUS("GET Vector Set Sample...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
-                            curl_code, url, ctx->curl_buf);
-        }
+        ACVP_LOG_STATUS("GET Vector Set Sample...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+                        curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_POST:
         ACVP_LOG_STATUS("POST...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_POST_LOGIN:
-        ACVP_LOG_STATUS("POST Login...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+        if (ctx->debug >= ACVP_LOG_LVL_INFO) {
+            ACVP_LOG_STATUS("POST Login...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                         curl_code, url, ctx->curl_buf);
+        } else {
+            ACVP_LOG_STATUS("POST Login...\n\tStatus: %d\n\tUrl: %s\n",
+                        curl_code, url);
+        }
         break;
     case ACVP_NET_POST_REG:
         ACVP_LOG_STATUS("POST Registration...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_POST_VS_RESP:
-        ACVP_LOG_STATUS("POST Response Submission...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
-                        curl_code, url, ctx->curl_buf);
+        if (ctx->debug >= ACVP_LOG_LVL_INFO) {
+            ACVP_LOG_STATUS("POST Response Submission...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+                             curl_code, url, ctx->curl_buf);
+        } else {
+            ACVP_LOG_STATUS("POST Response Submission...\n\tStatus: %d\n\tUrl: %s\n",
+                             curl_code, url);
+        }
         break;
     case ACVP_NET_PUT:
         ACVP_LOG_STATUS("PUT...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -855,7 +855,7 @@ int string_fits(const char *string, unsigned int max_allowed) {
  */
 void acvp_free_str_list(ACVP_STRING_LIST **list) {
     ACVP_STRING_LIST *top = NULL;
-    ACVP_STRING_LIST *tmp = NULL;;
+    ACVP_STRING_LIST *tmp = NULL;
 
     if (list == NULL) return;
     top = *list;
@@ -869,6 +869,41 @@ void acvp_free_str_list(ACVP_STRING_LIST **list) {
     }
 
     *list = NULL;
+}
+
+/**
+ * Simple utility function to add a string to a string list.
+ * Note that the string is COPIED and not referenced.
+ */
+ACVP_RESULT acvp_append_str_list(ACVP_STRING_LIST **list, char *string) {
+    ACVP_STRING_LIST *top = NULL;
+    ACVP_STRING_LIST *tmp = NULL;
+    if (!list) {
+        return ACVP_NO_DATA;
+    }
+    if (*list == NULL) {
+        *list = calloc(1, sizeof(ACVP_STRING_LIST));
+        if (!list) {
+            return ACVP_MALLOC_FAIL;
+        }
+    }
+    top = *list;
+    if (!top) {
+        return ACVP_NO_DATA;
+    }
+    tmp = top;
+    while (tmp->next) {
+        tmp = tmp->next;
+    }
+    
+    tmp->next = calloc(1, sizeof(ACVP_STRING_LIST));
+    int len = strnlen_s(string, ACVP_STRING_LIST_MAX_LEN);
+    tmp->string = calloc(len + 1, sizeof(char));
+    if(!tmp->string) {
+        return ACVP_MALLOC_FAIL;
+    }
+    strncpy_s(tmp->string, len + 1, string, len);
+    return ACVP_SUCCESS;
 }
 
 ACVP_RESULT acvp_json_serialize_to_file_pretty_a(const JSON_Value *value, const char *filename) {

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -928,7 +928,6 @@ int acvp_lookup_str_list(ACVP_STRING_LIST **list, const char *string) {
         tmp = tmp->next;
     }
     return 0;
-    
 }
 
 ACVP_RESULT acvp_json_serialize_to_file_pretty_a(const JSON_Value *value, const char *filename) {

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -875,14 +875,13 @@ void acvp_free_str_list(ACVP_STRING_LIST **list) {
  * Simple utility function to add a string to a string list.
  * Note that the string is COPIED and not referenced.
  */
-ACVP_RESULT acvp_append_str_list(ACVP_STRING_LIST **list, char *string) {
+ACVP_RESULT acvp_append_str_list(ACVP_STRING_LIST **list, const char *string) {
     ACVP_STRING_LIST *top = NULL;
     ACVP_STRING_LIST *tmp = NULL;
-    if (!list) {
-        return ACVP_NO_DATA;
-    }
-    if (*list == NULL) {
-        *list = calloc(1, sizeof(ACVP_STRING_LIST));
+    if (!list || *list == NULL) {
+        tmp = calloc(1, sizeof(ACVP_STRING_LIST));
+        *list = tmp;
+        list = &tmp;
         if (!list) {
             return ACVP_MALLOC_FAIL;
         }
@@ -904,6 +903,32 @@ ACVP_RESULT acvp_append_str_list(ACVP_STRING_LIST **list, char *string) {
     }
     strncpy_s(tmp->string, len + 1, string, len);
     return ACVP_SUCCESS;
+}
+
+/**
+ * Simple utility for looking to see if a string already exists
+ * inside of a string list.
+ */
+int acvp_lookup_str_list(ACVP_STRING_LIST **list, const char *string) {
+    ACVP_STRING_LIST *tmp = NULL;
+    if (!list) {
+        return 0;
+    }
+    if(*list == NULL) {
+        return 0;
+    }
+    tmp = *list;
+    int diff = 1;
+    while(tmp && tmp->string) {
+        strncmp_s(tmp->string, strnlen_s(tmp->string, ACVP_STRING_LIST_MAX_LEN),
+                  string, strnlen_s(string, ACVP_STRING_LIST_MAX_LEN), &diff);
+        if (!diff) {
+            return 1;
+        }
+        tmp = tmp->next;
+    }
+    return 0;
+    
 }
 
 ACVP_RESULT acvp_json_serialize_to_file_pretty_a(const JSON_Value *value, const char *filename) {


### PR DESCRIPTION
NOTE: large diff

- libacvp now logs failed algorithm names when reporting results (prevoiously only reported failed vector set URLs).
- Many server responses were moved from default "status" logging into --info. This will make regular run logs much shorter (and easier to read). 
- Detailed failure responses moved to --verbose (Does not give useful information unless user manually searches for which test group that test case ID is in)
- added acvp_append_str_list and acvp_lookup_str_list to make handling ACVP_STRING_LISTs easier
- Removed some redundant logging, reorganized some code for cleanliness

Todo: add CLI arguments to retrieve vector sets from a previous test session, and detailed fails from a previous test session, so people can debug individual test cases if desired.