### PR TITLE
Fix memory corruption issue with results reporting

### DIFF
--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2392,7 +2392,7 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
                         continue;
                     }
                     //retrieve_vector_set expects a non-const string
-                    char *vs_url = calloc(strnlen_s(vsurl, ACVP_REQUEST_STR_LEN_MAX + 1), sizeof(char));
+                    char *vs_url = calloc(ACVP_REQUEST_STR_LEN_MAX + 1, sizeof(char));
                     if (!vs_url) {
                         ACVP_LOG_ERR("Unable to calloc when reporting failed algorithms, skipping...");
                         continue;                    

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -876,33 +876,44 @@ void acvp_free_str_list(ACVP_STRING_LIST **list) {
  * Note that the string is COPIED and not referenced.
  */
 ACVP_RESULT acvp_append_str_list(ACVP_STRING_LIST **list, const char *string) {
-    ACVP_STRING_LIST *top = NULL;
-    ACVP_STRING_LIST *tmp = NULL;
-    if (!list || *list == NULL) {
-        tmp = calloc(1, sizeof(ACVP_STRING_LIST));
-        *list = tmp;
-        list = &tmp;
-        if (!list) {
-            return ACVP_MALLOC_FAIL;
-        }
-    }
-    top = *list;
-    if (!top) {
+    ACVP_STRING_LIST *current = NULL;
+    ACVP_STRING_LIST *prev = NULL;
+    char *word = NULL;
+
+    if (!list) {
         return ACVP_NO_DATA;
     }
-    tmp = top;
-    while (tmp->next) {
-        tmp = tmp->next;
-    }
-    
-    tmp->next = calloc(1, sizeof(ACVP_STRING_LIST));
+
     int len = strnlen_s(string, ACVP_STRING_LIST_MAX_LEN);
-    tmp->string = calloc(len + 1, sizeof(char));
-    if(!tmp->string) {
+    word = calloc(len + 1, sizeof(char));
+    if (!word) {
         return ACVP_MALLOC_FAIL;
     }
-    strncpy_s(tmp->string, len + 1, string, len);
-    return ACVP_SUCCESS;
+    strncpy_s(word, len + 1, string, len);
+
+    if (*list == NULL) {
+        *list = calloc(1, sizeof(ACVP_STRING_LIST));
+        if (*list == NULL) {
+            free(word);
+            return ACVP_MALLOC_FAIL;
+        }
+        (*list)->string = word;
+        return ACVP_SUCCESS;
+    } else {
+        current = *list;
+        while (current) {
+            prev = current;
+            current = current->next;
+        }
+        prev->next = calloc(1, sizeof(ACVP_STRING_LIST));
+        if (!prev->next) {
+            free(word);
+            return ACVP_MALLOC_FAIL;
+        }
+        prev->next->string = word;
+        return ACVP_SUCCESS;
+    }
+
 }
 
 /**
@@ -911,10 +922,7 @@ ACVP_RESULT acvp_append_str_list(ACVP_STRING_LIST **list, const char *string) {
  */
 int acvp_lookup_str_list(ACVP_STRING_LIST **list, const char *string) {
     ACVP_STRING_LIST *tmp = NULL;
-    if (!list) {
-        return 0;
-    }
-    if(*list == NULL) {
+    if (!list || *list == NULL) {
         return 0;
     }
     tmp = *list;


### PR DESCRIPTION
used strnlen for calloc, and did not for the strncpy. This has been fixed. 
Also had rewritten acvp_append_str_list when debugging, and the new version is cleaner, so including this. 

Will be much more careful with bounds creation and checking in the future.

