### PR TITLE
Some Memory Fixes (Mostly Tests)

### DIFF
--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1567,7 +1567,7 @@ static ACVP_RESULT acvp_build_login(ACVP_CTX *ctx, char **login, int *login_len,
     }
 
     if (ctx->totp_cb) {
-        token = calloc(ACVP_TOTP_TOKEN_MAX, sizeof(char));
+        token = calloc(ACVP_TOTP_TOKEN_MAX + 1, sizeof(char));
         if (!token) return ACVP_MALLOC_FAIL;
 
         ctx->totp_cb(&token, ACVP_TOTP_TOKEN_MAX);
@@ -2340,7 +2340,7 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
             ACVP_LOG_ERR("Error retrieving vector set results!");
             goto end;
         }
-
+        if (val) json_value_free(val);
         val = json_parse_string(ctx->curl_buf);
         if (!val) {
             ACVP_LOG_ERR("Error while parsing json from server!");

--- a/src/acvp_kdf108.c
+++ b/src/acvp_kdf108.c
@@ -524,6 +524,7 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             rv = acvp_kdf108_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
                 ACVP_LOG_ERR("JSON output failure in kdf135 tpm module");
+                json_value_free(r_tval);
                 acvp_kdf108_release_tc(&stc);
                 goto err;
             }

--- a/src/acvp_kdf108.c
+++ b/src/acvp_kdf108.c
@@ -491,14 +491,6 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             ACVP_LOG_INFO("         deferred: %d", deferred);
 
             /*
-             * Create a new test case in the response
-             */
-            r_tval = json_value_init_object();
-            r_tobj = json_value_get_object(r_tval);
-
-            json_object_set_number(r_tobj, "tcId", tc_id);
-
-            /*
              * Setup the test case data that will be passed down to
              * the crypto module.
              */
@@ -517,6 +509,14 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 goto err;
             }
+
+            /*
+             * Create a new test case in the response
+             */
+            r_tval = json_value_init_object();
+            r_tobj = json_value_get_object(r_tval);
+
+            json_object_set_number(r_tobj, "tcId", tc_id);
 
             /*
              * Output the test case results using JSON

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -166,7 +166,7 @@ static void teardown(void) {
 }
 
 static ACVP_RESULT dummy_totp_success(char **token, int token_max) {
-    strncpy(*token, "test", 4);
+    strncpy_s(*token, ACVP_TOTP_TOKEN_MAX + 1, "test", 4);
     return ACVP_SUCCESS;
 }
 

--- a/test/test_acvp_transport.c
+++ b/test/test_acvp_transport.c
@@ -480,8 +480,8 @@ Test(TRANSPORT_GET, good, .init = test_setup_session_parameters, .fini = teardow
     cr_assert(rv == ACVP_MISSING_ARG);
 
 
-    key = calloc(strlen("this is the key"), sizeof(char));
-    value = calloc(strlen("value"), sizeof(char));
+    key = calloc(strlen("this is the key") + 1, sizeof(char));
+    value = calloc(strlen("value") + 1, sizeof(char));
     memcpy(value, "value", 5);
     memcpy(key, "This is the key", 15);
     rv = acvp_kv_list_append(&parms, key, value);
@@ -491,6 +491,9 @@ Test(TRANSPORT_GET, good, .init = test_setup_session_parameters, .fini = teardow
     cr_assert(rv == ACVP_TRANSPORT_FAIL);
 #endif
     acvp_kv_list_free(parms);
+    free(key);
+    free(value);
+    
 }
 
 

--- a/test/test_acvp_utils.c
+++ b/test/test_acvp_utils.c
@@ -29,6 +29,8 @@ Test(LogMsg, null_ctx) {
 
     acvp_log_msg(ctx, ACVP_LOG_LVL_MAX, NULL);
     cr_assert(rv == ACVP_SUCCESS);
+    
+    acvp_cleanup(ctx);
 }
 
 /*
@@ -91,7 +93,7 @@ Test(LookupRSARandPQIndex, null_param) {
 
 Test(JsonSerializeToFilePrettyW, null_param) {
     ACVP_RESULT rv = ACVP_SUCCESS;
-    const JSON_Value *value;
+    JSON_Value *value;
 
     rv = acvp_json_serialize_to_file_pretty_w(NULL, "test");
     cr_assert(rv == ACVP_JSON_ERR);
@@ -102,11 +104,13 @@ Test(JsonSerializeToFilePrettyW, null_param) {
 
     rv = acvp_json_serialize_to_file_pretty_w(value, "no_file");
     cr_assert(rv == ACVP_SUCCESS);
+    
+    json_value_free(value);
 }
 
 Test(JsonSerializeToFilePrettyA, null_param) {
     ACVP_RESULT rv = ACVP_SUCCESS;
-    const JSON_Value *value;
+    JSON_Value *value;
 
     rv = acvp_json_serialize_to_file_pretty_a(NULL, "test");
     cr_assert(rv == ACVP_SUCCESS);
@@ -117,6 +121,8 @@ Test(JsonSerializeToFilePrettyA, null_param) {
 
     rv = acvp_json_serialize_to_file_pretty_a(value, "no_file");
     cr_assert(rv == ACVP_SUCCESS);
+    
+    json_value_free(value);
 }
 
 /*
@@ -179,8 +185,8 @@ Test(KvList, null_ctx) {
     rv = acvp_kv_list_append(&kv, "this is the key", NULL);
     cr_assert(rv == ACVP_INVALID_ARG);
 
-    key = calloc(strlen("this is the key"), sizeof(char));
-    value = calloc(strlen("value"), sizeof(char));
+    key = calloc(strlen("this is the key") + 1, sizeof(char));
+    value = calloc(strlen("value") + 1, sizeof(char));
     memcpy(value, "value", 5);
     memcpy(key, "This is the key", 15);
     rv = acvp_kv_list_append(&kv, key, value);
@@ -214,6 +220,8 @@ Test(GetObjFromRsp, null_ctx) {
     val = json_parse_file("json/aes/aes.json");
     obj = acvp_get_obj_from_rsp(ctx, val);
     cr_assert(obj != NULL);
-
+    
+    json_value_free(val);
+    acvp_free_test_session(ctx);
 }
 

--- a/test/test_app_cmac.c
+++ b/test/test_app_cmac.c
@@ -125,6 +125,8 @@ Test(APP_CMAC_HANDLER, missing_msg) {
     cr_assert_neq(rv, 0);
     
     free_cmac_tc(cmac_tc);
+    free(cmac_tc);
+    free(test_case);
 }
 
 /*
@@ -145,6 +147,8 @@ Test(APP_CMAC_HANDLER, missing_key_aes) {
     cr_assert_neq(rv, 0);
     
     free_cmac_tc(cmac_tc);
+    free(cmac_tc);
+    free(test_case);
 }
 
 /*
@@ -165,6 +169,8 @@ Test(APP_CMAC_HANDLER, missing_keys_tdes) {
     cr_assert_neq(rv, 0);
     
     free_cmac_tc(cmac_tc);
+    free(cmac_tc);
+    free(test_case);
 }
 
 /*
@@ -187,5 +193,7 @@ Test(APP_CMAC_HANDLER, disposition_mem_not_allocated) {
     cr_assert_neq(rv, 0);
     
     free_cmac_tc(cmac_tc);
+    free(cmac_tc);
+    free(test_case);
 }
 

--- a/test/test_app_hmac.c
+++ b/test/test_app_hmac.c
@@ -80,6 +80,8 @@ Test(APP_HMAC_HANDLER, missing_msg) {
     cr_assert_neq(rv, 0);
     
     free_hmac_tc(hmac_tc);
+    free(hmac_tc);
+    free(test_case);
 }
 
 /*
@@ -100,6 +102,8 @@ Test(APP_HMAC_HANDLER, missing_key) {
     cr_assert_neq(rv, 0);
     
     free_hmac_tc(hmac_tc);
+    free(hmac_tc);
+    free(test_case);
 }
 
 /*
@@ -122,4 +126,6 @@ Test(APP_HMAC_HANDLER, disposition_mem_not_allocated) {
     cr_assert_neq(rv, 0);
     
     free_hmac_tc(hmac_tc);
+    free(hmac_tc);
+    free(test_case);
 }


### PR DESCRIPTION
Added extra space in buffer for TOTP null, and fixed freeing memory in some error cases for kdf108. Freed memory in a bunch of test cases. All IDed using valgrind with the test suite - more testing needs to be done on app.