### PR TITLE
Bugfixes for windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ model {
                 targetPlatform "x64"
             }
 		}
-		example(NativeExecutableSpec) {
+		acvp_app(NativeExecutableSpec) {
 			sources {
 				c {
 					source {

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1382,7 +1382,11 @@ ACVP_RESULT acvp_retrieve_expected_result(ACVP_CTX *ctx, const char *api_url);
 
 ACVP_RESULT acvp_submit_vector_responses(ACVP_CTX *ctx, char *vsid_url);
 
+#ifdef WIN32
+void acvp_log_msg(ACVP_CTX *ctx, ACVP_LOG_LVL level, const char *format, ...);
+#else
 void acvp_log_msg(ACVP_CTX *ctx, ACVP_LOG_LVL level, const char *format, ...) __attribute__ ((format (gnu_printf, 3, 4)));
+#endif
 
 /*
  * These are the handler routines for each KAT operation

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2039,7 +2039,10 @@ static ACVP_RESULT acvp_retry_handler(ACVP_CTX *ctx, int *retry_period, unsigned
     }
 
     #ifdef WIN32
-    Sleep(*retry_period);
+    /*
+     * Windows uses milliseconds
+     */
+    Sleep(*retry_period * 1000);
     #else
     sleep(*retry_period);
     #endif


### PR DESCRIPTION
Changed output executable to be named acvp_app instead of example.

Updated windows Sleep call to wait the correct amount of time.

Added a switch to ignore a gnuc specific __attribute__.