### PR TITLE
Substantial logging changes

### DIFF
--- a/app/app_aes.c
+++ b/app/app_aes.c
@@ -666,7 +666,6 @@ int app_aes_handler_aead(ACVP_TEST_CASE *test_case) {
              */
             ret = EVP_Cipher(cipher_ctx, tc->pt, tc->ct, tc->ct_len);
             if (ret < 0) {
-                printf("Error performing decrypt operation CCM\n");
                 rc = 1;
                 goto end;
             }

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -90,7 +90,8 @@ static void setup_session_parameters(void) {
     printf("    ACV_URI_PREFIX: %s\n", path_segment);
     if (ca_chain_file) printf("    ACV_CA_FILE:    %s\n", ca_chain_file);
     if (cert_file) printf("    ACV_CERT_FILE:  %s\n", cert_file);
-    if (key_file) printf("    ACV_KEY_FILE:   %s\n\n", key_file);
+    if (key_file) printf("    ACV_KEY_FILE:   %s\n", key_file);
+    printf("\n");
 }
 
 /*

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -72,6 +72,20 @@
 #endif
 #endif
 
+#ifndef ACVP_LOG_VERBOSE
+#ifdef WIN32
+#define ACVP_LOG_VERBOSE(format, ...) do { \
+        acvp_log_msg(ctx, ACVP_LOG_LVL_VERBOSE, "***ACVP [INFO][%s:%d]--> " format "\n", \
+                     __func__, __LINE__, __VA_ARGS__); \
+} while (0)
+#else
+#define ACVP_LOG_VERBOSE(format, args ...) do { \
+        acvp_log_msg(ctx, ACVP_LOG_LVL_VERBOSE, "***ACVP [INFO][%s:%d]--> " format "\n", \
+                     __func__, __LINE__, ##args); \
+} while (0)
+#endif
+#endif
+
 #define ACVP_BIT2BYTE(x) ((x + 7) >> 3) /**< Convert bit length (x, of type integer) into byte length */
 
 #define ACVP_ALG_MAX ACVP_CIPHER_END - 1  /* Used by alg_tbl[] */
@@ -678,7 +692,7 @@
 #define ACVP_CURL_BUF_MAX       (1024 * 1024 * 16) /**< 16 MB */
 #define ACVP_RETRY_TIME_MIN     5 /* seconds */
 #define ACVP_RETRY_TIME_MAX     300 
-#define ACVP_MAX_WAIT_TIME      3600
+#define ACVP_MAX_WAIT_TIME      7200
 #define ACVP_RETRY_TIME         30
 #define ACVP_RETRY_MODIFIER_MAX 10
 #define ACVP_JWT_TOKEN_MAX      2048

--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -73,9 +73,6 @@ static unsigned char ctext[TEXT_COL_LEN][TEXT_ROW_LEN];
 static ACVP_RESULT acvp_aes_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, int i) {
     int j = stc->mct_index;
 
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        ACVP_LOG_INFO("MCT Iteration %d", j);
-    }
     if (stc->cipher != ACVP_AES_CFB1) {
         memcpy_s(ctext[j], TEXT_ROW_LEN, stc->ct, stc->ct_len);
         memcpy_s(ptext[j], TEXT_ROW_LEN, stc->pt, stc->pt_len);
@@ -925,17 +922,17 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             goto err;
         }
 
-        ACVP_LOG_INFO("    Test group: %d", i);
-        ACVP_LOG_INFO("           dir: %s", dir_str);
-        ACVP_LOG_INFO("            kw: %s", kwcipher_str);
-        ACVP_LOG_INFO("        keylen: %d", keylen);
-        ACVP_LOG_INFO("         ivlen: %d", ivlen);
-        ACVP_LOG_INFO("         ptlen: %d", ptlen);
-        ACVP_LOG_INFO("        aadlen: %d", aadlen);
-        ACVP_LOG_INFO("        taglen: %d", taglen);
-        ACVP_LOG_INFO("      testtype: %s", test_type_str);
-        ACVP_LOG_INFO("      incr_ctr: %d", incr_ctr);
-        ACVP_LOG_INFO("    ovrflw_ctr: %d", ovrflw_ctr);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("           dir: %s", dir_str);
+        ACVP_LOG_VERBOSE("            kw: %s", kwcipher_str);
+        ACVP_LOG_VERBOSE("        keylen: %d", keylen);
+        ACVP_LOG_VERBOSE("         ivlen: %d", ivlen);
+        ACVP_LOG_VERBOSE("         ptlen: %d", ptlen);
+        ACVP_LOG_VERBOSE("        aadlen: %d", aadlen);
+        ACVP_LOG_VERBOSE("        taglen: %d", taglen);
+        ACVP_LOG_VERBOSE("      testtype: %s", test_type_str);
+        ACVP_LOG_VERBOSE("      incr_ctr: %d", incr_ctr);
+        ACVP_LOG_VERBOSE("    ovrflw_ctr: %d", ovrflw_ctr);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
@@ -945,7 +942,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                        *key = NULL, *tag = NULL, *aad = NULL;
             unsigned int tc_id = 0;
 
-            ACVP_LOG_INFO("Found new AES test vector...");
+            ACVP_LOG_VERBOSE("Found new AES test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -1090,15 +1087,15 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 }
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("            tcId: %d", tc_id);
-            ACVP_LOG_INFO("              key: %s", key);
-            ACVP_LOG_INFO("               pt: %s", pt);
-            ACVP_LOG_INFO("          dataLen: %d", datalen);
-            ACVP_LOG_INFO("               ct: %s", ct);
-            ACVP_LOG_INFO("               iv: %s", iv);
-            ACVP_LOG_INFO("              tag: %s", tag);
-            ACVP_LOG_INFO("              aad: %s", aad);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("            tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("              key: %s", key);
+            ACVP_LOG_VERBOSE("               pt: %s", pt);
+            ACVP_LOG_VERBOSE("          dataLen: %d", datalen);
+            ACVP_LOG_VERBOSE("               ct: %s", ct);
+            ACVP_LOG_VERBOSE("               iv: %s", iv);
+            ACVP_LOG_VERBOSE("              tag: %s", tag);
+            ACVP_LOG_VERBOSE("              aad: %s", aad);
 
             /*
              * Create a new test case in the response
@@ -1174,11 +1171,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     rv = ACVP_SUCCESS;
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
 
 err:

--- a/src/acvp_cmac.c
+++ b/src/acvp_cmac.c
@@ -316,12 +316,12 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             goto err;
         }
 
-        ACVP_LOG_INFO("\n\n    Test group: %d", i);
+        ACVP_LOG_VERBOSE("\n\n    Test group: %d", i);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new cmac test vector...");
+            ACVP_LOG_VERBOSE("Found new cmac test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -390,24 +390,24 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 }
             }
 
-            ACVP_LOG_INFO("\n        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
-            ACVP_LOG_INFO("        direction: %s", direction);
+            ACVP_LOG_VERBOSE("\n        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("        direction: %s", direction);
 
-            ACVP_LOG_INFO("           msgLen: %d", msglen);
-            ACVP_LOG_INFO("              msg: %s", msg);
+            ACVP_LOG_VERBOSE("           msgLen: %d", msglen);
+            ACVP_LOG_VERBOSE("              msg: %s", msg);
             if (alg_id == ACVP_CMAC_AES) {
-                ACVP_LOG_INFO("           keyLen: %d", keyLen);
-                ACVP_LOG_INFO("              key: %s", key1);
+                ACVP_LOG_VERBOSE("           keyLen: %d", keyLen);
+                ACVP_LOG_VERBOSE("              key: %s", key1);
             } else if (alg_id == ACVP_CMAC_TDES) {
-                ACVP_LOG_INFO("     keyingOption: %d", keyingOption);
-                ACVP_LOG_INFO("             key1: %s", key1);
-                ACVP_LOG_INFO("             key2: %s", key2);
-                ACVP_LOG_INFO("             key3: %s", key3);
+                ACVP_LOG_VERBOSE("     keyingOption: %d", keyingOption);
+                ACVP_LOG_VERBOSE("             key1: %s", key1);
+                ACVP_LOG_VERBOSE("             key2: %s", key2);
+                ACVP_LOG_VERBOSE("             key3: %s", key3);
             }
 
             if (verify) {
-                ACVP_LOG_INFO("              mac: %s", mac);
+                ACVP_LOG_VERBOSE("              mac: %s", mac);
             }
 
             /*
@@ -464,11 +464,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+     ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -85,9 +85,7 @@ static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx,
                                            int i) {
     int j = stc->mct_index;
     int n;
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        ACVP_LOG_INFO("MCT Iteration %d", i);
-    }
+
     memcpy_s(ctext[j], TEXT_ROW_LEN,  stc->ct, stc->ct_len);
     memcpy_s(ptext[j], TEXT_ROW_LEN, stc->pt, stc->pt_len);
 
@@ -902,12 +900,12 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         // keyLen will always be the same for TDES
         keylen = ACVP_TDES_KEY_BIT_LEN;
 
-        ACVP_LOG_INFO("    Test group: %d", i);
-        ACVP_LOG_INFO("        keylen: %d", keylen);
-        ACVP_LOG_INFO("         dir:   %s", dir_str);
-        ACVP_LOG_INFO("      testtype: %s", test_type_str);
-        ACVP_LOG_INFO("      incr_ctr: %d", incr_ctr);
-        ACVP_LOG_INFO("    ovrflw_ctr: %d", ovrflw_ctr);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("        keylen: %d", keylen);
+        ACVP_LOG_VERBOSE("         dir:   %s", dir_str);
+        ACVP_LOG_VERBOSE("      testtype: %s", test_type_str);
+        ACVP_LOG_VERBOSE("      incr_ctr: %d", incr_ctr);
+        ACVP_LOG_VERBOSE("    ovrflw_ctr: %d", ovrflw_ctr);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
@@ -917,7 +915,8 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             unsigned int ivlen = 0, ptlen = 0, ctlen = 0, tmp_key_len = 0;
             char *key = NULL;
 
-            ACVP_LOG_INFO("Found new 3DES test vector...");
+            
+            ACVP_LOG_VERBOSE("Found new 3DES test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -1056,16 +1055,16 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 ivlen = ivlen * 4;
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("            tcId: %d", tc_id);
-            ACVP_LOG_INFO("              key: %s", key);
-            ACVP_LOG_INFO("               pt: %s", pt);
-            ACVP_LOG_INFO("            ptlen: %d", ptlen);
-            ACVP_LOG_INFO("               ct: %s", ct);
-            ACVP_LOG_INFO("            ctlen: %d", ctlen);
-            ACVP_LOG_INFO("               iv: %s", iv);
-            ACVP_LOG_INFO("            ivlen: %d", ivlen);
-            ACVP_LOG_INFO("              dir: %s", dir_str);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("            tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("              key: %s", key);
+            ACVP_LOG_VERBOSE("               pt: %s", pt);
+            ACVP_LOG_VERBOSE("            ptlen: %d", ptlen);
+            ACVP_LOG_VERBOSE("               ct: %s", ct);
+            ACVP_LOG_VERBOSE("            ctlen: %d", ctlen);
+            ACVP_LOG_VERBOSE("               iv: %s", iv);
+            ACVP_LOG_VERBOSE("            ivlen: %d", ivlen);
+            ACVP_LOG_VERBOSE("              dir: %s", dir_str);
 
             /*
              * Create a new test case in the response
@@ -1142,11 +1141,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     rv = ACVP_SUCCESS;
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
 
 err:

--- a/src/acvp_drbg.c
+++ b/src/acvp_drbg.c
@@ -84,7 +84,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         return ACVP_MALFORMED_JSON;
     }
 
-    ACVP_LOG_INFO("    DRBG alg: %s", alg_str);
+    ACVP_LOG_VERBOSE("    DRBG alg: %s", alg_str);
 
     /*
      * Get a reference to the abstracted test case
@@ -126,7 +126,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     groups = json_object_get_array(obj, "testGroups");
     g_cnt = json_array_get_count(groups);
-    ACVP_LOG_INFO("Number of TestGroups: %d", g_cnt);
+    ACVP_LOG_VERBOSE("Number of TestGroups: %d", g_cnt);
     for (i = 0; i < g_cnt; i++) {
         int tgId = 0;
         const char *mode_str = NULL;
@@ -234,24 +234,24 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             }
         }
 
-        ACVP_LOG_INFO("    Test group:");
-        ACVP_LOG_INFO("    DRBG mode: %s", mode_str);
-        ACVP_LOG_INFO("    derFunc: %s", der_func_enabled ? "true" : "false");
-        ACVP_LOG_INFO("    predResistance: %s", pred_resist_enabled ? "true" : "false");
-        ACVP_LOG_INFO("    entropyInputLen: %d", entropy_len);
+        ACVP_LOG_VERBOSE("    Test group:");
+        ACVP_LOG_VERBOSE("    DRBG mode: %s", mode_str);
+        ACVP_LOG_VERBOSE("    derFunc: %s", der_func_enabled ? "true" : "false");
+        ACVP_LOG_VERBOSE("    predResistance: %s", pred_resist_enabled ? "true" : "false");
+        ACVP_LOG_VERBOSE("    entropyInputLen: %d", entropy_len);
         if (pred_resist_enabled) {
-            ACVP_LOG_INFO("    additionalInputLen: %d", additional_input_len);
+            ACVP_LOG_VERBOSE("    additionalInputLen: %d", additional_input_len);
         }
-        ACVP_LOG_INFO("    persoStringLen: %d", perso_string_len);
-        ACVP_LOG_INFO("    nonceLen: %d", nonce_len);
-        ACVP_LOG_INFO("    returnedBitsLen: %d", drb_len);
+        ACVP_LOG_VERBOSE("    persoStringLen: %d", perso_string_len);
+        ACVP_LOG_VERBOSE("    nonceLen: %d", nonce_len);
+        ACVP_LOG_VERBOSE("    returnedBitsLen: %d", drb_len);
 
         /*
          * Handle test array
          */
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
-        ACVP_LOG_INFO("Number of Tests: %d", t_cnt);
+        ACVP_LOG_VERBOSE("Number of Tests: %d", t_cnt);
         for (j = 0; j < t_cnt; j++) {
             JSON_Value *pr_input_val = NULL;
             JSON_Object *pr_input_obj = NULL;
@@ -260,12 +260,12 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                        *additional_input_1 = NULL, *entropy_input_pr_1 = NULL,
                        *perso_string = NULL, *entropy = NULL, *nonce = NULL;
 
-            ACVP_LOG_INFO("Found new DRBG test vector...");
+            ACVP_LOG_VERBOSE("Found new DRBG test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
             json_result = json_serialize_to_string_pretty(testval, NULL);
-            ACVP_LOG_INFO("json testval count: %d\n %s\n", i, json_result);
+            ACVP_LOG_VERBOSE("json testval count: %d\n %s\n", i, json_result);
             json_free_serialized_string(json_result);
 
             tc_id = json_object_get_number(testobj, "tcId");
@@ -312,11 +312,11 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 goto err;
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
-            ACVP_LOG_INFO("             entropyInput: %s", entropy);
-            ACVP_LOG_INFO("             perso_string: %s", perso_string);
-            ACVP_LOG_INFO("             nonce: %s", nonce);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("             entropyInput: %s", entropy);
+            ACVP_LOG_VERBOSE("             perso_string: %s", perso_string);
+            ACVP_LOG_VERBOSE("             nonce: %s", nonce);
 
             /*
              * Handle pred_resist_input array. Has at most 2 elements
@@ -335,7 +335,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 goto err;
             }
 
-            ACVP_LOG_INFO("Found new DRBG Prediction Input...");
+            ACVP_LOG_VERBOSE("Found new DRBG Prediction Input...");
 
             /* Get 1st element from the array */
             pr_input_val = json_array_get_value(pred_resist_input, 0);
@@ -465,11 +465,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
 
     rv = ACVP_SUCCESS;

--- a/src/acvp_dsa.c
+++ b/src/acvp_dsa.c
@@ -497,8 +497,8 @@ ACVP_RESULT acvp_dsa_keygen_handler(ACVP_CTX *ctx,
         return ACVP_MISSING_ARG;
     }
 
-    ACVP_LOG_INFO("             l: %d", l);
-    ACVP_LOG_INFO("             n: %d", n);
+    ACVP_LOG_VERBOSE("             l: %d", l);
+    ACVP_LOG_VERBOSE("             n: %d", n);
 
     tests = json_object_get_array(groupobj, "tests");
     if (!tests) {
@@ -515,7 +515,7 @@ ACVP_RESULT acvp_dsa_keygen_handler(ACVP_CTX *ctx,
     stc = tc.tc.dsa;
 
     for (j = 0; j < t_cnt; j++) {
-        ACVP_LOG_INFO("Found new DSA KeyGen test vector...");
+        ACVP_LOG_VERBOSE("Found new DSA KeyGen test vector...");
         stc->mode = ACVP_DSA_MODE_KEYGEN;
 
         testval = json_array_get_value(tests, j);
@@ -527,8 +527,8 @@ ACVP_RESULT acvp_dsa_keygen_handler(ACVP_CTX *ctx,
             return ACVP_MISSING_ARG;
         }
 
-        ACVP_LOG_INFO("       Test case: %d", j);
-        ACVP_LOG_INFO("            tcId: %d", tc_id);
+        ACVP_LOG_VERBOSE("       Test case: %d", j);
+        ACVP_LOG_VERBOSE("            tcId: %d", tc_id);
 
         /*
          * Setup the test case data that will be passed down to
@@ -690,14 +690,14 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
     }
 
     if (gen_pq) {
-        ACVP_LOG_INFO("         genPQ: %s", gen_pq);
+        ACVP_LOG_VERBOSE("         genPQ: %s", gen_pq);
     }
     if (gen_g) {
-        ACVP_LOG_INFO("          genG: %s", gen_g);
+        ACVP_LOG_VERBOSE("          genG: %s", gen_g);
     }
-    ACVP_LOG_INFO("             l: %d", l);
-    ACVP_LOG_INFO("             n: %d", n);
-    ACVP_LOG_INFO("           sha: %s", sha_str);
+    ACVP_LOG_VERBOSE("             l: %d", l);
+    ACVP_LOG_VERBOSE("             n: %d", n);
+    ACVP_LOG_VERBOSE("           sha: %s", sha_str);
 
     tests = json_object_get_array(groupobj, "tests");
     if (!tests) {
@@ -714,7 +714,7 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
     stc = tc.tc.dsa;
 
     for (j = 0; j < t_cnt; j++) {
-        ACVP_LOG_INFO("Found new DSA PQGGen test vector...");
+        ACVP_LOG_VERBOSE("Found new DSA PQGGen test vector...");
         stc->mode = ACVP_DSA_MODE_PQGGEN;
 
         testval = json_array_get_value(tests, j);
@@ -726,8 +726,8 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
             return ACVP_MISSING_ARG;
         }
 
-        ACVP_LOG_INFO("       Test case: %d", j);
-        ACVP_LOG_INFO("            tcId: %d", tc_id);
+        ACVP_LOG_VERBOSE("       Test case: %d", j);
+        ACVP_LOG_VERBOSE("            tcId: %d", tc_id);
         if (gen_g) {
             gpq = read_gen_g(gen_g);
 
@@ -751,8 +751,8 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
 
                 gpq = ACVP_DSA_CANONICAL;
 
-                ACVP_LOG_INFO("            seed: %s", seed);
-                ACVP_LOG_INFO("           idx: %s", idx);
+                ACVP_LOG_VERBOSE("            seed: %s", seed);
+                ACVP_LOG_VERBOSE("           idx: %s", idx);
             }
 
             p = json_object_get_string(testobj, "p");
@@ -767,8 +767,8 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
                 return ACVP_MISSING_ARG;
             }
 
-            ACVP_LOG_INFO("               p: %s", p);
-            ACVP_LOG_INFO("               q: %s", q);
+            ACVP_LOG_VERBOSE("               p: %s", p);
+            ACVP_LOG_VERBOSE("               q: %s", q);
         }
 
         if (gen_pq) {
@@ -917,9 +917,9 @@ ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
-    ACVP_LOG_INFO("             l: %d", l);
-    ACVP_LOG_INFO("             n: %d", n);
-    ACVP_LOG_INFO("           sha: %s", sha_str);
+    ACVP_LOG_VERBOSE("             l: %d", l);
+    ACVP_LOG_VERBOSE("             n: %d", n);
+    ACVP_LOG_VERBOSE("           sha: %s", sha_str);
 
     tests = json_object_get_array(groupobj, "tests");
     if (!tests) {
@@ -936,7 +936,7 @@ ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
     stc = tc.tc.dsa;
 
     for (j = 0; j < t_cnt; j++) {
-        ACVP_LOG_INFO("Found new DSA SigGen test vector...");
+        ACVP_LOG_VERBOSE("Found new DSA SigGen test vector...");
         stc->mode = ACVP_DSA_MODE_SIGGEN;
 
         testval = json_array_get_value(tests, j);
@@ -954,9 +954,9 @@ ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
             return ACVP_MISSING_ARG;
         }
 
-        ACVP_LOG_INFO("       Test case: %d", j);
-        ACVP_LOG_INFO("            tcId: %d", tc_id);
-        ACVP_LOG_INFO("             msg: %s", msg);
+        ACVP_LOG_VERBOSE("       Test case: %d", j);
+        ACVP_LOG_VERBOSE("            tcId: %d", tc_id);
+        ACVP_LOG_VERBOSE("             msg: %s", msg);
 
         /*
          * Setup the test case data that will be passed down to
@@ -1096,11 +1096,11 @@ ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
         return ACVP_MISSING_ARG;
     }
 
-    ACVP_LOG_INFO("             l: %d", l);
-    ACVP_LOG_INFO("             n: %d", n);
-    ACVP_LOG_INFO("           sha: %s", sha_str);
-    ACVP_LOG_INFO("         gmode: %s", gmode);
-    ACVP_LOG_INFO("        pqmode: %s", pqmode);
+    ACVP_LOG_VERBOSE("             l: %d", l);
+    ACVP_LOG_VERBOSE("             n: %d", n);
+    ACVP_LOG_VERBOSE("           sha: %s", sha_str);
+    ACVP_LOG_VERBOSE("         gmode: %s", gmode);
+    ACVP_LOG_VERBOSE("        pqmode: %s", pqmode);
 
     tests = json_object_get_array(groupobj, "tests");
     if (!tests) {
@@ -1117,7 +1117,7 @@ ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
     stc = tc.tc.dsa;
 
     for (j = 0; j < t_cnt; j++) {
-        ACVP_LOG_INFO("Found new DSA PQGVer test vector...");
+        ACVP_LOG_VERBOSE("Found new DSA PQGVer test vector...");
         stc->mode = ACVP_DSA_MODE_PQGVER;
 
         testval = json_array_get_value(tests, j);
@@ -1147,16 +1147,16 @@ ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
 
         g = json_object_get_string(testobj, "g");
 
-        ACVP_LOG_INFO("       Test case: %d", j);
-        ACVP_LOG_INFO("            tcId: %d", tc_id);
-        ACVP_LOG_INFO("            seed: %s", seed);
-        ACVP_LOG_INFO("               p: %s", p);
-        ACVP_LOG_INFO("               q: %s", q);
-        ACVP_LOG_INFO("               g: %s", g);
-        ACVP_LOG_INFO("          pqMode: %s", pqmode);
-        ACVP_LOG_INFO("           gMode: %s", gmode);
-        ACVP_LOG_INFO("               c: %d", c);
-        ACVP_LOG_INFO("           idx: %s", idx);
+        ACVP_LOG_VERBOSE("       Test case: %d", j);
+        ACVP_LOG_VERBOSE("            tcId: %d", tc_id);
+        ACVP_LOG_VERBOSE("            seed: %s", seed);
+        ACVP_LOG_VERBOSE("               p: %s", p);
+        ACVP_LOG_VERBOSE("               q: %s", q);
+        ACVP_LOG_VERBOSE("               g: %s", g);
+        ACVP_LOG_VERBOSE("          pqMode: %s", pqmode);
+        ACVP_LOG_VERBOSE("           gMode: %s", gmode);
+        ACVP_LOG_VERBOSE("               c: %d", c);
+        ACVP_LOG_VERBOSE("           idx: %s", idx);
 
         /* find the mode */
         if (gmode) {
@@ -1274,9 +1274,9 @@ ACVP_RESULT acvp_dsa_sigver_handler(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
-    ACVP_LOG_INFO("             l: %d", l);
-    ACVP_LOG_INFO("             n: %d", n);
-    ACVP_LOG_INFO("           sha: %s", sha_str);
+    ACVP_LOG_VERBOSE("             l: %d", l);
+    ACVP_LOG_VERBOSE("             n: %d", n);
+    ACVP_LOG_VERBOSE("           sha: %s", sha_str);
 
     tests = json_object_get_array(groupobj, "tests");
     if (!tests) {
@@ -1311,7 +1311,7 @@ ACVP_RESULT acvp_dsa_sigver_handler(ACVP_CTX *ctx,
     }
 
     for (j = 0; j < t_cnt; j++) {
-        ACVP_LOG_INFO("Found new DSA SigVer test vector...");
+        ACVP_LOG_VERBOSE("Found new DSA SigVer test vector...");
         stc->mode = ACVP_DSA_MODE_SIGVER;
 
         testval = json_array_get_value(tests, j);
@@ -1344,15 +1344,15 @@ ACVP_RESULT acvp_dsa_sigver_handler(ACVP_CTX *ctx,
             return ACVP_MISSING_ARG;
         }
 
-        ACVP_LOG_INFO("       Test case: %d", j);
-        ACVP_LOG_INFO("            tcId: %d", tc_id);
-        ACVP_LOG_INFO("             msg: %s", msg);
-        ACVP_LOG_INFO("               p: %s", p);
-        ACVP_LOG_INFO("               q: %s", q);
-        ACVP_LOG_INFO("               g: %s", g);
-        ACVP_LOG_INFO("               r: %s", r);
-        ACVP_LOG_INFO("               s: %s", s);
-        ACVP_LOG_INFO("               y: %s", y);
+        ACVP_LOG_VERBOSE("       Test case: %d", j);
+        ACVP_LOG_VERBOSE("            tcId: %d", tc_id);
+        ACVP_LOG_VERBOSE("             msg: %s", msg);
+        ACVP_LOG_VERBOSE("               p: %s", p);
+        ACVP_LOG_VERBOSE("               q: %s", q);
+        ACVP_LOG_VERBOSE("               g: %s", g);
+        ACVP_LOG_VERBOSE("               r: %s", r);
+        ACVP_LOG_VERBOSE("               s: %s", s);
+        ACVP_LOG_VERBOSE("               y: %s", y);
 
         /*
          * Setup the test case data that will be passed down to
@@ -1485,7 +1485,7 @@ ACVP_RESULT acvp_dsa_pqgver_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         stc.mode = ACVP_DSA_MODE_PQGVER;
 
-        ACVP_LOG_INFO("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
 
         rv = acvp_dsa_pqgver_handler(ctx, tc, cap, r_tarr, groupobj);
         if (rv != ACVP_SUCCESS) {
@@ -1503,11 +1503,8 @@ ACVP_RESULT acvp_dsa_pqgver_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         goto err;
     }
 
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
+
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 
@@ -1610,7 +1607,7 @@ ACVP_RESULT acvp_dsa_pqggen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         stc.mode = ACVP_DSA_MODE_PQGGEN;
 
-        ACVP_LOG_INFO("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
 
         rv = acvp_dsa_pqggen_handler(ctx, tc, cap, r_tarr, groupobj);
         if (rv != ACVP_SUCCESS) {
@@ -1623,11 +1620,7 @@ ACVP_RESULT acvp_dsa_pqggen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     memzero_s(&stc, sizeof(ACVP_DSA_TC));
     json_array_append_value(reg_arry, r_vs_val);
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 
@@ -1730,7 +1723,7 @@ ACVP_RESULT acvp_dsa_siggen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         stc.mode = ACVP_DSA_MODE_SIGGEN;
 
-        ACVP_LOG_INFO("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
 
         rv = acvp_dsa_siggen_handler(ctx, tc, cap, r_tarr, groupobj, tgId, r_gobj);
         if (rv != ACVP_SUCCESS) {
@@ -1745,11 +1738,7 @@ ACVP_RESULT acvp_dsa_siggen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
 
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 
@@ -1852,7 +1841,7 @@ ACVP_RESULT acvp_dsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         stc.mode = ACVP_DSA_MODE_KEYGEN;
 
-        ACVP_LOG_INFO("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
 
         rv = acvp_dsa_keygen_handler(ctx, tc, cap, r_tarr, groupobj, tgId, r_gobj);
         if (rv != ACVP_SUCCESS) {
@@ -1866,11 +1855,7 @@ ACVP_RESULT acvp_dsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
 
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 
@@ -1973,7 +1958,7 @@ ACVP_RESULT acvp_dsa_sigver_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         stc.mode = ACVP_DSA_MODE_SIGVER;
 
-        ACVP_LOG_INFO("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
 
         rv = acvp_dsa_sigver_handler(ctx, tc, cap, r_tarr, groupobj);
         if (rv != ACVP_SUCCESS) {
@@ -1992,11 +1977,7 @@ ACVP_RESULT acvp_dsa_sigver_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         goto err;
     }
 
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_ecdsa.c
+++ b/src/acvp_ecdsa.c
@@ -282,7 +282,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
         ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
-    ACVP_LOG_INFO("    ECDSA mode: %s", mode_str);
+    ACVP_LOG_VERBOSE("    ECDSA mode: %s", mode_str);
 
     /*
      * Create ACVP array for response
@@ -385,10 +385,10 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
             }
         }
 
-        ACVP_LOG_INFO("           Test group: %d", i);
-        ACVP_LOG_INFO("                curve: %s", curve_str);
-        ACVP_LOG_INFO(" secretGenerationMode: %s", secret_gen_mode_str);
-        ACVP_LOG_INFO("              hashAlg: %s", hash_alg_str);
+        ACVP_LOG_VERBOSE("           Test group: %d", i);
+        ACVP_LOG_VERBOSE("                curve: %s", curve_str);
+        ACVP_LOG_VERBOSE(" secretGenerationMode: %s", secret_gen_mode_str);
+        ACVP_LOG_VERBOSE("              hashAlg: %s", hash_alg_str);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
@@ -399,7 +399,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
         }
 
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new ECDSA test vector...");
+            ACVP_LOG_VERBOSE("Found new ECDSA test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
             tc_id = json_object_get_number(testobj, "tcId");
@@ -448,8 +448,8 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
                 }
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
 
             /*
              * Create a new test case in the response
@@ -522,11 +522,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -47,9 +47,6 @@ static ACVP_RESULT acvp_hash_mct_iterate_tc(ACVP_CTX *ctx,
                                             ACVP_HASH_TC *stc,
                                             int i) {
 
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        ACVP_LOG_INFO("MCT Iteration %d", i);
-    }
     /* feed hash into the next message for MCT */
     memcpy_s(stc->m1, ACVP_HASH_MD_BYTE_MAX, stc->m2, stc->md_len);
     memcpy_s(stc->m2, ACVP_HASH_MD_BYTE_MAX, stc->m3, stc->md_len);
@@ -537,7 +534,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         json_object_set_value(r_gobj, "tests", json_value_init_array());
         r_tarr = json_object_get_array(r_gobj, "tests");
 
-        ACVP_LOG_INFO("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
 
         test_type_str = json_object_get_string(groupobj, "testType");
         if (!test_type_str) {
@@ -584,7 +581,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             unsigned int tmp_msg_len = 0;
             unsigned int xof_len = 0;
 
-            ACVP_LOG_INFO("Found new hash test vector...");
+            ACVP_LOG_VERBOSE("Found new hash test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -616,14 +613,14 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 }
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
-            ACVP_LOG_INFO("              len: %d", msglen);
-            ACVP_LOG_INFO("              msg: %s", msg);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("              len: %d", msglen);
+            ACVP_LOG_VERBOSE("              msg: %s", msg);
             if (test_type == ACVP_HASH_TEST_TYPE_VOT) {
-                ACVP_LOG_INFO("    outLen: %d", xof_len);
+                ACVP_LOG_VERBOSE("    outLen: %d", xof_len);
             }
-            ACVP_LOG_INFO("         testtype: %s", test_type_str);
+            ACVP_LOG_VERBOSE("         testtype: %s", test_type_str);
 
             /*
              * Create a new test case in the response
@@ -701,11 +698,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_hmac.c
+++ b/src/acvp_hmac.c
@@ -231,8 +231,8 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             goto err;
         }
 
-        ACVP_LOG_INFO("    Test group: %d", i);
-        ACVP_LOG_INFO("        msglen: %d", msglen);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("        msglen: %d", msglen);
 
         tests = json_object_get_array(groupobj, "tests");
         if (!tests) {
@@ -249,7 +249,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         }
 
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new hash test vector...");
+            ACVP_LOG_VERBOSE("Found new hash test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -287,13 +287,13 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 goto err;
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
-            ACVP_LOG_INFO("           msgLen: %d", msglen);
-            ACVP_LOG_INFO("           macLen: %d", maclen);
-            ACVP_LOG_INFO("              msg: %s", msg);
-            ACVP_LOG_INFO("           keyLen: %d", keylen);
-            ACVP_LOG_INFO("              key: %s", key);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("           msgLen: %d", msglen);
+            ACVP_LOG_VERBOSE("           macLen: %d", maclen);
+            ACVP_LOG_VERBOSE("              msg: %s", msg);
+            ACVP_LOG_VERBOSE("           keyLen: %d", keylen);
+            ACVP_LOG_VERBOSE("              key: %s", key);
 
             /*
              * Create a new test case in the response
@@ -347,11 +347,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_kas_ecc.c
+++ b/src/acvp_kas_ecc.c
@@ -361,8 +361,8 @@ static ACVP_RESULT acvp_kas_ecc_cdh(ACVP_CTX *ctx,
             goto err;
         }
 
-        ACVP_LOG_INFO("    Test group: %d", i);
-        ACVP_LOG_INFO("          curve: %s", curve_str);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("          curve: %s", curve_str);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
@@ -370,7 +370,7 @@ static ACVP_RESULT acvp_kas_ecc_cdh(ACVP_CTX *ctx,
         for (j = 0; j < t_cnt; j++) {
             const char *psx = NULL, *psy = NULL;
 
-            ACVP_LOG_INFO("Found new KAS-ECC CDH test vector...");
+            ACVP_LOG_VERBOSE("Found new KAS-ECC CDH test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
             tc_id = json_object_get_number(testobj, "tcId");
@@ -413,8 +413,8 @@ static ACVP_RESULT acvp_kas_ecc_cdh(ACVP_CTX *ctx,
                 goto err;
             }
 
-            ACVP_LOG_INFO("            psx: %s", psx);
-            ACVP_LOG_INFO("            psy: %s", psy);
+            ACVP_LOG_VERBOSE("            psx: %s", psx);
+            ACVP_LOG_VERBOSE("            psy: %s", psy);
 
             /*
              * Setup the test case data that will be passed down to
@@ -555,10 +555,10 @@ static ACVP_RESULT acvp_kas_ecc_comp(ACVP_CTX *ctx,
             goto err;
         }
 
-        ACVP_LOG_INFO("    Test group: %d", i);
-        ACVP_LOG_INFO("      test type: %s", test_type_str);
-        ACVP_LOG_INFO("          curve: %s", curve_str);
-        ACVP_LOG_INFO("           hash: %s", hash_str);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("      test type: %s", test_type_str);
+        ACVP_LOG_VERBOSE("          curve: %s", curve_str);
+        ACVP_LOG_VERBOSE("           hash: %s", hash_str);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
@@ -567,7 +567,7 @@ static ACVP_RESULT acvp_kas_ecc_comp(ACVP_CTX *ctx,
             const char *psx = NULL, *psy = NULL, *pix = NULL,
                        *piy = NULL, *d = NULL, *z = NULL;
 
-            ACVP_LOG_INFO("Found new KAS-ECC Component test vector...");
+            ACVP_LOG_VERBOSE("Found new KAS-ECC Component test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
             tc_id = json_object_get_number(testobj, "tcId");
@@ -610,8 +610,8 @@ static ACVP_RESULT acvp_kas_ecc_comp(ACVP_CTX *ctx,
                 goto err;
             }
 
-            ACVP_LOG_INFO("            psx: %s", psx);
-            ACVP_LOG_INFO("            psy: %s", psy);
+            ACVP_LOG_VERBOSE("            psx: %s", psx);
+            ACVP_LOG_VERBOSE("            psy: %s", psy);
 
             if (test_type == ACVP_KAS_ECC_TT_VAL) {
                 pix = json_object_get_string(testobj, "ephemeralPublicIutX");
@@ -674,10 +674,10 @@ static ACVP_RESULT acvp_kas_ecc_comp(ACVP_CTX *ctx,
                     goto err;
                 }
 
-                ACVP_LOG_INFO("              d: %s", d);
-                ACVP_LOG_INFO("            pix: %s", pix);
-                ACVP_LOG_INFO("            piy: %s", piy);
-                ACVP_LOG_INFO("              z: %s", z);
+                ACVP_LOG_VERBOSE("              d: %s", d);
+                ACVP_LOG_VERBOSE("            pix: %s", pix);
+                ACVP_LOG_VERBOSE("            piy: %s", piy);
+                ACVP_LOG_VERBOSE("              z: %s", z);
             }
 
             /*
@@ -914,11 +914,7 @@ ACVP_RESULT acvp_kas_ecc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_kas_ffc.c
+++ b/src/acvp_kas_ffc.c
@@ -295,12 +295,12 @@ static ACVP_RESULT acvp_kas_ffc_comp(ACVP_CTX *ctx,
             goto err;
         }
 
-        ACVP_LOG_INFO("    Test group: %d", i);
-        ACVP_LOG_INFO("      test type: %s", test_type_str);
-        ACVP_LOG_INFO("           hash: %s", hash_str);
-        ACVP_LOG_INFO("              p: %s", p);
-        ACVP_LOG_INFO("              q: %s", q);
-        ACVP_LOG_INFO("              g: %s", g);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("      test type: %s", test_type_str);
+        ACVP_LOG_VERBOSE("           hash: %s", hash_str);
+        ACVP_LOG_VERBOSE("              p: %s", p);
+        ACVP_LOG_VERBOSE("              q: %s", q);
+        ACVP_LOG_VERBOSE("              g: %s", g);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
@@ -308,7 +308,7 @@ static ACVP_RESULT acvp_kas_ffc_comp(ACVP_CTX *ctx,
         for (j = 0; j < t_cnt; j++) {
             const char *eps = NULL, *z = NULL, *epri = NULL, *epui = NULL;
 
-            ACVP_LOG_INFO("Found new KAS-FFC Component test vector...");
+            ACVP_LOG_VERBOSE("Found new KAS-FFC Component test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
             tc_id = json_object_get_number(testobj, "tcId");
@@ -374,10 +374,10 @@ static ACVP_RESULT acvp_kas_ffc_comp(ACVP_CTX *ctx,
                 }
             }
 
-            ACVP_LOG_INFO("            eps: %s", eps);
-            ACVP_LOG_INFO("              z: %s", z);
-            ACVP_LOG_INFO("           epri: %s", epri);
-            ACVP_LOG_INFO("           epui: %s", epui);
+            ACVP_LOG_VERBOSE("            eps: %s", eps);
+            ACVP_LOG_VERBOSE("              z: %s", z);
+            ACVP_LOG_VERBOSE("           epri: %s", epri);
+            ACVP_LOG_VERBOSE("           epui: %s", epui);
 
             /*
              * Create a new test case in the response
@@ -605,11 +605,7 @@ ACVP_RESULT acvp_kas_ffc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_kdf108.c
+++ b/src/acvp_kdf108.c
@@ -422,17 +422,17 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         /*
          * Log Test Group information...
          */
-        ACVP_LOG_INFO("    Test group: %d", i);
-        ACVP_LOG_INFO("       kdfMode: %s", kdf_mode_str);
-        ACVP_LOG_INFO("       macMode: %s", mac_mode_str);
-        ACVP_LOG_INFO("     keyOutLen: %d", key_out_bit_len);
-        ACVP_LOG_INFO("    counterLen: %d", ctr_len);
-        ACVP_LOG_INFO("    counterLoc: %s", ctr_loc_str);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("       kdfMode: %s", kdf_mode_str);
+        ACVP_LOG_VERBOSE("       macMode: %s", mac_mode_str);
+        ACVP_LOG_VERBOSE("     keyOutLen: %d", key_out_bit_len);
+        ACVP_LOG_VERBOSE("    counterLen: %d", ctr_len);
+        ACVP_LOG_VERBOSE("    counterLoc: %s", ctr_loc_str);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new kdf108 test vector...");
+            ACVP_LOG_VERBOSE("Found new kdf108 test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -485,10 +485,10 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             /*
              * Log Test Case information...
              */
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
-            ACVP_LOG_INFO("            keyIn: %s", key_in_str);
-            ACVP_LOG_INFO("         deferred: %d", deferred);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("            keyIn: %s", key_in_str);
+            ACVP_LOG_VERBOSE("         deferred: %d", deferred);
 
             /*
              * Setup the test case data that will be passed down to
@@ -542,11 +542,7 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_kdf135_ikev1.c
+++ b/src/acvp_kdf135_ikev1.c
@@ -374,19 +374,19 @@ ACVP_RESULT acvp_kdf135_ikev1_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             }
         }
 
-        ACVP_LOG_INFO("\n    Test group: %d", i);
-        ACVP_LOG_INFO("        hash alg: %s", hash_alg_str);
-        ACVP_LOG_INFO("     auth method: %s", auth_method_str);
-        ACVP_LOG_INFO("  init nonce len: %d", init_nonce_len);
-        ACVP_LOG_INFO("  resp nonce len: %d", resp_nonce_len);
-        ACVP_LOG_INFO("   dh secret len: %d", dh_secret_len);
-        ACVP_LOG_INFO("         psk len: %d", psk_len);
+        ACVP_LOG_VERBOSE("\n    Test group: %d", i);
+        ACVP_LOG_VERBOSE("        hash alg: %s", hash_alg_str);
+        ACVP_LOG_VERBOSE("     auth method: %s", auth_method_str);
+        ACVP_LOG_VERBOSE("  init nonce len: %d", init_nonce_len);
+        ACVP_LOG_VERBOSE("  resp nonce len: %d", resp_nonce_len);
+        ACVP_LOG_VERBOSE("   dh secret len: %d", dh_secret_len);
+        ACVP_LOG_VERBOSE("         psk len: %d", psk_len);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
 
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new KDF IKEv1 test vector...");
+            ACVP_LOG_VERBOSE("Found new KDF IKEv1 test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -483,8 +483,8 @@ ACVP_RESULT acvp_kdf135_ikev1_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 }
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
 
             /*
              * Create a new test case in the response
@@ -543,11 +543,7 @@ ACVP_RESULT acvp_kdf135_ikev1_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_kdf135_ikev2.c
+++ b/src/acvp_kdf135_ikev2.c
@@ -355,18 +355,18 @@ ACVP_RESULT acvp_kdf135_ikev2_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             goto err;
         }
 
-        ACVP_LOG_INFO("\n    Test group: %d", i);
-        ACVP_LOG_INFO("        hash alg: %s", hash_alg_str);
-        ACVP_LOG_INFO("  init nonce len: %d", init_nonce_len);
-        ACVP_LOG_INFO("  resp nonce len: %d", resp_nonce_len);
-        ACVP_LOG_INFO("   dh secret len: %d", dh_secret_len);
-        ACVP_LOG_INFO("derived key material: %d", keying_material_len);
+        ACVP_LOG_VERBOSE("\n    Test group: %d", i);
+        ACVP_LOG_VERBOSE("        hash alg: %s", hash_alg_str);
+        ACVP_LOG_VERBOSE("  init nonce len: %d", init_nonce_len);
+        ACVP_LOG_VERBOSE("  resp nonce len: %d", resp_nonce_len);
+        ACVP_LOG_VERBOSE("   dh secret len: %d", dh_secret_len);
+        ACVP_LOG_VERBOSE("derived key material: %d", keying_material_len);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
 
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new KDF IKEv2 test vector...");
+            ACVP_LOG_VERBOSE("Found new KDF IKEv2 test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -456,8 +456,8 @@ ACVP_RESULT acvp_kdf135_ikev2_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 goto err;
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
 
             /*
              * Create a new test case in the response
@@ -516,11 +516,7 @@ ACVP_RESULT acvp_kdf135_ikev2_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_kdf135_snmp.c
+++ b/src/acvp_kdf135_snmp.c
@@ -162,9 +162,9 @@ ACVP_RESULT acvp_kdf135_snmp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             goto err;
         }
 
-        ACVP_LOG_INFO("    Test group: %d", i);
-        ACVP_LOG_INFO("          pLen: %d", p_len);
-        ACVP_LOG_INFO("      engineID: %s", engine_id);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("          pLen: %d", p_len);
+        ACVP_LOG_VERBOSE("      engineID: %s", engine_id);
 
         tests = json_object_get_array(groupobj, "tests");
         if (!tests) {
@@ -181,7 +181,7 @@ ACVP_RESULT acvp_kdf135_snmp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         }
 
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new hash test vector...");
+            ACVP_LOG_VERBOSE("Found new hash test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -205,9 +205,9 @@ ACVP_RESULT acvp_kdf135_snmp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 goto err;
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
-            ACVP_LOG_INFO("         password: %s", password);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("         password: %s", password);
 
             /*
              * Create a new test case in the response
@@ -261,11 +261,7 @@ ACVP_RESULT acvp_kdf135_snmp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_kdf135_srtp.c
+++ b/src/acvp_kdf135_srtp.c
@@ -306,15 +306,15 @@ ACVP_RESULT acvp_kdf135_srtp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             goto err;
         }
 
-        ACVP_LOG_INFO("\n    Test group: %d", i);
-        ACVP_LOG_INFO("           kdr: %s", kdr);
-        ACVP_LOG_INFO("    key length: %d", aes_key_length);
+        ACVP_LOG_VERBOSE("\n    Test group: %d", i);
+        ACVP_LOG_VERBOSE("           kdr: %s", kdr);
+        ACVP_LOG_VERBOSE("    key length: %d", aes_key_length);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
 
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new KDF SRTP test vector...");
+            ACVP_LOG_VERBOSE("Found new KDF SRTP test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -348,12 +348,12 @@ ACVP_RESULT acvp_kdf135_srtp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 goto err;
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
-            ACVP_LOG_INFO("        masterKey: %s", master_key);
-            ACVP_LOG_INFO("       masterSalt: %s", master_salt);
-            ACVP_LOG_INFO("            idx: %s", idx);
-            ACVP_LOG_INFO("       srtcpIndex: %s", srtcp_idx);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("        masterKey: %s", master_key);
+            ACVP_LOG_VERBOSE("       masterSalt: %s", master_salt);
+            ACVP_LOG_VERBOSE("            idx: %s", idx);
+            ACVP_LOG_VERBOSE("       srtcpIndex: %s", srtcp_idx);
 
             /*
              * Create a new test case in the response
@@ -407,11 +407,7 @@ ACVP_RESULT acvp_kdf135_srtp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_kdf135_ssh.c
+++ b/src/acvp_kdf135_ssh.c
@@ -234,9 +234,9 @@ ACVP_RESULT acvp_kdf135_ssh_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         /*
          * Log Test Group information...
          */
-        ACVP_LOG_INFO("    Test group: %d", i);
-        ACVP_LOG_INFO("        cipher: %s", cipher_str);
-        ACVP_LOG_INFO("       hashAlg: %s", sha_str);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("        cipher: %s", cipher_str);
+        ACVP_LOG_VERBOSE("       hashAlg: %s", sha_str);
 
         tests = json_object_get_array(groupobj, "tests");
         if (!tests) {
@@ -253,7 +253,7 @@ ACVP_RESULT acvp_kdf135_ssh_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         }
 
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new KDF SSH test vector...");
+            ACVP_LOG_VERBOSE("Found new KDF SSH test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -285,11 +285,11 @@ ACVP_RESULT acvp_kdf135_ssh_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 goto err;
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
-            ACVP_LOG_INFO("                k: %s", shared_secret_str);
-            ACVP_LOG_INFO("                h: %s", hash_str);
-            ACVP_LOG_INFO("       session_id: %s", session_id_str);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("                k: %s", shared_secret_str);
+            ACVP_LOG_VERBOSE("                h: %s", hash_str);
+            ACVP_LOG_VERBOSE("       session_id: %s", session_id_str);
 
             /*
              * Create a new test case in the response
@@ -345,11 +345,7 @@ ACVP_RESULT acvp_kdf135_ssh_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_kdf135_tls.c
+++ b/src/acvp_kdf135_tls.c
@@ -206,16 +206,16 @@ ACVP_RESULT acvp_kdf135_tls_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             goto err;
         }
 
-        ACVP_LOG_INFO("    Test group: %d", i);
-        ACVP_LOG_INFO("            pmLen: %d", pm_len);
-        ACVP_LOG_INFO("            kbLen: %d", kb_len);
-        ACVP_LOG_INFO("           method: %s", method);
-        ACVP_LOG_INFO("              sha: %s", sha);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("            pmLen: %d", pm_len);
+        ACVP_LOG_VERBOSE("            kbLen: %d", kb_len);
+        ACVP_LOG_VERBOSE("           method: %s", method);
+        ACVP_LOG_VERBOSE("              sha: %s", sha);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new hash test vector...");
+            ACVP_LOG_VERBOSE("Found new hash test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -262,13 +262,13 @@ ACVP_RESULT acvp_kdf135_tls_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 goto err;
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
-            ACVP_LOG_INFO("         pmSecret: %s", pm_secret);
-            ACVP_LOG_INFO("            shRND: %s", sh_rnd);
-            ACVP_LOG_INFO("            chRND: %s", ch_rnd);
-            ACVP_LOG_INFO("             sRND: %s", s_rnd);
-            ACVP_LOG_INFO("             cRND: %s", c_rnd);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("         pmSecret: %s", pm_secret);
+            ACVP_LOG_VERBOSE("            shRND: %s", sh_rnd);
+            ACVP_LOG_VERBOSE("            chRND: %s", ch_rnd);
+            ACVP_LOG_VERBOSE("             sRND: %s", s_rnd);
+            ACVP_LOG_VERBOSE("             cRND: %s", c_rnd);
 
             /*
              * Create a new test case in the response
@@ -324,11 +324,7 @@ ACVP_RESULT acvp_kdf135_tls_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_kdf135_x963.c
+++ b/src/acvp_kdf135_x963.c
@@ -253,11 +253,11 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             goto err;
         }
 
-        ACVP_LOG_INFO("\n    Test group: %d", i);
-        ACVP_LOG_INFO("         hashAlg: %s", hash_alg_str);
-        ACVP_LOG_INFO("       fieldSize: %d", field_size);
-        ACVP_LOG_INFO("   sharedInfoLen: %d", shared_info_len);
-        ACVP_LOG_INFO("   keyDataLength: %d", key_data_length);
+        ACVP_LOG_VERBOSE("\n    Test group: %d", i);
+        ACVP_LOG_VERBOSE("         hashAlg: %s", hash_alg_str);
+        ACVP_LOG_VERBOSE("       fieldSize: %d", field_size);
+        ACVP_LOG_VERBOSE("   sharedInfoLen: %d", shared_info_len);
+        ACVP_LOG_VERBOSE("   keyDataLength: %d", key_data_length);
 
         tests = json_object_get_array(groupobj, "tests");
         if (!tests) {
@@ -274,7 +274,7 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         }
 
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new KDF135 X963 test vector...");
+            ACVP_LOG_VERBOSE("Found new KDF135 X963 test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
 
@@ -299,8 +299,8 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 goto err;
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
 
             /*
              * Create a new test case in the response
@@ -356,11 +356,7 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_operating_env.c
+++ b/src/acvp_operating_env.c
@@ -1441,7 +1441,7 @@ static ACVP_RESULT compare_vendor_address(ACVP_CTX *ctx, ACVP_VENDOR_ADDRESS *ad
             // Both exist, compare
             strcmp_s(address->street_1, ACVP_OE_STR_MAX, street_1, &diff);
             if (diff != 0) {
-                 ACVP_LOG_INFO("Street1 not equal");
+                 ACVP_LOG_VERBOSE("Street1 not equal");
                  continue; // Not equal
             }
         }
@@ -1454,7 +1454,7 @@ static ACVP_RESULT compare_vendor_address(ACVP_CTX *ctx, ACVP_VENDOR_ADDRESS *ad
             // Both exist, compare
             strcmp_s(address->street_2, ACVP_OE_STR_MAX, street_2, &diff);
             if (diff != 0) {
-                 ACVP_LOG_INFO("Street2 mismatch");
+                 ACVP_LOG_VERBOSE("Street2 mismatch");
                  continue; // Not equal
             }
         }
@@ -1467,7 +1467,7 @@ static ACVP_RESULT compare_vendor_address(ACVP_CTX *ctx, ACVP_VENDOR_ADDRESS *ad
             // Both exist, compare
             strcmp_s(address->street_3, ACVP_OE_STR_MAX, street_3, &diff);
             if (diff != 0) {
-                 ACVP_LOG_INFO("Street3 not equal");
+                 ACVP_LOG_VERBOSE("Street3 not equal");
                  continue; // Not equal
             }
         }
@@ -1480,7 +1480,7 @@ static ACVP_RESULT compare_vendor_address(ACVP_CTX *ctx, ACVP_VENDOR_ADDRESS *ad
             // Both exist, compare
             strcmp_s(address->locality, ACVP_OE_STR_MAX, locality, &diff);
             if (diff != 0) {
-                 ACVP_LOG_INFO("Locality not equal");
+                 ACVP_LOG_VERBOSE("Locality not equal");
                  continue; // Not equal
             }
         }
@@ -1493,7 +1493,7 @@ static ACVP_RESULT compare_vendor_address(ACVP_CTX *ctx, ACVP_VENDOR_ADDRESS *ad
             // Both exist, compare
             strcmp_s(address->region, ACVP_OE_STR_MAX, region, &diff);
             if (diff != 0) {
-                 ACVP_LOG_INFO("Region not equal");
+                 ACVP_LOG_VERBOSE("Region not equal");
                  continue; // Not equal
             }
         }
@@ -1506,7 +1506,7 @@ static ACVP_RESULT compare_vendor_address(ACVP_CTX *ctx, ACVP_VENDOR_ADDRESS *ad
             // Both exist, compare
             strcmp_s(address->country, ACVP_OE_STR_MAX, country, &diff);
             if (diff != 0) {
-                 ACVP_LOG_INFO("Country not equal");
+                 ACVP_LOG_VERBOSE("Country not equal");
                  continue; // Not equal
             }
         }
@@ -1519,7 +1519,7 @@ static ACVP_RESULT compare_vendor_address(ACVP_CTX *ctx, ACVP_VENDOR_ADDRESS *ad
             // Both exist, compare
             strcmp_s(address->postal_code, ACVP_OE_STR_MAX, postal_code, &diff);
             if (diff != 0) {
-                 ACVP_LOG_INFO("Postal code not equal");
+                 ACVP_LOG_VERBOSE("Postal code not equal");
                  continue; // Not equal
             }
         }
@@ -1540,7 +1540,7 @@ static ACVP_RESULT compare_vendor_address(ACVP_CTX *ctx, ACVP_VENDOR_ADDRESS *ad
             }
             strcpy_s(address->url, ACVP_ATTR_URL_MAX + 1, url);
             *match = 1;
-            ACVP_LOG_INFO("Vendor Address Match");
+            ACVP_LOG_VERBOSE("Vendor Address Match");
             return ACVP_SUCCESS;
         }
     }
@@ -1584,7 +1584,7 @@ static ACVP_RESULT query_vendor_contacts(ACVP_CTX *ctx,
         if (persons->count == 0) {
             // They are both empty
             *match = 1;
-            ACVP_LOG_INFO("Vendor No Contacts Match");
+            ACVP_LOG_VERBOSE("Vendor No Contacts Match");
             return ACVP_SUCCESS;
         } else {
             return ACVP_SUCCESS; // No match
@@ -1636,7 +1636,7 @@ static ACVP_RESULT query_vendor_contacts(ACVP_CTX *ctx,
             }
             strcmp_s(person->full_name, ACVP_OE_STR_MAX, full_name, &diff);
             if (diff != 0) {
-                 ACVP_LOG_INFO("Name not equal");
+                 ACVP_LOG_VERBOSE("Name not equal");
                  continue; // Not equal
             }
 
@@ -1652,10 +1652,10 @@ static ACVP_RESULT query_vendor_contacts(ACVP_CTX *ctx,
                 goto end;
             }
             if (!equal) {
-                ACVP_LOG_INFO("Emails do not match");
+                ACVP_LOG_VERBOSE("Emails do not match");
                 continue;
             }
-            ACVP_LOG_INFO("Email Match");
+            ACVP_LOG_VERBOSE("Email Match");
 
             phone_numbers = json_object_get_array(contact_obj, "phoneNumbers");
             if (phone_numbers == NULL)  {
@@ -1669,10 +1669,10 @@ static ACVP_RESULT query_vendor_contacts(ACVP_CTX *ctx,
                 goto end;
             }
             if (!equal) {
-                ACVP_LOG_INFO("Phone numbers do not match");
+                ACVP_LOG_VERBOSE("Phone numbers do not match");
                 continue;
             }
-            ACVP_LOG_INFO("Phone Match");
+            ACVP_LOG_VERBOSE("Phone Match");
 
             /*
              * Found a match.
@@ -1704,7 +1704,7 @@ static ACVP_RESULT query_vendor_contacts(ACVP_CTX *ctx,
     }
 
     // Got thorugh all of the linked Persons
-    ACVP_LOG_INFO("Contacts Match");
+    ACVP_LOG_VERBOSE("Contacts Match");
     *match = 1;
 
 end:
@@ -1788,7 +1788,7 @@ static ACVP_RESULT match_vendors_page(ACVP_CTX *ctx,
             goto end;
         }
         if (!equal) {
-            ACVP_LOG_INFO("Emails do not match");
+            ACVP_LOG_VERBOSE("Emails do not match");
             continue;
         }
 
@@ -1804,7 +1804,7 @@ static ACVP_RESULT match_vendors_page(ACVP_CTX *ctx,
             goto end;
         }
         if (!equal) {
-            ACVP_LOG_INFO("Phone numbers do not match");
+            ACVP_LOG_VERBOSE("Phone numbers do not match");
             continue;
         }
 
@@ -1820,7 +1820,7 @@ static ACVP_RESULT match_vendors_page(ACVP_CTX *ctx,
             goto end;
         }
         if (!equal) {
-            ACVP_LOG_INFO("Addresses do not match");
+            ACVP_LOG_VERBOSE("Addresses do not match");
             continue;
         }
 
@@ -1831,7 +1831,7 @@ static ACVP_RESULT match_vendors_page(ACVP_CTX *ctx,
             goto end;
         }
         if (!equal) {
-            ACVP_LOG_INFO("Contact URLs do not match");
+            ACVP_LOG_VERBOSE("Contact URLs do not match");
             continue;
         }
 

--- a/src/acvp_rsa_keygen.c
+++ b/src/acvp_rsa_keygen.c
@@ -493,22 +493,22 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             }
         }
 
-        ACVP_LOG_INFO("    Test group: %d", i);
-        ACVP_LOG_INFO("  infoGenByServer: %s", info_gen_by_server ? "true" : "false");
-        ACVP_LOG_INFO("       pubExpMode: %s", pub_exp_mode_str);
-        ACVP_LOG_INFO("        keyFormat: %s", key_format_str);
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("  infoGenByServer: %s", info_gen_by_server ? "true" : "false");
+        ACVP_LOG_VERBOSE("       pubExpMode: %s", pub_exp_mode_str);
+        ACVP_LOG_VERBOSE("        keyFormat: %s", key_format_str);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
 
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new RSA test vector...");
+            ACVP_LOG_VERBOSE("Found new RSA test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
             tc_id = json_object_get_number(testobj, "tcId");
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
 
             /*
              * Create a new test case in the response
@@ -612,11 +612,7 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_rsa_sig.c
+++ b/src/acvp_rsa_sig.c
@@ -242,7 +242,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
         return ACVP_UNSUPPORTED_OP;
     }
 
-    ACVP_LOG_INFO("    RSA mode: %s", mode_str);
+    ACVP_LOG_VERBOSE("    RSA mode: %s", mode_str);
 
     /*
      * Create ACVP array for response
@@ -349,16 +349,16 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
             }
         }
 
-        ACVP_LOG_INFO("       Test group: %d", i);
-        ACVP_LOG_INFO("          sigType: %s", sig_type_str);
-        ACVP_LOG_INFO("           modulo: %d", mod);
-        ACVP_LOG_INFO("          hashAlg: %s", hash_alg_str);
+        ACVP_LOG_VERBOSE("       Test group: %d", i);
+        ACVP_LOG_VERBOSE("          sigType: %s", sig_type_str);
+        ACVP_LOG_VERBOSE("           modulo: %d", mod);
+        ACVP_LOG_VERBOSE("          hashAlg: %s", hash_alg_str);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
 
         for (j = 0; j < t_cnt; j++) {
-            ACVP_LOG_INFO("Found new RSA test vector...");
+            ACVP_LOG_VERBOSE("Found new RSA test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
             tc_id = json_object_get_number(testobj, "tcId");
@@ -368,8 +368,8 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
                 goto err;
             }
 
-            ACVP_LOG_INFO("        Test case: %d", j);
-            ACVP_LOG_INFO("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
 
             /*
              * Create a new test case in the response
@@ -397,7 +397,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
                 json_value_free(r_tval);
                 goto err;
             }
-            ACVP_LOG_INFO("              msg: %s", msg);
+            ACVP_LOG_VERBOSE("              msg: %s", msg);
 
 
             if (alg_id == ACVP_RSA_SIGVER) {
@@ -503,11 +503,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
     json_array_append_value(reg_arry, r_vs_val);
 
     json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
-        printf("\n\n%s\n\n", json_result);
-    } else {
-        ACVP_LOG_INFO("\n\n%s\n\n", json_result);
-    }
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
     json_free_serialized_string(json_result);
     rv = ACVP_SUCCESS;
 

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -1413,60 +1413,51 @@ static void log_network_status(ACVP_CTX *ctx,
                                ACVP_NET_ACTION action,
                                int curl_code,
                                const char *url) {
+                                   
+    if (curl_code < 200 || curl_code >= 300) {
+        ACVP_LOG_ERR("%d error recieved from server. Message:", curl_code);
+        ACVP_LOG_ERR("%s", ctx->curl_buf);
+    }
+    
     switch(action) {
     case ACVP_NET_GET:
-        ACVP_LOG_STATUS("GET...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
-                        curl_code, url, ctx->curl_buf);
+        ACVP_LOG_INFO("GET...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+                      curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_GET_VS:
-        if (ctx->debug >= ACVP_LOG_LVL_INFO) {
-            ACVP_LOG_STATUS("GET Vector Set...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
-                            curl_code, url, ctx->curl_buf);
-        } else {
-            ACVP_LOG_STATUS("GET Vector Set...\n\tStatus: %d\n\tUrl: %s\n",
-                            curl_code, url);
-        }
+        ACVP_LOG_INFO("GET Vector Set...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_GET_VS_RESULT:
-        ACVP_LOG_STATUS("GET Vector Set Result...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+        ACVP_LOG_INFO("GET Vector Set Result...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_GET_VS_SAMPLE:
-        ACVP_LOG_STATUS("GET Vector Set Sample...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+        ACVP_LOG_INFO("GET Vector Set Sample...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_POST:
-        ACVP_LOG_STATUS("POST...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
+        ACVP_LOG_INFO("POST...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_POST_LOGIN:
-        if (ctx->debug >= ACVP_LOG_LVL_INFO) {
-            ACVP_LOG_STATUS("POST Login...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
-                        curl_code, url, ctx->curl_buf);
-        } else {
-            ACVP_LOG_STATUS("POST Login...\n\tStatus: %d\n\tUrl: %s\n",
-                        curl_code, url);
-        }
+        ACVP_LOG_INFO("POST Login...\n\tStatus: %d\n\tUrl: %s\n\tResp: Recieved\n",
+                      curl_code, url);
         break;
     case ACVP_NET_POST_REG:
-        ACVP_LOG_STATUS("POST Registration...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+        ACVP_LOG_INFO("POST Registration...\n\tStatus: %d\n\tUrl: %s\n\tResp: Recieved\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_POST_VS_RESP:
-        if (ctx->debug >= ACVP_LOG_LVL_INFO) {
-            ACVP_LOG_STATUS("POST Response Submission...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
-                             curl_code, url, ctx->curl_buf);
-        } else {
-            ACVP_LOG_STATUS("POST Response Submission...\n\tStatus: %d\n\tUrl: %s\n",
-                             curl_code, url);
-        }
+        ACVP_LOG_INFO("POST Response Submission...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+                      curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_PUT:
-        ACVP_LOG_STATUS("PUT...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
+        ACVP_LOG_INFO("PUT...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_PUT_VALIDATION:
-        ACVP_LOG_STATUS("PUT testSession Validation...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
+        ACVP_LOG_INFO("PUT testSession Validation...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     default:


### PR DESCRIPTION
-Moved lots of status logging into info logging - mostly network action logging.

-Moved lots of info logging into verbose logging - mostly details of test cases.

-Got rid of some verbose logging - specifically all logging of MCT iterations - just too many lines.

-Removed logging of tokens/any auth bearers regardless of verbosity level.

-Added some logging into status to make flow more easy to understand to end users.
