### PR TITLE
Memory releases in test cases, removed retry backoff

### DIFF
--- a/app/app_aes.c
+++ b/app/app_aes.c
@@ -333,7 +333,7 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
     }
     return rv;
 err:
-    if (cipher_ctx) EVP_CIPHER_CTX_free(cipher_ctx);
+    if (glb_cipher_ctx) EVP_CIPHER_CTX_free(glb_cipher_ctx);
     glb_cipher_ctx = NULL;
     return rv;
 }

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2466,7 +2466,7 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
              */
             acvp_list_failing_algorithms(ctx, &failedAlgList);
             ACVP_LOG_STATUS("TestSession results incomplete...");
-            if (acvp_retry_handler(ctx, &retry_interval, &time_waited_so_far, 2, ACVP_WAITING_FOR_RESULTS) != ACVP_KAT_DOWNLOAD_RETRY) {
+            if (acvp_retry_handler(ctx, &retry_interval, &time_waited_so_far, 1, ACVP_WAITING_FOR_RESULTS) != ACVP_KAT_DOWNLOAD_RETRY) {
                 ACVP_LOG_STATUS("Maximum wait time with server reached! (Max: %d seconds)", ACVP_MAX_WAIT_TIME);
                 rv = ACVP_TRANSPORT_FAIL;
                 goto end;

--- a/test/test_app_aes.c
+++ b/test/test_app_aes.c
@@ -390,6 +390,10 @@ Test(APP_AES_HANDLER, missing_dir) {
     
     rv = app_aes_handler(test_case);
     cr_assert_eq(rv, 0);
+    //skip to last iteration to ensure end works normally as well
+    aes_tc->mct_index = 999;
+    rv = app_aes_handler(test_case);
+    cr_assert_eq(rv, 0);
     
     free_aes_tc(aes_tc);
     free(test_case);

--- a/test/test_app_ecdsa.c
+++ b/test/test_app_ecdsa.c
@@ -126,7 +126,7 @@ void free_ecdsa_tc(ACVP_ECDSA_TC *stc) {
     if (stc->r) { free(stc->r); }
     if (stc->s) { free(stc->s); }
     if (stc->message) { free(stc->message); }
-    memset(stc, 0x0, sizeof(ACVP_ECDSA_TC));
+    free(stc);
 }
 
 // cipher, ecdsa tc, curve, secret gen mode, hash_alg, qx, qy, message, r, s, corrupt
@@ -148,6 +148,7 @@ Test(APP_ECDSA_HANDLER, missing_curve_app) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
 }
 
 /*
@@ -167,6 +168,7 @@ Test(APP_ECDSA_HANDLER, missing_hash_alg_app) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
 }
 
 /*
@@ -189,6 +191,7 @@ Test(APP_ECDSA_HANDLER, missing_keyver_qx_qy) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
 
     /* qy is missing */
     if (!initialize_ecdsa_tc(ACVP_ECDSA_KEYVER, ecdsa_tc, ACVP_EC_CURVE_P256, ACVP_ECDSA_SECRET_GEN_EXTRA_BITS, 0,
@@ -202,6 +205,7 @@ Test(APP_ECDSA_HANDLER, missing_keyver_qx_qy) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
     
     /* qx is missing */
     if (!initialize_ecdsa_tc(ACVP_ECDSA_KEYVER, ecdsa_tc, ACVP_EC_CURVE_P256, ACVP_ECDSA_SECRET_GEN_EXTRA_BITS, 0,
@@ -215,6 +219,7 @@ Test(APP_ECDSA_HANDLER, missing_keyver_qx_qy) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
 }
 
 /*
@@ -234,6 +239,7 @@ Test(APP_ECDSA_HANDLER, missing_siggen_msg) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
 }
 
 /*
@@ -257,6 +263,7 @@ Test(APP_ECDSA_HANDLER, missing_sigver_msg) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
 }
 
 /*
@@ -282,6 +289,7 @@ Test(APP_ECDSA_HANDLER, missing_sigver_r_s) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
 
     /* r is missing */
     if (!initialize_ecdsa_tc(ACVP_ECDSA_SIGVER, ecdsa_tc, ACVP_EC_CURVE_P256, ACVP_ECDSA_SECRET_GEN_EXTRA_BITS, ACVP_SHA256,
@@ -295,6 +303,7 @@ Test(APP_ECDSA_HANDLER, missing_sigver_r_s) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
     
     /* s is missing */
     if (!initialize_ecdsa_tc(ACVP_ECDSA_SIGVER, ecdsa_tc, ACVP_EC_CURVE_P256, ACVP_ECDSA_SECRET_GEN_EXTRA_BITS, ACVP_SHA256,
@@ -308,6 +317,7 @@ Test(APP_ECDSA_HANDLER, missing_sigver_r_s) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
 }
 
 /*
@@ -333,6 +343,7 @@ Test(APP_ECDSA_HANDLER, missing_sigver_qx_qy) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
     
     /* qy is missing */
     if (!initialize_ecdsa_tc(ACVP_ECDSA_SIGVER, ecdsa_tc, ACVP_EC_CURVE_P256, ACVP_ECDSA_SECRET_GEN_EXTRA_BITS, 0,
@@ -346,6 +357,7 @@ Test(APP_ECDSA_HANDLER, missing_sigver_qx_qy) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
     
     /* qx is missing */
     if (!initialize_ecdsa_tc(ACVP_ECDSA_SIGVER, ecdsa_tc, ACVP_EC_CURVE_P256, ACVP_ECDSA_SECRET_GEN_EXTRA_BITS, 0,
@@ -359,6 +371,7 @@ Test(APP_ECDSA_HANDLER, missing_sigver_qx_qy) {
     cr_assert_neq(rv, 0);
     
     free_ecdsa_tc(ecdsa_tc);
+    free(test_case);
 }
 
 #endif // ACVP_NO_RUNTIME

--- a/test/test_app_kas_ecc.c
+++ b/test/test_app_kas_ecc.c
@@ -30,7 +30,7 @@ void free_kas_ecc_tc(ACVP_KAS_ECC_TC *stc) {
     if (stc->piy) free(stc->piy);
     if (stc->d) free(stc->d);
     if (stc->z) free(stc->z);
-    memzero_s(stc, sizeof(ACVP_KAS_ECC_TC));
+    free(stc);
 }
 
 int initialize_kas_ecc_cdh_tc(ACVP_KAS_ECC_TC *stc,
@@ -211,6 +211,7 @@ Test(APP_KAS_ECC_HANDLER, invalid_curve) {
     cr_assert_neq(rv, 0);
     
     free_kas_ecc_tc(kas_ecc_tc);
+    free(test_case);
 }
 
 /*
@@ -240,6 +241,7 @@ Test(APP_KAS_ECC_HANDLER, invalid_hash_ecc_comp) {
     cr_assert_neq(rv, 0);
     
     free_kas_ecc_tc(kas_ecc_tc);
+    free(test_case);
 }
 
 /*
@@ -266,6 +268,7 @@ Test(APP_KAS_ECC_HANDLER, missing_psx) {
     cr_assert_neq(rv, 0);
     
     free_kas_ecc_tc(kas_ecc_tc);
+    free(test_case);
 }
 
 /*
@@ -292,6 +295,7 @@ Test(APP_KAS_ECC_HANDLER, missing_psy) {
     cr_assert_neq(rv, 0);
     
     free_kas_ecc_tc(kas_ecc_tc);
+    free(test_case);
 }
 
 /*
@@ -321,6 +325,7 @@ Test(APP_KAS_ECC_HANDLER, missing_pix) {
     cr_assert_neq(rv, 0);
     
     free_kas_ecc_tc(kas_ecc_tc);
+    free(test_case);
 }
 
 /*
@@ -350,6 +355,7 @@ Test(APP_KAS_ECC_HANDLER, missing_piy) {
     cr_assert_neq(rv, 0);
     
     free_kas_ecc_tc(kas_ecc_tc);
+    free(test_case);
 }
 
 #endif // ACVP_NO_RUNTIME

--- a/test/test_app_kas_ffc.c
+++ b/test/test_app_kas_ffc.c
@@ -32,7 +32,7 @@ void free_kas_ffc_tc(ACVP_KAS_FFC_TC *stc) {
     if (stc->p) free(stc->p);
     if (stc->q) free(stc->q);
     if (stc->g) free(stc->g);
-    memzero_s(stc, sizeof(ACVP_KAS_FFC_TC));
+    free(stc);
 }
 
 int initialize_kas_ffc_tc(ACVP_KAS_FFC_TC *stc,
@@ -139,8 +139,7 @@ int initialize_kas_ffc_tc(ACVP_KAS_FFC_TC *stc,
     }
     
     return 1;
-    
-    err:
+err:
     free_kas_ffc_tc(stc);
     return 0;
 }
@@ -172,6 +171,7 @@ Test(APP_KAS_FFC_HANDLER, invalid_hash_alg) {
     cr_assert_neq(rv, 0);
     
     free_kas_ffc_tc(kas_ffc_tc);
+    free(test_case);
 }
 
 /*
@@ -201,6 +201,7 @@ Test(APP_KAS_FFC_HANDLER, missing_p) {
     cr_assert_neq(rv, 0);
     
     free_kas_ffc_tc(kas_ffc_tc);
+    free(test_case);
 }
 
 /*
@@ -230,6 +231,7 @@ Test(APP_KAS_FFC_HANDLER, missing_q) {
     cr_assert_neq(rv, 0);
     
     free_kas_ffc_tc(kas_ffc_tc);
+    free(test_case);
 }
 
 /*
@@ -259,6 +261,7 @@ Test(APP_KAS_FFC_HANDLER, missing_g) {
     cr_assert_neq(rv, 0);
     
     free_kas_ffc_tc(kas_ffc_tc);
+    free(test_case);
 }
 
 /*
@@ -288,6 +291,7 @@ Test(APP_KAS_FFC_HANDLER, missing_eps) {
     cr_assert_neq(rv, 0);
     
     free_kas_ffc_tc(kas_ffc_tc);
+    free(test_case);
 }
 
 /*
@@ -317,6 +321,7 @@ Test(APP_KAS_FFC_HANDLER, missing_epri) {
     cr_assert_neq(rv, 0);
     
     free_kas_ffc_tc(kas_ffc_tc);
+    free(test_case);
 }
 
 /*
@@ -346,6 +351,7 @@ Test(APP_KAS_FFC_HANDLER, missing_epui) {
     cr_assert_neq(rv, 0);
     
     free_kas_ffc_tc(kas_ffc_tc);
+    free(test_case);
 }
 
 /*
@@ -376,6 +382,7 @@ Test(APP_KAS_FFC_HANDLER, missing_z) {
     cr_assert_neq(rv, 0);
     
     free_kas_ffc_tc(kas_ffc_tc);
+    free(test_case);
 }
 
 /*
@@ -405,6 +412,7 @@ Test(APP_KAS_FFC_HANDLER, unallocated_ans_bufs) {
     cr_assert_neq(rv, 0);
     
     free_kas_ffc_tc(kas_ffc_tc);
+    free(test_case);
 }
 
 #endif // ACVP_NO_RUNTIME

--- a/test/test_app_rsa_keygen.c
+++ b/test/test_app_rsa_keygen.c
@@ -29,7 +29,7 @@ void free_rsa_keygen_tc(ACVP_RSA_KEYGEN_TC *stc) {
     if (stc->q) { free(stc->q); }
     if (stc->n) { free(stc->n); }
     if (stc->d) { free(stc->d); }
-    memzero_s(stc, sizeof(ACVP_RSA_KEYGEN_TC));
+    free(stc);
 }
 
 int initialize_rsa_tc(ACVP_RSA_KEYGEN_TC *stc,
@@ -132,6 +132,7 @@ Test(APP_RSA_KEYGEN_HANDLER, invalid_hash_alg) {
     cr_assert_neq(rv, 0);
     
     free_rsa_keygen_tc(rsa_tc);
+    free(test_case);
 }
 
 /*
@@ -163,6 +164,7 @@ Test(APP_RSA_KEYGEN_HANDLER, invalid_key_format) {
     cr_assert_neq(rv, 0);
     
     free_rsa_keygen_tc(rsa_tc);
+    free(test_case);
 }
 
 /*
@@ -194,6 +196,7 @@ Test(APP_RSA_KEYGEN_HANDLER, invalid_pub_exp_mode) {
     cr_assert_neq(rv, 0);
     
     free_rsa_keygen_tc(rsa_tc);
+    free(test_case);
 }
 
 /*
@@ -225,6 +228,7 @@ Test(APP_RSA_KEYGEN_HANDLER, invalid_modulo) {
     cr_assert_neq(rv, 0);
     
     free_rsa_keygen_tc(rsa_tc);
+    free(test_case);
 }
 
 /*
@@ -256,6 +260,7 @@ Test(APP_RSA_KEYGEN_HANDLER, invalid_prime_test) {
     cr_assert_neq(rv, 0);
     
     free_rsa_keygen_tc(rsa_tc);
+    free(test_case);
 }
 
 /*
@@ -287,6 +292,7 @@ Test(APP_RSA_KEYGEN_HANDLER, invalid_rand_pq) {
     cr_assert_neq(rv, 0);
     
     free_rsa_keygen_tc(rsa_tc);
+    free(test_case);
 }
 
 /*
@@ -318,6 +324,7 @@ Test(APP_RSA_KEYGEN_HANDLER, missing_e) {
     cr_assert_neq(rv, 0);
     
     free_rsa_keygen_tc(rsa_tc);
+    free(test_case);
 }
 
 /*
@@ -349,6 +356,7 @@ Test(APP_RSA_KEYGEN_HANDLER, missing_seed) {
     cr_assert_neq(rv, 0);
     
     free_rsa_keygen_tc(rsa_tc);
+    free(test_case);
 }
 
 /*
@@ -380,6 +388,7 @@ Test(APP_RSA_KEYGEN_HANDLER, unallocated_ans_bufs) {
     cr_assert_neq(rv, 0);
     
     free_rsa_keygen_tc(rsa_tc);
+    free(test_case);
 }
 
 #endif // ACVP_NO_RUNTIME

--- a/test/test_app_rsa_sig.c
+++ b/test/test_app_rsa_sig.c
@@ -28,7 +28,7 @@ void free_rsa_sig_tc(ACVP_RSA_SIG_TC *stc) {
     if (stc->n) { free(stc->n); }
     if (stc->signature) { free(stc->signature); }
     if (stc->salt) { free(stc->salt); }
-    memzero_s(stc, sizeof(ACVP_RSA_SIG_TC));
+    free(stc);
 }
 
 int initialize_rsa_sig_tc(ACVP_CIPHER cipher,
@@ -154,6 +154,7 @@ Test(APP_RSA_SIG_HANDLER, invalid_hash_alg) {
     cr_assert_neq(rv, 0);
     
     free_rsa_sig_tc(rsa_sig_tc);
+    free(test_case);
 }
 
 #endif // ACVP_NO_RUNTIME


### PR DESCRIPTION
Adding frees to still reachable blocks in test cases - objective is to ensure issues reported by valgrind are relevant to the actual software and not TCs as we update pipeline internally soon.

Removed retry backoff. 