### PR TITLE
Added resume session feature

### DIFF
--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -38,6 +38,7 @@ typedef struct app_config {
     int vector_upload;
     int get;
     int get_results;
+    int resume_session;
     int post;
     int put;
     int kat;
@@ -49,6 +50,7 @@ typedef struct app_config {
     char vector_upload_file[JSON_FILENAME_LENGTH + 1];
     char get_string[JSON_REQUEST_LENGTH + 1];
     char get_results_file[JSON_FILENAME_LENGTH + 1];
+    char resume_session_file[JSON_FILENAME_LENGTH + 1];
     char post_filename[JSON_FILENAME_LENGTH + 1];
     char put_filename[JSON_FILENAME_LENGTH + 1];
     char kat_file[JSON_FILENAME_LENGTH + 1];

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -229,7 +229,6 @@ int main(int argc, char **argv) {
         goto end;
     }
 
-
     if (cfg.json) {
         /*
          * Using a JSON to register allows us to skip the
@@ -343,9 +342,14 @@ int main(int argc, char **argv) {
     if (!cfg.empty_alg && cfg.put) {
         acvp_mark_as_put_after_test(ctx, cfg.put_filename);
     }
-
+    
     if (cfg.get_results) {
         rv = acvp_get_results_from_server(ctx, cfg.get_results_file);
+        goto end;
+    }
+    
+    if (cfg.resume_session) {
+        rv = acvp_resume_test_session(ctx, cfg.resume_session_file, cfg.fips_validation);
         goto end;
     }
     

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -2632,6 +2632,7 @@ ACVP_RESULT acvp_upload_vectors_from_file(ACVP_CTX *ctx, const char *rsp_filenam
 ACVP_RESULT acvp_run_vectors_from_file(ACVP_CTX *ctx, const char *req_filename, const char *rsp_filename);
 ACVP_RESULT acvp_put_data_from_file(ACVP_CTX *ctx, const char *put_filename);
 ACVP_RESULT acvp_get_results_from_server(ACVP_CTX *ctx, const char *request_filename);
+ACVP_RESULT acvp_resume_test_session(ACVP_CTX *ctx, const char *request_filename, int fips_validation);
 
 /*! @brief acvp_set_2fa_callback() sets a callback function which
     will create or obtain a TOTP password for the second part of

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1141,8 +1141,7 @@ ACVP_RESULT acvp_upload_vectors_from_file(ACVP_CTX *ctx, const char *rsp_filenam
         ACVP_LOG_STATUS("Sending responses for vector set %d", ctx->vs_id);
         rv = acvp_submit_vector_responses(ctx, vs_entry->string);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Failed to submit test results");
-            goto end;
+            ACVP_LOG_ERR("Failed to submit test results for vector set - skipping...");
         }
 
         n++;
@@ -1245,6 +1244,217 @@ ACVP_RESULT acvp_get_results_from_server(ACVP_CTX *ctx, const char *request_file
         ACVP_LOG_ERR("Unable to retrieve test results");
     }
     
+end:
+    json_value_free(val);
+    return rv;
+}
+
+/**
+ * Allows application to continue a previous test session by checking which KAT responses the server is missing
+ */
+ACVP_RESULT acvp_resume_test_session(ACVP_CTX *ctx, const char *request_filename, int fips_validation) {
+    JSON_Value *val = NULL;
+    JSON_Array *reg_array;
+    JSON_Object *obj = NULL;
+    const char *test_session_url = NULL;
+    const char *jwt = NULL;
+    ACVP_RESULT rv = ACVP_SUCCESS;
+
+    if (!ctx) {
+        return ACVP_NO_CTX;
+    }
+    if (!request_filename) {
+        ACVP_LOG_ERR("Must provide value for JSON filename");
+        return ACVP_MISSING_ARG;
+    }
+    
+    if (strnlen_s(request_filename, ACVP_JSON_FILENAME_MAX + 1) > ACVP_JSON_FILENAME_MAX) {
+        ACVP_LOG_ERR("Provided request_filename length > max(%d)", ACVP_JSON_FILENAME_MAX);
+        return ACVP_INVALID_ARG;
+    }
+    
+    val = json_parse_file(request_filename);
+    if (!val) {
+        ACVP_LOG_ERR("JSON val parse error");
+        return ACVP_MALFORMED_JSON;
+    }
+    reg_array = json_value_get_array(val);
+    obj = json_array_get_object(reg_array, 0);
+    if (!obj) {
+        ACVP_LOG_ERR("JSON obj parse error");
+        rv = ACVP_MALFORMED_JSON;
+        goto end;
+    }
+
+    test_session_url = json_object_get_string(obj, "url");
+    if (!test_session_url) {
+        ACVP_LOG_ERR("Missing session URL");
+        rv = ACVP_MALFORMED_JSON;
+        goto end;
+    }
+
+    ctx->session_url = calloc(ACVP_ATTR_URL_MAX + 1, sizeof(char));
+    if (!ctx->session_url) {
+        rv = ACVP_MALLOC_FAIL;
+        goto end;
+    }
+    strcpy_s(ctx->session_url, ACVP_ATTR_URL_MAX + 1, test_session_url);
+
+    jwt = json_object_get_string(obj, "jwt");
+    if (!jwt) {
+        rv = ACVP_MALFORMED_JSON;
+        goto end;
+    }
+    ctx->jwt_token = calloc(ACVP_JWT_TOKEN_MAX + 1, sizeof(char));
+    if (!ctx->jwt_token) {
+        rv = ACVP_MALLOC_FAIL;
+        goto end;
+    }
+    strcpy_s(ctx->jwt_token, ACVP_JWT_TOKEN_MAX + 1, jwt);
+    
+    json_value_free(val);
+    val = NULL;
+    obj = NULL;
+
+    rv = acvp_retrieve_vector_set_result(ctx, ctx->session_url);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Error retrieving vector set results!");
+        goto end;
+    }
+
+    val = json_parse_string(ctx->curl_buf);
+    if (!val) {
+        ACVP_LOG_ERR("Error while parsing json from server!");
+        rv = ACVP_JSON_ERR;
+        goto end;
+    }
+    obj = acvp_get_obj_from_rsp(ctx, val);
+    if (!obj) {
+        if (val) json_value_free(val);
+        ACVP_LOG_ERR("Error while parsing json from server!");
+        rv = ACVP_JSON_ERR;
+        goto end;
+    }
+
+    if (fips_validation) {
+        rv = fips_metadata_ready(ctx);
+        if (ACVP_SUCCESS != rv) {
+            ACVP_LOG_ERR("Validation metadata not ready");
+            return ACVP_UNSUPPORTED_OP;
+        }
+
+        ctx->fips.do_validation = 1; /* Enable */
+    } else {
+        ctx->fips.do_validation = 0; /* Disable */
+    }
+    /*
+     * Check for vector sets the server received no response to
+     */
+
+    JSON_Array *results = NULL;
+    int count = 0, i = 0;
+
+    results = json_object_get_array(obj, "results");
+    if (!results) {
+        ACVP_LOG_ERR("Error parsing status from server");
+        rv = ACVP_JSON_ERR;
+        goto end;
+    }
+    
+    count = (int)json_array_get_count(results);
+    JSON_Object *current = NULL;
+    const char *vsid_url = NULL, *status = NULL;
+    
+    for (i = 0; i < count; i++) {
+        int diff = 1;
+        current = json_array_get_object(results, i);
+        if (!current) {
+            ACVP_LOG_ERR("Error parsing status from server");
+            rv = ACVP_JSON_ERR;
+            goto end;
+        }
+        
+        status = json_object_get_string(current, "status");
+        if (!status) {
+            ACVP_LOG_ERR("Error parsing status from server");
+            rv = ACVP_JSON_ERR;
+            goto end;
+        }
+        vsid_url = json_object_get_string(current, "vectorSetUrl");
+        if (!vsid_url) {
+            ACVP_LOG_ERR("Error parsing status from server");
+            rv = ACVP_JSON_ERR;
+            goto end;
+        }
+        
+        if (ctx->vector_req) {
+            //If we are just saving to file, we don't need to check status, download all VS
+            rv = acvp_append_vsid_url(ctx, vsid_url);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("Error resuming session");
+                goto end;
+            }
+        } else {
+            strcmp_s("expired", 7, status, &diff);
+            if (!diff) {
+                ACVP_LOG_ERR("One more more vector sets has expired! Start a new session.");
+                rv = ACVP_INVALID_ARG;
+                goto end;
+            }
+            
+            /*
+             * If the result is unreceived, add it to the list of vsID urls
+             */
+            strcmp_s("unreceived", 10, status, &diff);
+            if (!diff) {
+                rv = acvp_append_vsid_url(ctx, vsid_url);
+                if (rv != ACVP_SUCCESS) {
+                    ACVP_LOG_ERR("Error resuming session");
+                    goto end;
+                }
+            }
+        }
+    }
+
+    if (!ctx->vsid_url_list) {
+        ACVP_LOG_STATUS("All vector set results already uploaded. Nothing to resume.");
+        goto end;
+    } else {
+        rv = acvp_process_tests(ctx);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("Failed to process vectors");
+            goto end;
+        }
+        if (ctx->vector_req) {
+            ACVP_LOG_STATUS("Successfully downloaded vector sets and saved to specified file.");
+            return ACVP_SUCCESS;
+        }
+
+        /*
+         * Check the test results.
+         */
+        ACVP_LOG_STATUS("Tests complete, checking results...");
+        rv = acvp_check_test_results(ctx);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("Unable to retrieve test results");
+            goto end;
+        }
+
+        if (fips_validation) {
+            /*
+             * Tell the server to provision a FIPS certificate for this testSession.
+             */
+            rv = acvp_validate_test_session(ctx);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("Failed to perform Validation of testSession");
+                goto end;
+            }
+        }
+
+        if (ctx->put) {
+           rv = acvp_put_data_from_ctx(ctx);
+        }
+    }
 end:
     json_value_free(val);
     return rv;
@@ -2376,6 +2586,17 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
             if (!status) {
                 goto end;
             }
+            strcmp_s("expired", 7, status, &diff);
+            if (!diff) {
+                ACVP_LOG_ERR("One or more vector sets expired before results were submitted. Please start a new test session.");
+                goto end;
+            }
+            
+            strcmp_s("unreceived", 10, status, &diff);
+            if (!diff) {
+                ACVP_LOG_ERR("Missing submissions for one or more vector sets. Please submit responses for all vector sets.");
+                goto end;
+            }
             /*
              * If the result is incomplete, set the flag so it keeps retrying
              */
@@ -2490,6 +2711,7 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
                 if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
                     ACVP_LOG_STATUS("Getting details for failed Vector Set...");
                     rv = acvp_retrieve_vector_set_result(ctx, vs_url);
+                    printf("\n%s\n", ctx->curl_buf);
                     if (rv != ACVP_SUCCESS) goto end;
                 }
                 /*
@@ -2754,6 +2976,11 @@ ACVP_RESULT acvp_run(ACVP_CTX *ctx, int fips_validation) {
         ACVP_LOG_ERR("Failed to register with ACVP server");
         goto end;
     }
+    
+    //write session info so if we time out or lose connection waiting for results, we can recheck later on
+    if (!ctx->put) {
+        acvp_write_session_info(ctx);
+    }
 
     ACVP_LOG_STATUS("Beginning to download and process vector sets...");
 
@@ -2769,11 +2996,6 @@ ACVP_RESULT acvp_run(ACVP_CTX *ctx, int fips_validation) {
     if (ctx->vector_req) {
         ACVP_LOG_STATUS("Successfully downloaded vector sets and saved to specified file.");
         return ACVP_SUCCESS;
-    }
-
-    //write session info so if we time out or lose connection waiting for results, we can recheck later on
-    if (!ctx->put) {
-        acvp_write_session_info(ctx);
     }
 
     /*

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1259,6 +1259,11 @@ ACVP_RESULT acvp_resume_test_session(ACVP_CTX *ctx, const char *request_filename
     const char *test_session_url = NULL;
     const char *jwt = NULL;
     ACVP_RESULT rv = ACVP_SUCCESS;
+    
+    ACVP_LOG_STATUS("Resuming session...");
+    if (ctx->vector_req) {
+        ACVP_LOG_STATUS("Restarting download of vector sets to file...");
+    }
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -2388,11 +2393,12 @@ static ACVP_RESULT acvp_process_vsid(ACVP_CTX *ctx, char *vsid_url, int count) {
             };
             retry = 1;
         } else {
-
             /*
              * Save the KAT VectorSet to file
              */
             if (ctx->vector_req) {
+                
+                ACVP_LOG_STATUS("Saving vector set %s to file...", vsid_url);
                 alg_array = json_value_get_array(val);
                 alg_val = json_array_get_value(alg_array, 1);
 

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -785,3 +785,21 @@ Test(PROCESS_TESTS, acvp_get_results_from_server, .init = setup_full_ctx, .fini 
     rv = acvp_get_results_from_server(ctx, "json/getResults.json");
     cr_assert(rv = ACVP_MALFORMED_JSON);
 }
+
+/*
+ * Test acvp_resume_test_session
+ */
+Test(PROCESS_TESTS, acvp_resume_test_session, .init = setup_full_ctx, .fini = teardown) {
+   
+    rv = acvp_resume_test_session(NULL, "test", 0);
+    cr_assert(rv == ACVP_NO_CTX);
+
+    rv = acvp_resume_test_session(ctx, NULL, 0);
+    cr_assert(rv == ACVP_MISSING_ARG);
+
+    rv = acvp_resume_test_session(ctx, "testFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLong", 0);
+    cr_assert(rv == ACVP_INVALID_ARG);
+
+    rv = acvp_resume_test_session(ctx, "json/getResults.json", 1);
+    cr_assert(rv = ACVP_MALFORMED_JSON);
+}


### PR DESCRIPTION
--new API function acvp_resume_test_session
--Checks the results of a stored test session, finds vector set URLs with "unreceived" status, downloads those URLs, processes, and uploads
--new acvp_app argument, --resume_session <filename>

if --downloading vectors using --vector_req, it doesn't check status (nothing to check), just downloads all vector sets

Updated --vector_upload so it doesnt stop working if re-submitting a response, just skips instead

Added printf for verbose debugging that was missing