### PR TITLE
Update to use libssl1.1 instead of 1.0

### DIFF
--- a/.muse/setup.sh
+++ b/.muse/setup.sh
@@ -1,5 +1,5 @@
 if [ $(whoami) = "root" ]; then
-    apt install -y libssl1.0-dev libcurl4-gnutls-dev
+    apt install -y libssl1.1-dev libcurl4-gnutls-dev
 fi
 
 cd $1


### PR DESCRIPTION
LibSSL 1.0 isn't in Ubuntu 20.04, which is the new base image used by the MuseDev analysis system.