### PR TITLE
Updated some functionality around using registration files

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -58,19 +58,14 @@ static void print_usage(int err) {
     printf("      --drbg\n");
     printf("      --kas_ecc\n");
     printf("\n");
-    printf("To resume a previous test session that was interupted:\n");
-    printf("      --resume_session <file>\n");
-    printf("Note: this does not save your arguments from your initial run and you MUST include them\n");
-    printf("again (e.x. --aes,  --vector_req and --fips_validation)\n");
-    printf("\n");
     printf("Perform a FIPS Validation for this testSession:\n");
     printf("      --fips_validation <full metadata file>\n");
     printf("\n");
     printf("To specify a cert number associated with all prerequistes:\n");
     printf("      --certnum <string>\n");
     printf("\n");
-    printf("To register a formatted JSON file use:\n");
-    printf("      --json <file>\n");
+    printf("To register manually using a JSON file instead of application settings use:\n");
+    printf("      --manual_registration <file>\n");
     printf("\n");
     printf("To register and save the vectors to file:\n");
     printf("      --vector_req <file>\n");
@@ -84,6 +79,13 @@ static void print_usage(int err) {
     printf("\n");
     printf("To process kat vectors from a JSON file use:\n");
     printf("      --kat <file>\n");
+    printf("\n");
+    printf("Note: --resume_session and --get_results use the test session info file created automatically by the library as input\n");
+    printf("\n");
+    printf("To resume a previous test session that was interupted:\n");
+    printf("      --resume_session <file>\n");
+    printf("            Note: this does not save your arguments from your initial run and you MUST include them\n");
+    printf("            again (e.x. --aes,  --vector_req and --fips_validation)\n");
     printf("\n");
     printf("To get the results of a previous test session:\n");
     printf("      --get_results <file>\n");
@@ -171,7 +173,7 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
         { "ecdsa", ko_no_argument, 319 },
         { "kas_ecc", ko_no_argument, 320 },
         { "all_algs", ko_no_argument, 322 },
-        { "json", ko_required_argument, 400 },
+        { "manual_registration", ko_required_argument, 400 },
         { "kat", ko_required_argument, 401 },
         { "fips_validation", ko_required_argument, 402 },
         { "vector_req", ko_required_argument, 403 },
@@ -305,19 +307,19 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
         }
         if (c == 400) {
             int filename_len = 0;
-            cfg->json = 1;
+            cfg->manual_reg = 1;
 
             filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
             if (filename_len > JSON_FILENAME_LENGTH) {
                 printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
                        "\nThe <file> \"%s\", has a name that is too long."
                        "\nMax allowed <file> name length is (%d).\n",
-                       "--json", opt.arg, JSON_FILENAME_LENGTH);
+                       "--manual_registration", opt.arg, JSON_FILENAME_LENGTH);
                 print_usage(1);
                 return 1;
             }
 
-            strcpy_s(cfg->json_file, JSON_FILENAME_LENGTH + 1, opt.arg);
+            strcpy_s(cfg->reg_file, JSON_FILENAME_LENGTH + 1, opt.arg);
             continue;
         }
         if (c == 401) {
@@ -527,7 +529,7 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
 
     /* allopw put, post and get without algs defined */
     if (cfg->empty_alg && !cfg->post && !cfg->get && !cfg->put && !cfg->get_results
-                                                              && !cfg->vector_upload) {
+                                        && !cfg->manual_reg && !cfg->vector_upload) {
         /* The user needs to select at least 1 algorithm */
         printf(ANSI_COLOR_RED "Requires at least 1 Algorithm Test Suite\n"ANSI_COLOR_RESET);
         print_usage(1);

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -33,7 +33,7 @@ char value[JSON_STRING_LENGTH];
 typedef struct app_config {
     ACVP_LOG_LVL level;
     int sample;
-    int json;
+    int manual_reg;
     int vector_req;
     int vector_rsp;
     int vector_upload;
@@ -45,7 +45,7 @@ typedef struct app_config {
     int kat;
     int empty_alg;
     int fips_validation;
-    char json_file[JSON_FILENAME_LENGTH + 1];
+    char reg_file[JSON_FILENAME_LENGTH + 1];
     char vector_req_file[JSON_FILENAME_LENGTH + 1];
     char vector_rsp_file[JSON_FILENAME_LENGTH + 1];
     char vector_upload_file[JSON_FILENAME_LENGTH + 1];

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -242,13 +242,13 @@ int main(int argc, char **argv) {
         goto end;
     }
 
-    if (cfg.json) {
+    if (cfg.manual_reg) {
         /*
          * Using a JSON to register allows us to skip the
          * "acvp_enable_*" API calls... could reduce the
          * size of this file if you choose to use this capability.
          */
-        rv = acvp_set_json_filename(ctx, cfg.json_file);
+        rv = acvp_set_json_filename(ctx, cfg.reg_file);
         if (rv != ACVP_SUCCESS) {
             printf("Failed to set json file within ACVP ctx (rv=%d)\n", rv);
             goto end;

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -263,6 +263,8 @@ Test(SET_SESSION_PARAMS, null_params_2fa, .init = setup, .fini = teardown) {
  * This test sets json filename
  */
 Test(SET_SESSION_PARAMS, set_input_json_good, .init = setup, .fini = teardown) {
+    rv = acvp_mark_as_request_only(ctx, "test.json");
+    cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_set_json_filename(ctx, filename);
     cr_assert(rv == ACVP_SUCCESS);
 }


### PR DESCRIPTION
--json option for acvp_app changed to --manual_registration

acvp_set_json_filename can now only be used if acvp_mark_as_request_only has been used

Updated logic to properly run session with registration filename