### PR TITLE
Bugfix/vendor lookup

### DIFF
--- a/src/acvp_operating_env.c
+++ b/src/acvp_operating_env.c
@@ -1895,7 +1895,7 @@ static ACVP_RESULT query_vendor(ACVP_CTX *ctx,
                  ctx->path_segment, "vendors?");
 
         if (vendor->name) {
-            rv = acvp_kv_list_append(&parameters, "name[0]=contains:", vendor->name);
+            rv = acvp_kv_list_append(&parameters, "name[0]=eq:", vendor->name);
             if (ACVP_SUCCESS != rv) {
                 ACVP_LOG_ERR("Failed acvp_kv_list_append()");
                 goto end;

--- a/src/acvp_operating_env.c
+++ b/src/acvp_operating_env.c
@@ -1913,6 +1913,10 @@ static ACVP_RESULT query_vendor(ACVP_CTX *ctx,
         /* Query using the first email in the list */
         if (vendor->emails) {
             rv = acvp_kv_list_append(&parameters, "email[0]=eq:", vendor->emails->string);
+            if (ACVP_SUCCESS != rv) {
+                ACVP_LOG_ERR("Failed acvp_kv_list_append()");
+                goto end;
+            }
         }
     }
 

--- a/src/acvp_operating_env.c
+++ b/src/acvp_operating_env.c
@@ -1909,6 +1909,11 @@ static ACVP_RESULT query_vendor(ACVP_CTX *ctx,
                 goto end;
             }
         }
+        
+        /* Query using the first email in the list */
+        if (vendor->emails) {
+            rv = acvp_kv_list_append(&parameters, "email[0]=eq:", vendor->emails->string);
+        }
     }
 
 

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -1246,13 +1246,14 @@ static ACVP_RESULT inspect_http_code(ACVP_CTX *ctx, int code) {
             goto end;
         }
 
-        tmp_err_str = calloc(sizeof(char), strnlen_s(err_str, ACVP_CURL_BUF_MAX) + 1);
+        int err_str_len = strnlen_s(err_str, ACVP_CURL_BUF_MAX);
+        tmp_err_str = calloc(sizeof(char), err_str_len + 1);
         if (!tmp_err_str) {
         ACVP_LOG_WARN("Issue while allocating memory to check message from server, trying to continue...");
             goto end;
         }
 
-        if (strncpy_s(tmp_err_str, ACVP_CURL_BUF_MAX, err_str, ACVP_CURL_BUF_MAX)) {
+        if (strncpy_s(tmp_err_str, err_str_len + 1, err_str, err_str_len)) {
         ACVP_LOG_WARN("Issue while checking message from server, trying to continue...");
             goto end;
         }


### PR DESCRIPTION
Removed recursion from database lookups, using a do-while loop instead.
Removed "page limit" from database lookups, simply continuing to search pages as long as "nextPage" exists. 
Added email to the initial query to shorten the amount of returned results, speed things up, and reduce risk of wrong vendors being selected.
Fixed issue with strncpy_s boundaries for refreshing JWT mid session.

Tested briefly with generic/cisco metadata, but hard to thoroughly test until NIST resolves URL formatting.
