### PR TITLE
Added ability to change path/prefix for session info file

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,17 @@ CROSS_COMPILE=arm-linux-gnueabihf-
 HOSTCC=gcc
 
 ## Running
-1. `export LD_LIBRARY_PATH=<path to ssl lib>`
+1. `export LD_LIBRARY_PATH=<path to ssl lib;path to curl lib>`
 2. Modify and run `scripts/nist_setup.sh`
 3. `./app/acvp_app --<options>`
 
 Use `./app/acvp_app --help` for more information on available options.
+
+libacvp generates a file containing information that can be used to resume or check the results
+of a session. By default, this is usually placed in the folder of the executable utilizing
+libacvp, though this can be different on some OS. The name, by default, is
+testSession_(ID number).json. The path and prefix can be controlled using ACV_SESSION_SAVE_PATH
+and ACV_SESSION_SAVE_PREFIX in your environment, respectively. 
 
 ## Windows
 The Visual Studio projects for acvp_app and libacvp are set to use 2017 tools and are designed to

--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -111,9 +111,20 @@ static void print_usage(int err) {
     printf("    ACV_TOTP_SEED (when not set, client will not use Two-factor authentication)\n");
     printf("    ACV_CA_FILE\n");
     printf("    ACV_CERT_FILE\n");
-    printf("    ACV_KEY_FILE\n\n");
+    printf("    ACV_KEY_FILE\n");
     printf("The CA certificates, cert and key should be PEM encoded. There should be no\n");
-    printf("password on the key file.\n");
+    printf("password on the key file.\n\n");
+    printf("Some options can be passed to the library itself with environment variables:\n\n");
+    printf("    ACV_SESSION_SAVE_PATH (Location where test session info files are saved)\n");
+    printf("    ACV_SESSION_SAVE_PREFIX (Determines file name of info file, followed by ID number\n");
+    printf("    The following are used by the library for an HTTP user-agent string, only when\n");
+    printf("    the information cannot be automatically collected:\n");
+    printf("        ACV_OE_OSNAME\n");
+    printf("        ACV_OE_OSVERSION\n");
+    printf("        ACV_OE_ARCHITECTURE\n");
+    printf("        ACV_OE_PROCESSOR\n");
+    printf("        ACV_OE_COMPILER\n\n");
+
 }
 
 static void default_config(APP_CONFIG *cfg) {

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -704,6 +704,12 @@
 #define ACVP_PATH_SEGMENT_DEFAULT ""
 #define ACVP_JSON_FILENAME_MAX 128
 
+/* 
+ * This should NOT be made longer than ACVP_JSON_FILENAME_MAX - 15
+ * (accounting for _ character, ".json", and 9 digits for testSession ID)
+ */
+#define ACVP_SAVE_DEFAULT_PREFIX "testSession"
+
 #define ACVP_CFB1_BIT_MASK      0x80
 
 

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -3005,7 +3005,7 @@ static ACVP_RESULT acvp_write_session_info(ACVP_CTX *ctx) {
         goto end;
     }
 end:
-    if (allocedPrefix) free(prefix);
+    if (allocedPrefix && prefix) free(prefix);
     if (ts_val) json_value_free(ts_val);
     free(filename);
     return rv;


### PR DESCRIPTION
ACV_SESSION_SAVE_PATH can be used to define the location to save the file in. 

ACV_SESSION_SAVE_PREFIX can be used to define the prefix of the test session file. The default prefix remains "testSession". The format for the file will always be <prefix>_<ID number>.json.

In the case of an invalid path or prefix (or ones that are too long combined), we revert to the default setting - using testSession and whatever the OS decides for path (usually application directory).

In the case of valid path/prefix, but an error occurs while writing the file, the session will continue without writing a testSession file, but prints an error to the log. Usually would happen in case of folder not existing, or in case of not having write permissions to folder.

Given path and prefix may result in full file path exceeding ACVP_JSON_FILENAME_MAX, currently 128 chars. 

Updated readme and app docs.