### PR TITLE
logging updates, formatting/logic fixes

### DIFF
--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -529,6 +529,12 @@ typedef enum acvp_hash_testtype {
     ACVP_HASH_TEST_TYPE_VOT
 } ACVP_HASH_TESTTYPE;
 
+/*! @struct ACVP_CMAC_TESTTYPE */
+typedef enum acvp_cmac_testtype {
+    ACVP_CMAC_TEST_TYPE_NONE = 0,
+    ACVP_CMAC_TEST_TYPE_AFT
+} ACVP_CMAC_TESTTYPE;
+
 /*! @struct ACVP_HMAC_PARM */
 typedef enum acvp_hmac_parameter {
     ACVP_HMAC_KEYLEN = 1,
@@ -897,6 +903,7 @@ typedef struct acvp_hmac_tc_t {
  */
 typedef struct acvp_cmac_tc_t {
     ACVP_CIPHER cipher;
+    ACVP_CMAC_TESTTYPE test_type;
     int verify;                            /**< 1 indicates verify. 0 indicates generate. */
     ACVP_TEST_DISPOSITION ver_disposition; /**< Indicates pass/fail (only in "verify" direction)*/
     unsigned int tc_id;                    /* Test case id */

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -85,6 +85,15 @@
 } while (0)
 #endif
 #endif
+#define ACVP_LOG_NEWLINE do { \
+        acvp_log_newline(ctx); \
+} while (0)
+
+
+#define ACVP_LOG_TRUNCATED_STR "...[truncated]\n"
+//This MUST be the length of the above screen (want to avoid calculating at runtime frequently)
+#define ACVP_LOG_TRUNCATED_STR_LEN 15
+#define ACVP_LOG_MAX_MSG_LEN 2048
 
 #define ACVP_BIT2BYTE(x) ((x + 7) >> 3) /**< Convert bit length (x, of type integer) into byte length */
 
@@ -1411,7 +1420,7 @@ void acvp_log_msg(ACVP_CTX *ctx, ACVP_LOG_LVL level, const char *format, ...);
 #else
 void acvp_log_msg(ACVP_CTX *ctx, ACVP_LOG_LVL level, const char *format, ...) __attribute__ ((format (gnu_printf, 3, 4)));
 #endif
-
+void acvp_log_newline(ACVP_CTX *ctx);
 /*
  * These are the handler routines for each KAT operation
  */

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2974,7 +2974,7 @@ static ACVP_RESULT acvp_write_session_info(ACVP_CTX *ctx) {
     }
     if (!prefix) {
         int len = strnlen_s(ACVP_SAVE_DEFAULT_PREFIX, ACVP_JSON_FILENAME_MAX);
-        prefix = calloc(sizeof(char), len + 1);
+        prefix = calloc(len + 1, sizeof(char));
         if (!prefix) {
             rv = ACVP_MALLOC_FAIL;
             goto end;


### PR DESCRIPTION
- Log messages that are now longer than the max allowed (currently 2048 chars) now get the end characters cut off in the log and replaced with a '...[truncated]\n' string. This is more communicative and the newline character makes logs cleaner.
- There is a new ACVP_LOG_NEWLINE macro which will send an empty string to the log callback. This is in a trend towards what I hope will be removing any and all printfs from the library itself for portability sake.
- TODO: Create a log function that get requests can use to print the curl buffer with no limit. Is sending a const pointer to the entire curl buffer to the application a risk if only done for --get requests?


- Beginning of reorganization of logging for vector sets, test groups, and test cases. Will be done in stages. This PR does it for aes and cmac. the goal is to make the logging look as close to the actual JSON test cases as possible, so people can see what the test cases look like more clearly.
- Beginning thorough check of memory allocation. This changes several calloc calls to match the actual order and format of the arguments for consistency (e.x. sometimes sizeof was used first and number of elements second, when it is supposed to be the other way around). The readability of calloc calls is also being checked (no magic numbers, etc). I will be continously doing this as well. Once all of the calloc calls are consistent I will begin checking memory edit calls (strncpy, memcpy, strcat, etc)
- Added a test type value for cmac to make it more spec-consistent, despite aft being the only option right now. Will be making things more consistent with spec as I find them assuming they do not affect interoperability with the NIST server.
- Renamed ptlen in aes processing code to paylen to make more sense (ptlen in given context referred to payloadlen, which could be pt or ct depending on direction)

