### PR TITLE
Moved MCT loop values to acvp.h so apps can use them

### DIFF
--- a/app/app_aes.c
+++ b/app/app_aes.c
@@ -313,7 +313,7 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
             rv = 1;
             goto err;
         }
-        if (tc->mct_index == 999) {
+        if (tc->mct_index == ACVP_AES_MCT_INNER - 1) {
             EVP_CIPHER_CTX_free(cipher_ctx);
             glb_cipher_ctx = NULL;
         }

--- a/app/app_des.c
+++ b/app/app_des.c
@@ -226,7 +226,7 @@ int app_des_handler(ACVP_TEST_CASE *test_case) {
             printf("Unsupported direction\n");
             goto err;
         }
-        if (tc->mct_index == 9999) {
+        if (tc->mct_index == ACVP_DES_MCT_INNER - 1) {
             EVP_CIPHER_CTX_free(cipher_ctx);
             glb_cipher_ctx = NULL;
         }

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -22,6 +22,13 @@ extern "C"
 #define ACVP_TOTP_LENGTH 8
 #define ACVP_TOTP_TOKEN_MAX 128
 
+#define ACVP_HASH_MCT_INNER     1000
+#define ACVP_HASH_MCT_OUTER     100
+#define ACVP_AES_MCT_INNER      1000
+#define ACVP_AES_MCT_OUTER      100
+#define ACVP_DES_MCT_INNER      10000
+#define ACVP_DES_MCT_OUTER      400
+
 /*! @enum ACVP_LOG_LVL
  * @brief This enum defines the different log levels for
  * the ACVP client library

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -470,13 +470,6 @@
 #define ACVP_HASH_XOF_MD_STR_MAX (ACVP_HASH_XOF_MD_BIT_MAX >> 2) /**< 16,384 characters */
 #define ACVP_HASH_XOF_MD_BYTE_MAX (ACVP_HASH_XOF_MD_BIT_MAX >> 3) /**< 8,192 bytes */
 
-#define ACVP_HASH_MCT_INNER     1000
-#define ACVP_HASH_MCT_OUTER     100
-#define ACVP_AES_MCT_INNER      1000
-#define ACVP_AES_MCT_OUTER      100
-#define ACVP_DES_MCT_INNER      10000
-#define ACVP_DES_MCT_OUTER      400
-
 #define ACVP_TDES_KEY_BIT_LEN 192                           /**< 192 bits */
 #define ACVP_TDES_KEY_STR_LEN (ACVP_TDES_KEY_BIT_LEN >> 2)  /**< 48 characters */
 #define ACVP_TDES_KEY_BYTE_LEN (ACVP_TDES_KEY_BIT_LEN >> 3) /**< 24 bytes */


### PR DESCRIPTION
replacing MCT loop limits with references to MCT loop limits defined in headers (as per internal support case) so applications can reference them 