### PR TITLE
Adding more modulo support, fixing windows API issue

### DIFF
--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -87,6 +87,7 @@ EXPORTS
   acvp_put_data_from_file
   acvp_get_results_from_server
   acvp_resume_test_session
+  acvp_get_expected_results
   acvp_set_2fa_callback
   acvp_bin_to_hexstr
   acvp_hexstr_to_bin

--- a/src/acvp_rsa_sig.c
+++ b/src/acvp_rsa_sig.c
@@ -312,7 +312,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
             rv = ACVP_MISSING_ARG;
             goto err;
         }
-        if (mod != 2048 && mod != 3072 && mod != 4096) {
+        if (mod != 1024 && mod != 1536 && mod != 2048 && mod != 3072 && mod != 4096) {
             ACVP_LOG_ERR("Server JSON invalid 'modulo', (%d)", mod);
             rv = ACVP_INVALID_ARG;
             goto err;


### PR DESCRIPTION
There does not seem to be any specific flag that differentiates legacy rsa vs regular, which is confusing because they have different sections in the spec, unless I am missing something. Regardless - adding support for the extra modulo and fixing a bug in the windows build process caused by forgetting to add the new API name to sources.def