### PR TITLE
New API acvp_set_get_save_file, curl buffer increase

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -616,8 +616,8 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
         }
     }
 
-    if (cfg->save_to && !cfg->get_expected) {
-        printf("Warning: --save-to only works with --get_expected. Option will be ignored.\n");
+    if (cfg->save_to && !cfg->get_expected && !cfg->get) {
+        printf("Warning: --save-to only works with --get and --get_expected. Option will be ignored.\n");
     }
 
     /* allopw put, post and get without algs defined */

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1106,6 +1106,11 @@ end:
 static int enable_cmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
+    /****************************************************************************
+     * Note: Setting extremely high keylen or msglen (6 digits) domains may     *
+     * require a resize of ACVP_CURL_BUF_MAX in acvp_lcl.h in the library code. *
+     ****************************************************************************/
+
     /*
      * Enable CMAC
      */
@@ -1150,6 +1155,11 @@ end:
 
 static int enable_hmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
+
+    /****************************************************************************
+     * Note: Setting extremely high keylen or msglen (6 digits) domains may     *
+     * require a resize of ACVP_CURL_BUF_MAX in acvp_lcl.h in the library code. *
+     ****************************************************************************/
 
     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -226,7 +226,16 @@ int main(int argc, char **argv) {
     }
 
     if (cfg.get) {
-        acvp_mark_as_get_only(ctx, cfg.get_string);
+        rv = acvp_mark_as_get_only(ctx, cfg.get_string);
+        if (rv != ACVP_SUCCESS) {
+            printf("Failed to mark as get only.\n");
+            goto end;
+        } else if (cfg.save_to) {
+            rv = acvp_set_get_save_file(ctx, cfg.save_file);
+            if (rv != ACVP_SUCCESS) {
+                printf("Failed to set save file for get request, continuing anyway...\n");
+            }
+        }
     }
 
     if (cfg.post) {

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -2556,6 +2556,20 @@ ACVP_RESULT acvp_mark_as_request_only(ACVP_CTX *ctx, char *filename);
  */
 ACVP_RESULT acvp_mark_as_get_only(ACVP_CTX *ctx, char *string);
 
+/*! @brief acvp_set_get_save_file() indicates a file to save get requests to.
+
+    This function will only work if acvp_mark_as_get_only() has already been
+    successfully called. It will take a string parameter for the location
+    to save the results from the GET request indicated in acvp_mark_as_get_only()
+    to as a file.
+
+    @param ctx Pointer to ACVP_CTX that was previously created by
+        calling acvp_create_test_session.
+    @param filename location to save the GET results to (assumes data in JSON format)
+
+ */
+ACVP_RESULT acvp_set_get_save_file(ACVP_CTX *ctx, char *filename);
+
 /*! @brief acvp_mark_as_post_only() marks the operation as a POST only.
 
     This function will take the filename and perform a POST of the data

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -691,7 +691,7 @@
  * END RSA
  */
 
-#define ACVP_CURL_BUF_MAX       (1024 * 1024 * 16) /**< 16 MB */
+#define ACVP_CURL_BUF_MAX       (1024 * 1024 * 32) /**< 32 MB */
 #define ACVP_RETRY_TIME_MIN     5 /* seconds */
 #define ACVP_RETRY_TIME_MAX     300 
 #define ACVP_MAX_WAIT_TIME      7200

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1349,6 +1349,7 @@ struct acvp_ctx_t {
     int vector_rsp;         /* flag to indicate we are storing vector responses JSON in a file */
     int get;                /* flag to indicate we are only getting status or metadata */
     char *get_string;       /* string used for get request */
+    char *get_filename;     /* string used for file to save GET requests to */
     int post;               /* flag to indicate we are only posting metadata */
     char *post_filename;    /* string used for post */
     int put;                /* flag to indicate we are only putting metadata  for post test validation*/

--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -70,6 +70,7 @@ EXPORTS
   acvp_mark_as_sample
   acvp_mark_as_request_only
   acvp_mark_as_get_only
+  acvp_set_get_save_file
   acvp_mark_as_post_only
   acvp_mark_as_put_after_test
   acvp_run

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -604,6 +604,7 @@ ACVP_RESULT acvp_free_test_session(ACVP_CTX *ctx) {
     if (ctx->session_url) { free(ctx->session_url); }
     if (ctx->vector_req_file) { free(ctx->vector_req_file); }
     if (ctx->get_string) { free(ctx->get_string); }
+    if (ctx->get_filename) { free(ctx->get_filename); }
     if (ctx->post_filename) { free(ctx->post_filename); }
     if (ctx->put_filename) { free(ctx->put_filename); }
     if (ctx->jwt_token) { free(ctx->jwt_token); }
@@ -1761,7 +1762,6 @@ ACVP_RESULT acvp_mark_as_request_only(ACVP_CTX *ctx, char *filename) {
 }
 
 ACVP_RESULT acvp_mark_as_get_only(ACVP_CTX *ctx, char *string) {
-
     if (!ctx) {
         return ACVP_NO_CTX;
     } 
@@ -1781,6 +1781,34 @@ ACVP_RESULT acvp_mark_as_get_only(ACVP_CTX *ctx, char *string) {
 
     strcpy_s(ctx->get_string, ACVP_REQUEST_STR_LEN_MAX + 1, string);
     ctx->get = 1;
+    return ACVP_SUCCESS;
+}
+
+ACVP_RESULT acvp_set_get_save_file(ACVP_CTX *ctx, char *filename) {
+    if (!ctx) {
+        ACVP_LOG_ERR("No CTX given");
+        return ACVP_NO_CTX;
+    } 
+    if (!filename) {
+        ACVP_LOG_ERR("No filename given");
+        return ACVP_MISSING_ARG;
+    }
+    if (!ctx->get) {
+        ACVP_LOG_ERR("Session must be marked as get only to set a get save file");
+        return ACVP_UNSUPPORTED_OP;
+    }
+    int filenameLen = 0;
+    filenameLen = strnlen_s(filename, ACVP_JSON_FILENAME_MAX + 1);
+    if (filenameLen > ACVP_JSON_FILENAME_MAX || filenameLen <= 0) {
+        ACVP_LOG_ERR("Provided filename invalid");
+        return ACVP_INVALID_ARG;
+    }
+    if (ctx->get_filename) { free(ctx->get_filename); }
+    ctx->get_filename = calloc(filenameLen + 1, sizeof(char));
+    if (!ctx->get_filename) {
+        return ACVP_MALLOC_FAIL;
+    }
+    strncpy_s(ctx->get_filename, filenameLen + 1, filename, filenameLen);
     return ACVP_SUCCESS;
 }
 
@@ -3171,6 +3199,22 @@ ACVP_RESULT acvp_run(ACVP_CTX *ctx, int fips_validation) {
 
     if (ctx->get) { 
         rv = acvp_transport_get(ctx, ctx->get_string, NULL);
+        if (ctx->get_filename) {
+            ACVP_LOG_STATUS("Saving GET result to specified file...");
+            JSON_Value *val = NULL;
+            val = json_parse_string(ctx->curl_buf);
+            if (!val) {
+                ACVP_LOG_ERR("Unable to parse JSON. printing output instead...");
+            } else {
+                rv = acvp_json_serialize_to_file_pretty_w(val, ctx->get_filename);
+                if (rv != ACVP_SUCCESS) {
+                    ACVP_LOG_ERR("Failed to write file, printing instead...");
+                } else {
+                    rv = acvp_json_serialize_to_file_pretty_a(NULL, ctx->get_filename);
+                    goto end;
+                }
+            }
+        }
         if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
             printf("\n\n%s\n\n", ctx->curl_buf);
         } else {

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -480,6 +480,35 @@ Test(RUN, missing_path, .init = setup_full_ctx, .fini = teardown) {
     cr_assert(rv == ACVP_MISSING_ARG);
 }
 
+/**
+ * Calls run with mark_as_get_only and save filename. Will fail because no transport
+ */
+Test(RUN, marked_as_get, .init = setup_full_ctx, .fini = teardown) {
+    rv = acvp_set_server(ctx, test_server, port);
+    cr_assert(rv == ACVP_SUCCESS);
+    
+    rv = acvp_set_api_context(ctx, api_context);
+    cr_assert(rv == ACVP_SUCCESS);
+
+    rv = acvp_set_path_segment(ctx, path_segment);
+    cr_assert(rv == ACVP_SUCCESS);
+    
+    rv = acvp_set_server(ctx, test_server, port);
+    cr_assert(rv == ACVP_SUCCESS);
+    
+    rv = acvp_set_2fa_callback(ctx, &totp);
+    cr_assert(rv == ACVP_SUCCESS);
+
+    rv = acvp_mark_as_get_only(ctx, "/acvp/v1/test");
+    cr_assert(rv == ACVP_SUCCESS);
+    
+    rv = acvp_set_get_save_file(ctx, "filename.json");
+    cr_assert(rv == ACVP_SUCCESS);
+
+    rv = acvp_run(ctx, 0);
+    cr_assert(rv == ACVP_TRANSPORT_FAIL);
+}
+
 /*
  * Calls run with good values
  * transport fail is exptected - we made it through the register
@@ -754,6 +783,29 @@ Test(PROCESS_TESTS, mark_as_get_only, .init = setup_full_ctx, .fini = teardown) 
     rv = acvp_mark_as_get_only(ctx, "test");
     cr_assert(rv == ACVP_SUCCESS);
 }
+
+/*
+ * Test acvp_set_get_save_file
+ */
+ Test(PROCESS_TESTS, set_get_save_file, .init = setup_full_ctx, .fini = teardown) {
+    rv = acvp_set_get_save_file(ctx, "haventCalledGetOnly.json");
+    cr_assert(rv == ACVP_UNSUPPORTED_OP);
+
+    rv = acvp_mark_as_get_only(ctx, "test");
+    cr_assert(rv == ACVP_SUCCESS);
+
+    rv = acvp_set_get_save_file(NULL, "noCtx.json");
+    cr_assert(rv == ACVP_NO_CTX);
+
+    rv = acvp_set_get_save_file(ctx, NULL);
+    cr_assert(rv == ACVP_MISSING_ARG);
+
+    rv = acvp_set_get_save_file(ctx, "testFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLong");
+    cr_assert(rv == ACVP_INVALID_ARG);
+
+    rv = acvp_set_get_save_file(ctx, "");
+    cr_assert(rv == ACVP_INVALID_ARG);
+ }
 
 /*
  * Test acvp_mark_as_put_after_test


### PR DESCRIPTION
New API acvp_set_get_save_file for saving files when the session is marked as acvp_mark_as_get_only. App has been updated to use. So you can now do
 ./acvp_app --get /acvp/v1/etc --save_to filename.json

In next major release (probably a long time away), we would hope to add this as an optional parameter to acvp_mark_as_get_only instead of it being a separate API.

Increased curl buffer size to 32MB, and added comment blocks to enable_hmac and enable_cmac indicating the buffer size may need to be increased in some scenarios. 

Added UTs.