### PR TITLE
Added library support for aes-xpn and disabled app registration

### DIFF
--- a/app/app_aes.c
+++ b/app/app_aes.c
@@ -694,6 +694,7 @@ int app_aes_handler_aead(ACVP_TEST_CASE *test_case) {
     case ACVP_AES_XTS:
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:

--- a/app/app_cmac.c
+++ b/app/app_cmac.c
@@ -84,6 +84,7 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:

--- a/app/app_des.c
+++ b/app/app_des.c
@@ -109,6 +109,7 @@ int app_des_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_CBCI:
     case ACVP_TDES_OFBI:
     case ACVP_TDES_CFBP1:

--- a/app/app_drbg.c
+++ b/app/app_drbg.c
@@ -223,6 +223,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:

--- a/app/app_ecdsa.c
+++ b/app/app_ecdsa.c
@@ -381,6 +381,7 @@ points_err:
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:

--- a/app/app_hmac.c
+++ b/app/app_hmac.c
@@ -92,6 +92,7 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -837,6 +837,50 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
+#if 0 //AES-XPN not currently supported by openSSL
+    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XPN, &app_aes_handler_aead);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_set_prereq(ctx, ACVP_AES_XPN, ACVP_PREREQ_AES, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_set_prereq(ctx, ACVP_AES_XPN, ACVP_PREREQ_DRBG, value);
+    CHECK_ENABLE_CAP_RV(rv);
+
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_NA);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_INT);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_821);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PARM_SALT_SRC, ACVP_SYM_CIPH_SALT_SRC_EXT);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_KEYLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_KEYLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_TAGLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PTLEN, 16);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PTLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PTLEN, 136);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PTLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PTLEN, 264);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_AADLEN, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_AADLEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_AADLEN, 136);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_AADLEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+#endif
+
 end:
 
     return rv;

--- a/app/app_sha.c
+++ b/app/app_sha.c
@@ -103,6 +103,7 @@ int app_sha_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -94,6 +94,7 @@ typedef enum acvp_cipher {
     ACVP_AES_KW,
     ACVP_AES_KWP,
     ACVP_AES_GMAC,
+    ACVP_AES_XPN,
     ACVP_TDES_ECB,
     ACVP_TDES_CBC,
     ACVP_TDES_CBCI,
@@ -285,6 +286,19 @@ typedef enum acvp_sym_cipher_ivgen_source {
     ACVP_SYM_CIPH_IVGEN_SRC_NA,
     ACVP_SYM_CIPH_IVGEN_SRC_MAX
 } ACVP_SYM_CIPH_IVGEN_SRC;
+
+
+/*!
+ * @struct ACVP_SYM_CIPH_SALT_SRC
+ * @brief The IV generation source for AES_XPN
+ * This can be internal, external, or not applicable.
+ */
+typedef enum acvp_sym_cipher_salt_source {
+    ACVP_SYM_CIPH_SALT_SRC_INT = 1,
+    ACVP_SYM_CIPH_SALT_SRC_EXT,
+    ACVP_SYM_CIPH_SALT_SRC_NA,
+    ACVP_SYM_CIPH_SALT_SRC_MAX
+} ACVP_SYM_CIPH_SALT_SRC;
 
 /*!
  * @struct ACVP_SYM_CIPH_IVGEN_MODE
@@ -503,7 +517,8 @@ typedef enum acvp_sym_cipher_parameter {
     ACVP_SYM_CIPH_PARM_CTR_INCR,
     ACVP_SYM_CIPH_PARM_CTR_OVRFLW,
     ACVP_SYM_CIPH_PARM_IVGEN_MODE,
-    ACVP_SYM_CIPH_PARM_IVGEN_SRC
+    ACVP_SYM_CIPH_PARM_IVGEN_SRC,
+    ACVP_SYM_CIPH_PARM_SALT_SRC
 } ACVP_SYM_CIPH_PARM;
 
 /*! @struct ACVP_SYM_CIPH_TWEAK_MODE */
@@ -605,6 +620,7 @@ typedef struct acvp_sym_cipher_tc_t {
     ACVP_SYM_CIPH_DIR direction;      /* encrypt or decrypt */
     ACVP_SYM_CIPH_IVGEN_SRC ivgen_source;
     ACVP_SYM_CIPH_IVGEN_MODE ivgen_mode;
+    ACVP_SYM_CIPH_SALT_SRC salt_source; /* for AES-XPN */
     unsigned int tc_id;          /* Test case id */
     unsigned char *key;          /* Aes symmetric key */
     unsigned char *pt;           /* Plaintext */
@@ -614,6 +630,7 @@ typedef struct acvp_sym_cipher_tc_t {
     unsigned char *tag;          /* Aead tag */
     unsigned char *iv_ret;       /* updated IV used for TDES MCT */
     unsigned char *iv_ret_after; /* updated IV used for TDES MCT */
+    unsigned char *salt;
     ACVP_SYM_KW_MODE kwcipher;
     ACVP_SYM_CIPH_TWEAK_MODE tw_mode;
     unsigned int seq_num;     
@@ -624,6 +641,7 @@ typedef struct acvp_sym_cipher_tc_t {
     unsigned int iv_len;
     unsigned int ct_len;
     unsigned int tag_len;
+    unsigned int salt_len;
     unsigned int mct_index;  /* used to identify init vs. update */
     unsigned int incr_ctr;
     unsigned int ovrflw_ctr;

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -123,6 +123,7 @@
 #define ACVP_REV_AES_KW              ACVP_REVISION_LATEST
 #define ACVP_REV_AES_KWP             ACVP_REVISION_LATEST
 #define ACVP_REV_AES_GMAC            ACVP_REVISION_LATEST
+#define ACVP_REV_AES_XPN             ACVP_REVISION_LATEST
 
 /* TDES */
 #define ACVP_REV_TDES_OFB            ACVP_REVISION_LATEST
@@ -226,6 +227,7 @@
 #define ACVP_ALG_AES_KW              "ACVP-AES-KW"
 #define ACVP_ALG_AES_KWP             "ACVP-AES-KWP"
 #define ACVP_ALG_AES_GMAC            "ACVP-AES-GMAC"
+#define ACVP_ALG_AES_XPN             "ACVP-AES-XPN"
 #define ACVP_ALG_TDES_OFB            "ACVP-TDES-OFB"
 #define ACVP_ALG_TDES_OFBI           "ACVP-TDES-OFBI"
 #define ACVP_ALG_TDES_CFB1           "ACVP-TDES-CFB1"
@@ -417,6 +419,7 @@
 #define ACVP_SYM_IV_MAX (ACVP_SYM_IV_BIT_MAX >> 2)      /**< 256 characters */
 #define ACVP_SYM_IV_BYTE_MAX (ACVP_SYM_IV_BIT_MAX >> 3) /**< 128 bytes */
 #define ACVP_AES_GCM_SIV_IVLEN 96
+#define ACVP_AES_XPN_IVLEN 96
 
 #define ACVP_SYM_TAG_BIT_MIN 4                            /**< 128 bits */
 #define ACVP_SYM_TAG_BIT_MAX 128                          /**< 128 bits */
@@ -427,6 +430,8 @@
 #define ACVP_SYM_AAD_BIT_MAX 65536                        /**< 65536 bits */
 #define ACVP_SYM_AAD_MAX (ACVP_SYM_AAD_BIT_MAX >> 2)      /**< 16384 characters */
 #define ACVP_SYM_AAD_BYTE_MAX (ACVP_SYM_AAD_BIT_MAX >> 3) /**< 8192 bytes */
+
+#define ACVP_AES_XPN_SALTLEN 96
 
 /**
  * Accepted length ranges for DRBG.
@@ -875,6 +880,7 @@ typedef struct acvp_sym_cipher_capability {
     ACVP_SYM_CIPH_KO keying_option;
     ACVP_SYM_CIPH_IVGEN_SRC ivgen_source;
     ACVP_SYM_CIPH_IVGEN_MODE ivgen_mode;
+    ACVP_SYM_CIPH_SALT_SRC salt_source;
     unsigned int ctr_incr;
     unsigned int ctr_ovrflw;
     ACVP_SL_LIST *keylen;

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -81,6 +81,7 @@ ACVP_ALG_HANDLER alg_tbl[ACVP_ALG_MAX] = {
     { ACVP_AES_KW,            &acvp_aes_kat_handler,          ACVP_ALG_AES_KW,            NULL, ACVP_REV_AES_KW},
     { ACVP_AES_KWP,           &acvp_aes_kat_handler,          ACVP_ALG_AES_KWP,           NULL, ACVP_REV_AES_KWP},
     { ACVP_AES_GMAC,          &acvp_aes_kat_handler,          ACVP_ALG_AES_GMAC,          NULL, ACVP_REV_AES_GMAC},
+    { ACVP_AES_XPN,           &acvp_aes_kat_handler,          ACVP_ALG_AES_XPN ,          NULL, ACVP_REV_AES_XPN},
     { ACVP_TDES_ECB,          &acvp_des_kat_handler,          ACVP_ALG_TDES_ECB,          NULL, ACVP_REV_TDES_ECB},
     { ACVP_TDES_CBC,          &acvp_des_kat_handler,          ACVP_ALG_TDES_CBC,          NULL, ACVP_REV_TDES_CBC},
     { ACVP_TDES_CBCI,         &acvp_des_kat_handler,          ACVP_ALG_TDES_CBCI,         NULL, ACVP_REV_TDES_CBCI},

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -378,6 +378,23 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
         break;
     }
 
+        /*
+     * Set the salt generation source if applicable (XPN)
+     */
+    switch (sym_cap->salt_source) {
+    case ACVP_SYM_CIPH_SALT_SRC_INT:
+        json_object_set_string(cap_obj, "saltGen", "internal");
+        break;
+    case ACVP_SYM_CIPH_SALT_SRC_EXT:
+        json_object_set_string(cap_obj, "saltGen", "external");
+        break;
+    case ACVP_SYM_CIPH_SALT_SRC_NA:
+    case ACVP_SYM_CIPH_SALT_SRC_MAX:
+    default:
+        /* do nothing, this is an optional capability */
+        break;
+    }
+
     /*
      * Set the IV generation mode if applicable
      */
@@ -429,7 +446,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
      * Set the supported tag lengths (for AEAD ciphers)
      */
     if ((cap_entry->cipher == ACVP_AES_GCM) || (cap_entry->cipher == ACVP_AES_CCM)
-                                            || (cap_entry->cipher == ACVP_AES_GMAC)) {
+          || (cap_entry->cipher == ACVP_AES_GMAC) || (cap_entry->cipher == ACVP_AES_XPN)) {
         json_object_set_value(cap_obj, "tagLen", json_value_init_array());
         opts_arr = json_object_get_array(cap_obj, "tagLen");
         sl_list = sym_cap->taglen;
@@ -443,6 +460,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
      * Set the supported IV lengths
      */
     switch (cap_entry->cipher) {
+    case ACVP_CIPHER_START:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -466,12 +484,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_XTS:
-        break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_HASH_SHA1:
     case ACVP_HASH_SHA224:
     case ACVP_HASH_SHA256:
@@ -527,6 +540,11 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
     case ACVP_KAS_FFC_COMP:
     case ACVP_KAS_FFC_NOCOMP:
     case ACVP_CIPHER_END:
+        break;
+    case ACVP_AES_GCM:
+    case ACVP_AES_GCM_SIV:
+    case ACVP_AES_CCM:
+    case ACVP_AES_GMAC:
     default:
         json_object_set_value(cap_obj, "ivLen", json_value_init_array());
         opts_arr = json_object_get_array(cap_obj, "ivLen");
@@ -575,7 +593,8 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
      * Set the supported AAD lengths (for AEAD ciphers)
      */
     if ((cap_entry->cipher == ACVP_AES_GCM) || (cap_entry->cipher == ACVP_AES_CCM)
-            || (cap_entry->cipher == ACVP_AES_GMAC || (cap_entry->cipher == ACVP_AES_GCM_SIV))) {
+            || (cap_entry->cipher == ACVP_AES_GMAC) || (cap_entry->cipher == ACVP_AES_GCM_SIV)
+            || (cap_entry->cipher == ACVP_AES_XPN)) {
         json_object_set_value(cap_obj, "aadLen", json_value_init_array());
         opts_arr = json_object_get_array(cap_obj, "aadLen");
         sl_list = sym_cap->aadlen;
@@ -1032,6 +1051,7 @@ static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CIPHER cipher, JSON_Object
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -2722,6 +2742,7 @@ ACVP_RESULT acvp_build_test_session(ACVP_CTX *ctx, char **reg, int *out_len) {
             case ACVP_AES_KWP:
             case ACVP_AES_XTS:
             case ACVP_AES_GMAC:
+            case ACVP_AES_XPN:
             case ACVP_TDES_ECB:
             case ACVP_TDES_CBC:
             case ACVP_TDES_CTR:

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -756,6 +756,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_AES_OFB:
         case ACVP_AES_CTR:
         case ACVP_AES_GMAC:
+        case ACVP_AES_XPN:
             if (value >= 4 && value <= 128) {
                 retval = ACVP_SUCCESS;
             }
@@ -840,6 +841,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
     case ACVP_SYM_CIPH_IVLEN:
         switch (cipher) {
         case ACVP_AES_GCM_SIV:
+        case ACVP_AES_XPN:
             break;
         case ACVP_CIPHER_START:
         case ACVP_AES_GCM:
@@ -949,6 +951,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_AES_OFB:
         case ACVP_AES_CTR:
         case ACVP_AES_GMAC:
+        case ACVP_AES_XPN:
             if (value >= 0 && value <= 65536) {
                 retval = ACVP_SUCCESS;
             }
@@ -1047,6 +1050,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_AES_XTS:
         case ACVP_AES_KW:
         case ACVP_AES_KWP:
+        case ACVP_AES_XPN:
         case ACVP_TDES_ECB:
         case ACVP_TDES_CBC:
         case ACVP_TDES_CBCI:
@@ -1129,6 +1133,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
     case ACVP_SYM_CIPH_PARM_CTR_OVRFLW:
     case ACVP_SYM_CIPH_PARM_IVGEN_MODE:
     case ACVP_SYM_CIPH_PARM_IVGEN_SRC:
+    case ACVP_SYM_CIPH_PARM_SALT_SRC:
     default:
         break;
     }
@@ -1152,6 +1157,7 @@ static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG 
     case ACVP_AES_KWP:
     case ACVP_AES_XTS:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
         if (pre_req == ACVP_PREREQ_AES ||
             pre_req == ACVP_PREREQ_DRBG) {
             return ACVP_SUCCESS;
@@ -1419,6 +1425,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -1516,7 +1523,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
         }
 
     case ACVP_SYM_CIPH_PARM_DIR:
-        if (value != 0 && value < ACVP_SYM_CIPH_DIR_MAX) {
+        if (value > 0 && value < ACVP_SYM_CIPH_DIR_MAX) {
             cap->cap.sym_cap->direction = value;
             return ACVP_SUCCESS;
         } else {
@@ -1525,7 +1532,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
         }
 
     case ACVP_SYM_CIPH_PARM_KO:
-        if (value != 0 && value < ACVP_SYM_CIPH_KO_MAX) {
+        if (value > 0 && value < ACVP_SYM_CIPH_KO_MAX) {
             cap->cap.sym_cap->keying_option = value;
             return ACVP_SUCCESS;
         } else {
@@ -1552,7 +1559,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
         }
 
     case ACVP_SYM_CIPH_PARM_IVGEN_SRC:
-        if (value != 0 && value < ACVP_SYM_CIPH_IVGEN_SRC_MAX) {
+        if (value > 0 && value < ACVP_SYM_CIPH_IVGEN_SRC_MAX) {
             cap->cap.sym_cap->ivgen_source = value;
             return ACVP_SUCCESS;
         } else {
@@ -1561,13 +1568,22 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
         }
 
     case ACVP_SYM_CIPH_PARM_IVGEN_MODE:
-        if (value != 0 && value < ACVP_SYM_CIPH_IVGEN_MODE_MAX) {
+        if (value > 0 && value < ACVP_SYM_CIPH_IVGEN_MODE_MAX) {
             cap->cap.sym_cap->ivgen_mode = value;
             return ACVP_SUCCESS;
         } else {
             ACVP_LOG_ERR("Invalid parameter 'value' for param ACVP_SYM_CIPH_PARM_IVGEN_MODE");
             return ACVP_INVALID_ARG;
         }
+    case ACVP_SYM_CIPH_PARM_SALT_SRC:
+        if  (cipher == ACVP_AES_XPN && value > 0 && value < ACVP_SYM_CIPH_SALT_SRC_MAX) {
+            cap->cap.sym_cap->salt_source = value;
+            return ACVP_SUCCESS;
+        } else {
+            ACVP_LOG_ERR("Invalid parameter 'value' for parm ACVP_SYM_CIPH_PARM_SALT_SRC");
+            return ACVP_INVALID_ARG;
+        }
+
 
     case ACVP_SYM_CIPH_KEYLEN:
     case ACVP_SYM_CIPH_TAGLEN:
@@ -1580,6 +1596,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
     }
 
     if (acvp_validate_sym_cipher_parm_value(cipher, parm, value) != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Unable to validate given parameter (cipher=%d, value=%d)", cipher, value);
         return ACVP_INVALID_ARG;
     }
 
@@ -1656,6 +1673,7 @@ ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -1784,6 +1802,7 @@ ACVP_RESULT acvp_cap_hash_enable(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -1907,6 +1926,7 @@ ACVP_RESULT acvp_cap_hash_set_parm(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -2014,6 +2034,7 @@ ACVP_RESULT acvp_cap_hash_set_parm(ACVP_CTX *ctx,
         case ACVP_AES_KW:
         case ACVP_AES_KWP:
         case ACVP_AES_GMAC:
+        case ACVP_AES_XPN:
         case ACVP_TDES_ECB:
         case ACVP_TDES_CBC:
         case ACVP_TDES_CBCI:
@@ -2139,6 +2160,7 @@ ACVP_RESULT acvp_cap_hash_set_domain(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -2321,6 +2343,7 @@ static ACVP_RESULT acvp_validate_hmac_parm_value(ACVP_CIPHER cipher,
         case ACVP_AES_KW:
         case ACVP_AES_KWP:
         case ACVP_AES_GMAC:
+        case ACVP_AES_XPN:
         case ACVP_TDES_ECB:
         case ACVP_TDES_CBC:
         case ACVP_TDES_CBCI:
@@ -2437,6 +2460,7 @@ ACVP_RESULT acvp_cap_hmac_enable(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -2675,6 +2699,7 @@ ACVP_RESULT acvp_cap_cmac_enable(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -3317,6 +3342,7 @@ ACVP_RESULT acvp_cap_drbg_set_parm(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -4187,6 +4213,7 @@ static ACVP_RESULT internal_cap_rsa_sig_enable(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -4299,6 +4326,7 @@ ACVP_RESULT acvp_cap_rsa_sig_enable(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -4429,6 +4457,7 @@ ACVP_RESULT acvp_cap_ecdsa_set_parm(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -4625,6 +4654,7 @@ ACVP_RESULT acvp_cap_ecdsa_enable(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -6045,6 +6075,7 @@ ACVP_RESULT acvp_cap_kas_ecc_enable(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -6161,6 +6192,7 @@ ACVP_RESULT acvp_cap_kas_ecc_set_parm(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -6375,6 +6407,7 @@ ACVP_RESULT acvp_cap_kas_ecc_set_scheme(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -6679,6 +6712,7 @@ ACVP_RESULT acvp_cap_kas_ffc_enable(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:

--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -196,6 +196,7 @@ static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_CBCI:
     case ACVP_TDES_OFBI:
     case ACVP_TDES_CFBP1:
@@ -493,6 +494,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_CBCI:
     case ACVP_TDES_OFBI:
     case ACVP_TDES_CFBP1:

--- a/src/acvp_kas_ecc.c
+++ b/src/acvp_kas_ecc.c
@@ -840,6 +840,7 @@ ACVP_RESULT acvp_kas_ecc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:

--- a/src/acvp_kas_ffc.c
+++ b/src/acvp_kas_ffc.c
@@ -530,6 +530,7 @@ ACVP_RESULT acvp_kas_ffc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     case ACVP_AES_KW:
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:


### PR DESCRIPTION
Tested with a sample session and zereod out results (got "fail" disposition but all fields and data were present)

Fixed small issue where negative value could be fed to some sym cipher parm API. Fortunately only caused an error from the server.