### PR TITLE
Update muse config

### DIFF
--- a/.muse/config
+++ b/.muse/config
@@ -1,3 +1,2 @@
 setup = ".muse/setup.sh"
 build = "make"
-verifiers = [ "infer" ]

--- a/.muse/setup.sh
+++ b/.muse/setup.sh
@@ -1,8 +1,10 @@
+#!/usr/bin/env bash
+
 if [ $(whoami) = "root" ]; then
-    apt install -y libssl1.1-dev libcurl4-gnutls-dev
+    apt update && apt install -y libssl-dev libcurl4-gnutls-dev
 fi
 
 cd $1
 sed -i 's/gcc_z_support=yes/gcc_z_support=no/' configure
 sed -i 's/-z,noexecstack//' configure
-./configure LIBS=-lcurl
+./configure LIBS=-lcurl --with-libcurl-dir=/usr/lib/x86_64-linux-gnu/


### PR DESCRIPTION
The muse config has lagged a bit with changes to both muse and libacvp.  This PR fixes the build system (which now requires a --with-libcurl-dir flag) and relaxes the configuration to allow all analyzers to run.

Analysis of this PR won't succeed because master analysis isn't currently functional.  The individual branch, however, [does work](https://console.muse.dev/result/TomMD/libacvp/01EQGYYVJCFMTPQGSHCM3Z9R6R?tab=results) so master will be in a good state post-merge.