### PR TITLE
Fix KAS-IFC leaks and remove unused function setup_fail

### DIFF
--- a/app/app_kas.c
+++ b/app/app_kas.c
@@ -446,6 +446,9 @@ int app_kas_ifc_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KAS_IFC_TC *tc;
     int rv = 1;
     BIGNUM *e = NULL, *n = NULL, *p = NULL, *q = NULL, *d = NULL;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    BIGNUM *tmp_e = NULL, *tmp_n = NULL;
+#endif
     RSA *rsa = NULL;
     const EVP_MD *md = NULL;
 
@@ -516,13 +519,17 @@ int app_kas_ifc_handler(ACVP_TEST_CASE *test_case) {
         rsa->p = BN_dup(p);
         rsa->q = BN_dup(q);
     }
-    BN_free(e);
-    BN_free(n);
     if (d) BN_free(d);
 
 #else
     if (tc->kas_role == ACVP_KAS_IFC_INITIATOR) {
-        RSA_set0_key(rsa, n, e, NULL);
+        tmp_e = BN_dup(e);
+        tmp_n = BN_dup(n);
+        if (!tmp_n || !tmp_e) {
+            printf("Error: Failed to dup tmp_n or tmp_e\n");
+            goto err;
+        }
+        RSA_set0_key(rsa, tmp_n, tmp_e, d);
     } else {
         if (!tc->p || !tc->q || !tc->d) {
             printf("Failed p or q or d from library\n");
@@ -538,7 +545,13 @@ int app_kas_ifc_handler(ACVP_TEST_CASE *test_case) {
         BN_bin2bn(tc->p, tc->plen, p);
         BN_bin2bn(tc->q, tc->qlen, q);
         BN_bin2bn(tc->d, tc->dlen, d);
-        RSA_set0_key(rsa, n, e, d);
+        tmp_e = BN_dup(e);
+        tmp_n = BN_dup(n);
+        if (!tmp_n || !tmp_e) {
+            printf("Error: Failed to dup tmp_n or tmp_e\n");
+            goto err;
+        }
+        RSA_set0_key(rsa, tmp_n, tmp_e, d);
         RSA_set0_factors(rsa, p, q);
     }
 #endif
@@ -600,6 +613,8 @@ err:
     if (p) BN_free(p);
     if (q) BN_free(q);
 #endif
+    if (e) BN_free(e);
+    if (n) BN_free(n);
     if (rsa) RSA_free(rsa);
     return rv;
 }

--- a/test/test_acvp_kas_ifc.c
+++ b/test/test_acvp_kas_ifc.c
@@ -53,40 +53,6 @@ static void setup(void) {
 
 }
 
-static void setup_fail(void) {
-    char *expo_str = calloc(7, sizeof(char));
-    strncpy(expo_str, "010001", 7); // RSA_F4
-
-    setup_empty_ctx(&ctx);
-    /* Support is for IFC-SSC for hashZ only */
-    rv = acvp_cap_kas_ifc_enable(ctx, ACVP_KAS_IFC_SSC, &dummy_handler_failure);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_RSA, cvalue);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_RSADP, cvalue);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_SHA, cvalue);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_DRBG, cvalue);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KAS1, ACVP_KAS_IFC_INITIATOR);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KAS1, ACVP_KAS_IFC_RESPONDER);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_MODULO, 2048);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_MODULO, 3072);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_MODULO, 4096);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KEYGEN_METHOD, ACVP_KAS_IFC_RSAKPG1_BASIC);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_HASH, ACVP_SHA512);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_kas_ifc_set_exponent(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_FIXEDPUBEXP, expo_str);
-    cr_assert(rv == ACVP_SUCCESS);
-}
-
 static void teardown(void) {
     if (ctx) teardown_ctx(&ctx);
 }


### PR DESCRIPTION
This may conflict since I already added it to internal, so I'll look out for merge conflict on the sync.