### PR TITLE
Fixing criterion testing issues

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,6 @@
 noinst_PROGRAMS = runtest
 runtest_SOURCES = ut_common.c
-tmp_cflags = -g -O0 -Wall -DNO_SSL_DL -p $(SAFEC_CFLAGS) $(CRITERION_CFLAGS) $(LIBACVP_CFLAGS) -I../include
+tmp_cflags = -g -O0 -Wall -DNO_SSL_DL $(SAFEC_CFLAGS) $(CRITERION_CFLAGS) $(LIBACVP_CFLAGS) -I../include
 tmp_ldflags= -ldl $(CRITERION_LDFLAGS) $(SAFEC_LDFLAGS) $(LIBACVP_LDFLAGS)
 if ! LIB_NOT_SUPPORTED
 runtest_SOURCES += create_session.c \

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -500,7 +500,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 runtest_SOURCES = ut_common.c $(am__append_1) $(am__append_4)
-tmp_cflags = -g -O0 -Wall -DNO_SSL_DL -p $(SAFEC_CFLAGS) \
+tmp_cflags = -g -O0 -Wall -DNO_SSL_DL $(SAFEC_CFLAGS) \
 	$(CRITERION_CFLAGS) $(LIBACVP_CFLAGS) -I../include \
 	$(am__append_2) $(am__append_5)
 tmp_ldflags = -ldl $(CRITERION_LDFLAGS) $(SAFEC_LDFLAGS) \


### PR DESCRIPTION
The sandbox-gmon files were actually profile data files; when I revamped the build system a bit -p found its way into the test make data.

This was also causing valgrind to throw some harmless warnings during runs.

We still use debugging symbols with -g though.