### PR TITLE
Re-architect enums, fix some warnings

### DIFF
--- a/app/app_aes.c
+++ b/app/app_aes.c
@@ -30,6 +30,7 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
     unsigned char *iv = 0;
     /* assume fail at first */
     int rv = 0;
+    ACVP_SUB_AES alg;
 
     if (!test_case) {
         return rv;
@@ -51,8 +52,13 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
         EVP_CIPHER_CTX_init(cipher_ctx);
     }
 
-    switch (tc->cipher) {
-    case ACVP_AES_ECB:
+    alg = acvp_get_aes_alg(tc->cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+    switch (alg) {
+    case ACVP_SUB_AES_ECB:
         switch (tc->key_len) {
         case 128:
             cipher = EVP_aes_128_ecb();
@@ -69,7 +75,7 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
             goto err;
         }
         break;
-    case ACVP_AES_CTR:
+    case ACVP_SUB_AES_CTR:
         iv = tc->iv;
         switch (tc->key_len) {
         case 128:
@@ -87,7 +93,7 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
             goto err;
         }
         break;
-    case ACVP_AES_CFB1:
+    case ACVP_SUB_AES_CFB1:
         iv = tc->iv;
         switch (tc->key_len) {
         case 128:
@@ -105,7 +111,7 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
             goto err;
         }
         break;
-    case ACVP_AES_CFB8:
+    case ACVP_SUB_AES_CFB8:
         iv = tc->iv;
         switch (tc->key_len) {
         case 128:
@@ -123,7 +129,7 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
             goto err;
         }
         break;
-    case ACVP_AES_CFB128:
+    case ACVP_SUB_AES_CFB128:
         iv = tc->iv;
         switch (tc->key_len) {
         case 128:
@@ -141,7 +147,7 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
             goto err;
         }
         break;
-    case ACVP_AES_OFB:
+    case ACVP_SUB_AES_OFB:
         iv = tc->iv;
         switch (tc->key_len) {
         case 128:
@@ -159,7 +165,7 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
             goto err;
         }
         break;
-    case ACVP_AES_CBC:
+    case ACVP_SUB_AES_CBC:
         iv = tc->iv;
         switch (tc->key_len) {
         case 128:
@@ -177,13 +183,13 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
             goto err;
         }
         break;
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
+    case ACVP_SUB_AES_CBC_CS1:
+    case ACVP_SUB_AES_CBC_CS2:
+    case ACVP_SUB_AES_CBC_CS3:
         printf("AES-CBC-CSX algorithms are unsupported currently\n");
         rv = 1;
         goto err;
-    case ACVP_AES_XTS:
+    case ACVP_SUB_AES_XTS:
         switch (tc->key_len) {
         case 128:
             cipher = EVP_aes_128_xts();
@@ -209,81 +215,13 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
             break;
         }
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_AES_GCM:
+    case ACVP_SUB_AES_GCM_SIV:
+    case ACVP_SUB_AES_CCM:
+    case ACVP_SUB_AES_XPN:
+    case ACVP_SUB_AES_KW:
+    case ACVP_SUB_AES_KWP:
+    case ACVP_SUB_AES_GMAC:
     default:
         printf("Error: Unsupported AES mode requested by ACVP server\n");
         rv = 1;
@@ -362,6 +300,7 @@ int app_aes_keywrap_handler(ACVP_TEST_CASE *test_case) {
     const EVP_CIPHER        *cipher;
     int c_len;
     int rc = 1;
+    ACVP_SUB_AES alg;
 
     if (!test_case) {
         return rc;
@@ -378,9 +317,15 @@ int app_aes_keywrap_handler(ACVP_TEST_CASE *test_case) {
     cipher_ctx = EVP_CIPHER_CTX_new();
     EVP_CIPHER_CTX_init(cipher_ctx);
 
-    switch (tc->cipher) {
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
+    alg = acvp_get_aes_alg(tc->cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_AES_KW:
+    case ACVP_SUB_AES_KWP:
         switch (tc->key_len) {
         case 128:
             cipher = EVP_aes_128_wrap();
@@ -396,87 +341,22 @@ int app_aes_keywrap_handler(ACVP_TEST_CASE *test_case) {
             goto end;
         }
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_GMAC:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_AES_GCM:
+    case ACVP_SUB_AES_GCM_SIV:
+    case ACVP_SUB_AES_CCM:
+    case ACVP_SUB_AES_ECB:
+    case ACVP_SUB_AES_CBC:
+    case ACVP_SUB_AES_CBC_CS1:
+    case ACVP_SUB_AES_CBC_CS2:
+    case ACVP_SUB_AES_CBC_CS3:
+    case ACVP_SUB_AES_CFB1:
+    case ACVP_SUB_AES_CFB8:
+    case ACVP_SUB_AES_CFB128:
+    case ACVP_SUB_AES_OFB:
+    case ACVP_SUB_AES_CTR:
+    case ACVP_SUB_AES_XTS:
+    case ACVP_SUB_AES_XPN:
+    case ACVP_SUB_AES_GMAC:
     default:
         printf("Error: Unsupported AES keywrap mode requested by ACVP server\n");
         goto end;
@@ -535,6 +415,7 @@ int app_aes_handler_aead(ACVP_TEST_CASE *test_case) {
     unsigned char iv_fixed[4] = { 1, 2, 3, 4 };
     int rc = 0;
     int ret = 0;
+    ACVP_SUB_AES alg;
 
     if (!test_case) {
         return 1;
@@ -557,9 +438,15 @@ int app_aes_handler_aead(ACVP_TEST_CASE *test_case) {
     EVP_CIPHER_CTX_init(cipher_ctx);
 
     /* Validate key length and assign OpenSSL EVP cipher */
-    switch (tc->cipher) {
-    case ACVP_AES_GMAC:
-    case ACVP_AES_GCM:
+    alg = acvp_get_aes_alg(tc->cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_AES_GMAC:
+    case ACVP_SUB_AES_GCM:
         if (tc->cipher == ACVP_AES_GMAC && (tc->pt_len || tc->ct_len ||
                 strnlen_s((const char *)tc->ct, 1) || strnlen_s((const char *)tc->pt, 1))) {
             printf("Invalid AES-GMAC ct/pt data\n");
@@ -640,7 +527,7 @@ int app_aes_handler_aead(ACVP_TEST_CASE *test_case) {
             }
         }
         break;
-    case ACVP_AES_CCM:
+    case ACVP_SUB_AES_CCM:
         switch (tc->key_len) {
         case 128:
             cipher = EVP_aes_128_ccm();
@@ -688,87 +575,21 @@ int app_aes_handler_aead(ACVP_TEST_CASE *test_case) {
             }
         }
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_AES_GCM_SIV:
+    case ACVP_SUB_AES_ECB:
+    case ACVP_SUB_AES_CBC:
+    case ACVP_SUB_AES_CFB1:
+    case ACVP_SUB_AES_CFB8:
+    case ACVP_SUB_AES_CFB128:
+    case ACVP_SUB_AES_OFB:
+    case ACVP_SUB_AES_CTR:
+    case ACVP_SUB_AES_XTS:
+    case ACVP_SUB_AES_KW:
+    case ACVP_SUB_AES_KWP:
+    case ACVP_SUB_AES_XPN:
+    case ACVP_SUB_AES_CBC_CS1:
+    case ACVP_SUB_AES_CBC_CS2:
+    case ACVP_SUB_AES_CBC_CS3:
     default:
         printf("Error: Unsupported AES AEAD mode requested by ACVP server\n");
         rc = 1;

--- a/app/app_cmac.c
+++ b/app/app_cmac.c
@@ -27,6 +27,7 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
     unsigned char mac_compare[16] = { 0 };
     char full_key[33] = { 0 };
     size_t mac_cmp_len;
+    ACVP_SUB_CMAC alg;
 
     if (!test_case) {
         return rv;
@@ -36,8 +37,14 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
     if (!tc) return rv;
     if (!tc->key) return rv;
 
-    switch (tc->cipher) {
-    case ACVP_CMAC_AES:
+    alg = acvp_get_cmac_alg(tc->cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_CMAC_AES:
         switch (tc->key_len * 8) {
         case 128:
             c = EVP_aes_128_cbc();
@@ -56,7 +63,7 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
             full_key[i] = tc->key[i];
         }
         break;
-    case ACVP_CMAC_TDES:
+    case ACVP_SUB_CMAC_TDES:
         c = EVP_des_ede3_cbc();
         for (i = 0; i < 8; i++) {
             full_key[i] = tc->key[i];
@@ -69,88 +76,6 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
         }
         key_len = 24;
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_CIPHER_END:
     default:
         printf("Error: Unsupported CMAC algorithm requested by ACVP server\n");
         return rv;

--- a/app/app_des.c
+++ b/app/app_des.c
@@ -29,6 +29,7 @@ int app_des_handler(ACVP_TEST_CASE *test_case) {
     EVP_CIPHER_CTX *cipher_ctx;
     const EVP_CIPHER        *cipher;
     unsigned char *iv = 0;
+    ACVP_SUB_TDES alg;
 
     if (!test_case) {
         goto err;
@@ -64,113 +65,48 @@ int app_des_handler(ACVP_TEST_CASE *test_case) {
     /* Begin encrypt code section */
     cipher_ctx = glb_cipher_ctx;
 
-    switch (tc->cipher) {
-    case ACVP_TDES_ECB:
+    alg = acvp_get_tdes_alg(tc->cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+    
+    switch (alg) {
+    case ACVP_SUB_TDES_ECB:
         cipher = EVP_des_ede3_ecb();
         break;
-    case ACVP_TDES_CBC:
+    case ACVP_SUB_TDES_CBC:
         iv = tc->iv;
         cipher = EVP_des_ede3_cbc();
         break;
-    case ACVP_TDES_OFB:
+    case ACVP_SUB_TDES_OFB:
         iv = tc->iv;
         cipher = EVP_des_ede3_ofb();
         break;
-    case ACVP_TDES_CFB64:
+    case ACVP_SUB_TDES_CFB64:
         iv = tc->iv;
         cipher = EVP_des_ede3_cfb64();
         break;
-    case ACVP_TDES_CFB8:
+    case ACVP_SUB_TDES_CFB8:
         iv = tc->iv;
         cipher = EVP_des_ede3_cfb8();
         break;
-    case ACVP_TDES_CFB1:
+    case ACVP_SUB_TDES_CFB1:
         iv = tc->iv;
         cipher = EVP_des_ede3_cfb1();
         break;
-    case ACVP_TDES_CTR:
+    case ACVP_SUB_TDES_CTR:
     /*
      * IMPORTANT: if this mode is supported in your crypto module,
      * you will need to fill that out here. It is set to fall
      * through as an unsupported mode.
      */
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_TDES_CBCI:
+    case ACVP_SUB_TDES_OFBI:
+    case ACVP_SUB_TDES_CFBP1:
+    case ACVP_SUB_TDES_CFBP8:
+    case ACVP_SUB_TDES_CFBP64:
+    case ACVP_SUB_TDES_KW:
     default:
         printf("Error: Unsupported DES mode requested by ACVP server\n");
         goto err;

--- a/app/app_drbg.c
+++ b/app/app_drbg.c
@@ -62,6 +62,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
     int der_func = 0;
     unsigned int drbg_entropy_len;
     int fips_rc;
+    ACVP_SUB_DRBG alg;
 
     unsigned char   *nonce = NULL;
 
@@ -75,8 +76,14 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
      */
     drbg_entropy_len = tc->entropy_len;
 
-    switch (tc->cipher) {
-    case ACVP_HASHDRBG:
+    alg = acvp_get_drbg_alg(tc->cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_DRBG_HASH:
         nonce = tc->nonce;
         switch (tc->mode) {
         case ACVP_DRBG_SHA_1:
@@ -119,7 +126,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
         }
         break;
 
-    case ACVP_HMACDRBG:
+    case ACVP_SUB_DRBG_HMAC:
         nonce = tc->nonce;
         switch (tc->mode) {
         case ACVP_DRBG_SHA_1:
@@ -162,7 +169,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
         }
         break;
 
-    case ACVP_CTRDRBG:
+    case ACVP_SUB_DRBG_CTR:
         /*
          * DR function Only valid in CTR mode
          * if not set nonce is ignored
@@ -208,87 +215,6 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
             break;
         }
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_CIPHER_END:
     default:
         printf("%s: Unsupported algorithm %d (tc_id=%d)\n", __FUNCTION__, tc->tc_id,
                tc->cipher);

--- a/app/app_dsa.c
+++ b/app/app_dsa.c
@@ -154,6 +154,11 @@ int app_dsa_handler(ACVP_TEST_CASE *test_case) {
         case ACVP_SHA512_224:
         case ACVP_SHA512_256:
 #endif
+        case ACVP_SHA3_224:
+        case ACVP_SHA3_256:
+        case ACVP_SHA3_384:
+        case ACVP_SHA3_512:
+        case ACVP_NO_SHA:
         case ACVP_HASH_ALG_MAX:
         default:
             printf("DSA sha value not supported %d\n", tc->sha);
@@ -294,6 +299,11 @@ int app_dsa_handler(ACVP_TEST_CASE *test_case) {
         case ACVP_SHA512_224:
         case ACVP_SHA512_256:
 #endif
+        case ACVP_SHA3_224:
+        case ACVP_SHA3_256:
+        case ACVP_SHA3_384:
+        case ACVP_SHA3_512:
+        case ACVP_NO_SHA:
         case ACVP_HASH_ALG_MAX:
         default:
             printf("DSA sha value not supported %d\n", tc->sha);
@@ -388,6 +398,11 @@ int app_dsa_handler(ACVP_TEST_CASE *test_case) {
         case ACVP_SHA512_224:
         case ACVP_SHA512_256:
 #endif
+        case ACVP_SHA3_224:
+        case ACVP_SHA3_256:
+        case ACVP_SHA3_384:
+        case ACVP_SHA3_512:
+        case ACVP_NO_SHA:
         case ACVP_HASH_ALG_MAX:
         default:
             printf("DSA sha value not supported %d\n", tc->sha);
@@ -495,6 +510,11 @@ int app_dsa_handler(ACVP_TEST_CASE *test_case) {
         case ACVP_SHA512_224:
         case ACVP_SHA512_256:
 #endif
+        case ACVP_SHA3_224:
+        case ACVP_SHA3_256:
+        case ACVP_SHA3_384:
+        case ACVP_SHA3_512:
+        case ACVP_NO_SHA:
         case ACVP_HASH_ALG_MAX:
         default:
             printf("DSA sha value not supported %d\n", tc->sha);

--- a/app/app_ecdsa.c
+++ b/app/app_ecdsa.c
@@ -74,7 +74,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
 #endif
     const BIGNUM *d = NULL;
     EC_KEY *key = NULL;
-
+    ACVP_SUB_ECDSA alg;
 
     if (!test_case) {
         printf("No test case found\n");
@@ -115,6 +115,11 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
         case ACVP_SHA512_224:
         case ACVP_SHA512_256:
 #endif
+        case ACVP_SHA3_224:
+        case ACVP_SHA3_256:
+        case ACVP_SHA3_384:
+        case ACVP_SHA3_512:
+        case ACVP_NO_SHA:
         case ACVP_HASH_ALG_MAX:
         default:
             printf("Unsupported hash alg in ECDSA\n");
@@ -169,8 +174,15 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
 
-    switch (mode) {
-    case ACVP_ECDSA_KEYGEN:
+
+    alg = acvp_get_ecdsa_alg(mode);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_ECDSA_KEYGEN:
         Qx = FIPS_bn_new();
         Qy = FIPS_bn_new();
         if (!Qx || !Qy) {
@@ -200,7 +212,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
         tc->qy_len = BN_bn2bin(Qy, tc->qy);
         tc->d_len = BN_bn2bin(d, tc->d);
         break;
-    case ACVP_ECDSA_KEYVER:
+    case ACVP_SUB_ECDSA_KEYVER:
         Qx = FIPS_bn_new();
         Qy = FIPS_bn_new();
         if (!tc->qx || !tc->qy) {
@@ -226,7 +238,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
             tc->ver_disposition = ACVP_TEST_DISPOSITION_FAIL;
         }
         break;
-    case ACVP_ECDSA_SIGGEN:
+    case ACVP_SUB_ECDSA_SIGGEN:
         if (ecdsa_current_tg != tc->tg_id) {
             ecdsa_current_tg = tc->tg_id;
 
@@ -294,7 +306,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
         BN_free(r);
 # endif
         break;
-    case ACVP_ECDSA_SIGVER:
+    case ACVP_SUB_ECDSA_SIGVER:
         if (!tc->message) {
             printf("missing sigver message - nothing to verify\n");
             goto err;
@@ -366,86 +378,6 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
         }
 points_err:
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_CIPHER_END:
     default:
         printf("Unsupported ECDSA mode\n");
         break;

--- a/app/app_hmac.c
+++ b/app/app_hmac.c
@@ -22,6 +22,7 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     HMAC_CTX *hmac_ctx = NULL;
     int msg_len;
     int rc = 1;
+    ACVP_SUB_HMAC alg;
 
 #if OPENSSL_VERSION_NUMBER <= 0x10100000L
     HMAC_CTX static_ctx;
@@ -34,122 +35,55 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     tc = test_case->tc.hmac;
     if (!tc) return rc;
 
-    switch (tc->cipher) {
-    case ACVP_HMAC_SHA1:
+    alg = acvp_get_hmac_alg(tc->cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_HMAC_SHA1:
         md = EVP_sha1();
         break;
-    case ACVP_HMAC_SHA2_224:
+    case ACVP_SUB_HMAC_SHA2_224:
         md = EVP_sha224();
         break;
-    case ACVP_HMAC_SHA2_256:
+    case ACVP_SUB_HMAC_SHA2_256:
         md = EVP_sha256();
         break;
-    case ACVP_HMAC_SHA2_384:
+    case ACVP_SUB_HMAC_SHA2_384:
         md = EVP_sha384();
         break;
-    case ACVP_HMAC_SHA2_512:
+    case ACVP_SUB_HMAC_SHA2_512:
         md = EVP_sha512();
         break;
 #if OPENSSL_VERSION_NUMBER >= 0x10101010L /* OpenSSL 1.1.1 or greater */
-    case ACVP_HMAC_SHA2_512_224:
+    case ACVP_SUB_HMAC_SHA2_512_224:
         md = EVP_sha512_224();
         break;
-    case ACVP_HMAC_SHA2_512_256:
+    case ACVP_SUB_HMAC_SHA2_512_256:
         md = EVP_sha512_256();
         break;
-    case ACVP_HMAC_SHA3_224:
+    case ACVP_SUB_HMAC_SHA3_224:
         md = EVP_sha3_224();
         break;
-    case ACVP_HMAC_SHA3_256:
+    case ACVP_SUB_HMAC_SHA3_256:
         md = EVP_sha3_256();
         break;
-    case ACVP_HMAC_SHA3_384:
+    case ACVP_SUB_HMAC_SHA3_384:
         md = EVP_sha3_384();
         break;
-    case ACVP_HMAC_SHA3_512:
+    case ACVP_SUB_HMAC_SHA3_512:
         md = EVP_sha3_512();
         break;
 #else
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
+    case ACVP_SUB_HMAC_SHA2_512_224:
+    case ACVP_SUB_HMAC_SHA2_512_256:
+    case ACVP_SUB_HMAC_SHA3_224:
+    case ACVP_SUB_HMAC_SHA3_256:
+    case ACVP_SUB_HMAC_SHA3_384:
+    case ACVP_SUB_HMAC_SHA3_512:
 #endif
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_CIPHER_END:
     default:
         printf("Error: Unsupported hash algorithm requested by ACVP server\n");
         return rc;

--- a/app/app_kas.c
+++ b/app/app_kas.c
@@ -175,6 +175,11 @@ int app_kas_ecc_handler(ACVP_TEST_CASE *test_case) {
         case ACVP_SHA512_224:
         case ACVP_SHA512_256:
         case ACVP_HASH_ALG_MAX:
+        case ACVP_SHA3_224:
+        case ACVP_SHA3_256:
+        case ACVP_SHA3_384:
+        case ACVP_SHA3_512:
+        case ACVP_NO_SHA:
         default:
             printf("No valid hash name %d\n", tc->md);
             return rv;
@@ -519,6 +524,11 @@ int app_kas_ffc_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_SHA512_224:
     case ACVP_SHA512_256:
     case ACVP_HASH_ALG_MAX:
+    case ACVP_SHA3_224:
+    case ACVP_SHA3_256:
+    case ACVP_SHA3_384:
+    case ACVP_SHA3_512:
+    case ACVP_NO_SHA:
     default:
         printf("No valid hash name %d\n", tc->md);
         return rv;
@@ -604,7 +614,28 @@ int app_kas_ffc_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_KAS_FFC_FFDHE8192:
         dh = DH_new_by_nid(NID_ffdhe8192);
         break;
+#else
+
+    case ACVP_KAS_FFC_MODP2048:
+    case ACVP_KAS_FFC_MODP3072:
+    case ACVP_KAS_FFC_MODP4096:
+    case ACVP_KAS_FFC_MODP6144:
+    case ACVP_KAS_FFC_MODP8192:
+    case ACVP_KAS_FFC_FFDHE2048:
+    case ACVP_KAS_FFC_FFDHE3072:
+    case ACVP_KAS_FFC_FFDHE4096:
+    case ACVP_KAS_FFC_FFDHE6144:
+        printf("\nInvalid dgm for this version");
+        goto error;
+        break;
 #endif
+    case ACVP_KAS_FFC_FFDHE8192:
+    case ACVP_KAS_FFC_FUNCTION:
+    case ACVP_KAS_FFC_CURVE:
+    case ACVP_KAS_FFC_ROLE:
+    case ACVP_KAS_FFC_HASH:
+    case ACVP_KAS_FFC_GEN_METH:
+    case ACVP_KAS_FFC_KDF:
     default:
         printf("\nInvalid dgm");
         goto error;
@@ -746,6 +777,11 @@ int app_kas_ifc_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_SHA512_224:
     case ACVP_SHA512_256:
     case ACVP_HASH_ALG_MAX:
+    case ACVP_SHA3_224:
+    case ACVP_SHA3_256:
+    case ACVP_SHA3_384:
+    case ACVP_SHA3_512:
+    case ACVP_NO_SHA:
     default:
         printf("No valid hash name %d\n", tc->md);
         return rv;
@@ -1018,17 +1054,14 @@ int app_safe_primes_handler(ACVP_TEST_CASE *test_case)
         BN_bin2bn(tc->x, tc->xlen, priv_key_ver);
         BN_bin2bn(tc->y, tc->ylen, pub_key_ver);
         if (BN_is_zero(priv_key_ver)) {
-            printf("Zero failed\n"); 
             tc->result = 0;
             goto end;
         }
         if (BN_is_negative(priv_key_ver)) {
-            printf("Negative failed\n"); 
             tc->result = 0;
             goto end;
         }
         if (BN_cmp(q1, priv_key_ver) != 1) {
-            printf("Compare failed\n"); 
             tc->result = 0;
             goto end;
         }
@@ -1041,7 +1074,6 @@ int app_safe_primes_handler(ACVP_TEST_CASE *test_case)
         }
         BN_mod_exp(tmp_pub_key, gver, priv_key_ver, pver, c); 
         if (BN_cmp(tmp_pub_key, pub_key_ver) != 0) {
-            printf("Pub key compare failed\n"); 
             tc->result = 0;
             goto end;
         }
@@ -1062,6 +1094,9 @@ err:
     if (dh) DH_free(dh);
     return rv;
 #else 
+    if (!test_case) {
+        return -1;
+    }
     printf("Safe Primes not supported prior to 1.1.1/n");
     return 1;
 #endif

--- a/app/app_kas_kdf.c
+++ b/app/app_kas_kdf.c
@@ -123,12 +123,16 @@ int app_kas_hkdf_handler(ACVP_TEST_CASE *test_case) {
                 memcpy_s(fixedInfo + tmp, fixedInfoLen - tmp, (char *)&lBits, 4);
                 tmp += 4;
                 break;
+            case ACVP_KAS_KDF_PATTERN_NONE:
+            case ACVP_KAS_KDF_PATTERN_MAX:
             default:
                 printf("Invalid fixedInfoPattern candidate value\n");
                 goto end;
             }
         }
         break;
+    case ACVP_KAS_KDF_ENCODING_NONE:
+    case ACVP_KAS_KDF_ENCODING_MAX:
     default:
         printf("Invalid encoding for fixed info provided in test case\n");
         goto end;
@@ -184,6 +188,9 @@ int app_kas_hkdf_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_SHA3_384:
     case ACVP_SHA3_512:
 #endif
+    case ACVP_SHA1:
+    case ACVP_NO_SHA:
+    case ACVP_HASH_ALG_MAX:
     default:
         printf("Invalid hmac algorithm provided in test case\n");
         goto end;
@@ -305,6 +312,8 @@ int app_kas_kdf_onestep_handler(ACVP_TEST_CASE *test_case) {
 #endif
     HMAC_CTX *hmac_ctx = NULL;
     EVP_MD_CTX *sha_ctx = NULL;
+    ACVP_SUB_HASH hashalg;
+    ACVP_SUB_HMAC hmacalg;
 
     if (!test_case) {
         printf("Missing KDF onestep test case\n");
@@ -411,89 +420,151 @@ int app_kas_kdf_onestep_handler(ACVP_TEST_CASE *test_case) {
                 memcpy_s(fixedInfo + tmp, fixedInfoLen - tmp, (char *)&lBits, 4);
                 tmp += 4;
                 break;
+            case ACVP_KAS_KDF_PATTERN_NONE:
+            case ACVP_KAS_KDF_PATTERN_MAX:
             default:
                 printf("Invalid fixedInfoPattern candidate value\n");
                 goto end;
             }
         }
         break;
+    case ACVP_KAS_KDF_ENCODING_NONE:
+    case ACVP_KAS_KDF_ENCODING_MAX:
     default:
         printf("Invalid encoding for fixed info provided in test case\n");
         goto end;
     }
 
-    switch (stc->aux_function) {
-    case ACVP_HASH_SHA224:
-    case ACVP_HMAC_SHA2_224:
+  if (isSha) {
+    hashalg = acvp_get_hash_alg(stc->aux_function);
+    if (hashalg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (hashalg) {
+    case ACVP_SUB_HASH_SHA2_224:
         md = EVP_sha224();
         h_output_len = 224;
         break;
-    case ACVP_HASH_SHA256:
-    case ACVP_HMAC_SHA2_256:
+    case ACVP_SUB_HASH_SHA2_256:
         md = EVP_sha256();
         h_output_len = 256;
         break;
-    case ACVP_HASH_SHA384:
-    case ACVP_HMAC_SHA2_384:
+    case ACVP_SUB_HASH_SHA2_384:
         md = EVP_sha384();
         h_output_len = 384;
         break;
-    case ACVP_HASH_SHA512:
-    case ACVP_HMAC_SHA2_512:
+    case ACVP_SUB_HASH_SHA2_512:
         md = EVP_sha512();
         h_output_len = 512;
         break;
 #if OPENSSL_VERSION_NUMBER >= 0x10101010L /* OpenSSL 1.1.1 or greater */
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HMAC_SHA2_512_224:
+    case ACVP_SUB_HASH_SHA2_512_224:
         md = EVP_sha512_224();
         h_output_len = 224;
         break;
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HMAC_SHA2_512_256:
+    case ACVP_SUB_HASH_SHA2_512_256:
         md = EVP_sha512_256();
         h_output_len = 256;
         break;
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HMAC_SHA3_224:
+    case ACVP_SUB_HASH_SHA3_224:
         md = EVP_sha3_224();
         h_output_len = 224;
         break;
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HMAC_SHA3_256:
+    case ACVP_SUB_HASH_SHA3_256:
         md = EVP_sha3_256();
         h_output_len = 256;
         break;
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HMAC_SHA3_384:
+    case ACVP_SUB_HASH_SHA3_384:
         md = EVP_sha3_384();
         h_output_len = 384;
         break;
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HMAC_SHA3_512:
+    case ACVP_SUB_HASH_SHA3_512:
         md = EVP_sha3_512();
         h_output_len = 512;
         break;
 #else
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HMAC_SHA3_512:
+    case ACVP_SUB_HASH_SHA2_512_224:
+    case ACVP_SUB_HASH_SHA2_512_256:
+    case ACVP_SUB_HASH_SHA3_224:
+    case ACVP_SUB_HASH_SHA3_256:
+    case ACVP_SUB_HASH_SHA3_384:
+    case ACVP_SUB_HASH_SHA3_512:
 #endif
+    case ACVP_SUB_HASH_SHA1:
+    case ACVP_SUB_HASH_SHAKE_128:
+    case ACVP_SUB_HASH_SHAKE_256:
     default:
         printf("Invalid aux function provided in test case\n");
         goto end;
         break;
     }
 
+  } else {
+    hmacalg = acvp_get_hmac_alg(stc->aux_function);
+    if (hmacalg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (hmacalg) {
+    case ACVP_SUB_HMAC_SHA2_224:
+        md = EVP_sha224();
+        h_output_len = 224;
+        break;
+    case ACVP_SUB_HMAC_SHA2_256:
+        md = EVP_sha256();
+        h_output_len = 256;
+        break;
+    case ACVP_SUB_HMAC_SHA2_384:
+        md = EVP_sha384();
+        h_output_len = 384;
+        break;
+    case ACVP_SUB_HMAC_SHA2_512:
+        md = EVP_sha512();
+        h_output_len = 512;
+        break;
+#if OPENSSL_VERSION_NUMBER >= 0x10101010L /* OpenSSL 1.1.1 or greater */
+    case ACVP_SUB_HMAC_SHA2_512_224:
+        md = EVP_sha512_224();
+        h_output_len = 224;
+        break;
+    case ACVP_SUB_HMAC_SHA2_512_256:
+        md = EVP_sha512_256();
+        h_output_len = 256;
+        break;
+    case ACVP_SUB_HMAC_SHA3_224:
+        md = EVP_sha3_224();
+        h_output_len = 224;
+        break;
+    case ACVP_SUB_HMAC_SHA3_256:
+        md = EVP_sha3_256();
+        h_output_len = 256;
+        break;
+    case ACVP_SUB_HMAC_SHA3_384:
+        md = EVP_sha3_384();
+        h_output_len = 384;
+        break;
+    case ACVP_SUB_HMAC_SHA3_512:
+        md = EVP_sha3_512();
+        h_output_len = 512;
+        break;
+#else
+    case ACVP_SUB_HMAC_SHA2_512_224:
+    case ACVP_SUB_HMAC_SHA2_512_256:
+    case ACVP_SUB_HMAC_SHA3_224:
+    case ACVP_SUB_HMAC_SHA3_256:
+    case ACVP_SUB_HMAC_SHA3_384:
+    case ACVP_SUB_HMAC_SHA3_512:
+#endif
+    case ACVP_SUB_HMAC_SHA1:
+    default:
+        printf("Invalid aux function provided in test case\n");
+        goto end;
+        break;
+    }
+  }
     //convert h_output_len to bytes for use with functions
     h_output_len /= 8;
 

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -81,7 +81,7 @@ typedef struct app_config {
 int ingest_cli(APP_CONFIG *cfg, int argc, char **argv);
 int app_setup_two_factor_auth(ACVP_CTX *ctx);
 unsigned int convert_uint_to_big_endian(unsigned int i);
-int check_is_little_endian();
+int check_is_little_endian(void);
 
 void app_aes_cleanup(void);
 void app_des_cleanup(void);

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -473,9 +473,9 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_IVLEN, 96);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_PTLEN, 0, 65536, 256);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_AADLEN, 0, 65536, 256);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_DOMAIN_AADLEN, 0, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
     /*
@@ -536,7 +536,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PTLEN, 256, 65536, 64);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
     
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
@@ -549,7 +549,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_PTLEN, 256, 65536, 64);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
@@ -562,7 +562,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PTLEN, 256, 65536, 64);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
@@ -677,15 +677,15 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_PTLEN, 0, 256, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 256, 8);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 32);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 128);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_IVLEN, 56, 104, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_DOMAIN_IVLEN, 56, 104, 8);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_AADLEN, 0, 524288, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_DOMAIN_AADLEN, 0, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
     /*
@@ -713,7 +713,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PTLEN, 128, 65536, 64);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 64);
     CHECK_ENABLE_CAP_RV(rv);
 #ifdef OPENSSL_KWP
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
@@ -736,7 +736,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_PTLEN, 0, 65536, 256);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
 #endif
     /*
@@ -758,7 +758,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_PTLEN, 256, 65536, 256);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_DOMAIN_PTLEN, 256, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_TWEAK, ACVP_SYM_CIPH_TWEAK_HEX);
     CHECK_ENABLE_CAP_RV(rv);
@@ -793,7 +793,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PTLEN, 8, 128, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_DOMAIN_PTLEN, 8, 128, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
     //GMAC
@@ -823,7 +823,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_IVLEN, 96);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_AADLEN, 256, 65536, 256);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_DOMAIN_AADLEN, 256, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
 #if 0 //not currently supported by openSSL
@@ -843,9 +843,9 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_PTLEN, 0, 65536, 256);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_AADLEN, 0, 65536, 256);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GCM_SIV, ACVP_SYM_CIPH_DOMAIN_AADLEN, 0, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
@@ -873,9 +873,9 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_TAGLEN, 128);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PTLEN, 0, 65536, 256);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_AADLEN, 0, 65536, 256);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_DOMAIN_AADLEN, 0, 65536, 256);
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
@@ -1666,6 +1666,8 @@ static int enable_kts_ifc(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     BIGNUM *expo = NULL;
     char *expo_str = NULL;
+    char iut_id[] = "DEADDEAD";
+    char concatenation[] = "concatenation";
 
     expo = BN_new();
     if (!expo || !BN_set_word(expo, RSA_F4)) {
@@ -1687,7 +1689,7 @@ static int enable_kts_ifc(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kts_ifc_set_param_string(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_FIXEDPUBEXP, expo_str);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_kts_ifc_set_param_string(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_IUT_ID, "CAFEBABE");
+    rv = acvp_cap_kts_ifc_set_param_string(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_IUT_ID, iut_id);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_FUNCTION, ACVP_KTS_IFC_KEYPAIR_GEN);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1712,7 +1714,7 @@ static int enable_kts_ifc(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_NULL_ASSOC_DATA, 1);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_kts_ifc_set_scheme_string(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_ENCODING, "concatenation");
+    rv = acvp_cap_kts_ifc_set_scheme_string(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_ENCODING, concatenation);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_L, 512);
     CHECK_ENABLE_CAP_RV(rv);

--- a/app/app_rsa.c
+++ b/app/app_rsa.c
@@ -207,6 +207,11 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_SHA512_224:
     case ACVP_SHA512_256:
 #endif
+    case ACVP_NO_SHA:
+    case ACVP_SHA3_224:
+    case ACVP_SHA3_256:
+    case ACVP_SHA3_384:
+    case ACVP_SHA3_512:
     case ACVP_HASH_ALG_MAX:
     default:
         printf("\nError: hashAlg not supported for RSA SigGen\n");

--- a/app/app_sha.c
+++ b/app/app_sha.c
@@ -23,6 +23,7 @@ int app_sha_handler(ACVP_TEST_CASE *test_case) {
     /* assume fail */
     int rc = 1;
     int sha3 = 0, shake = 0;
+    ACVP_SUB_HASH alg;
 
     if (!test_case) {
         return 1;
@@ -31,134 +32,69 @@ int app_sha_handler(ACVP_TEST_CASE *test_case) {
     tc = test_case->tc.hash;
     if (!tc) return rc;
 
-    switch (tc->cipher) {
-    case ACVP_HASH_SHA1:
+    alg = acvp_get_hash_alg(tc->cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_HASH_SHA1:
         md = EVP_sha1();
         break;
-    case ACVP_HASH_SHA224:
+    case ACVP_SUB_HASH_SHA2_224:
         md = EVP_sha224();
         break;
-    case ACVP_HASH_SHA256:
+    case ACVP_SUB_HASH_SHA2_256:
         md = EVP_sha256();
         break;
-    case ACVP_HASH_SHA384:
+    case ACVP_SUB_HASH_SHA2_384:
         md = EVP_sha384();
         break;
-    case ACVP_HASH_SHA512:
+    case ACVP_SUB_HASH_SHA2_512:
         md = EVP_sha512();
         break;
 #if OPENSSL_VERSION_NUMBER >= 0x10101010L /* OpenSSL 1.1.1 or greater */
-    case ACVP_HASH_SHA512_224:
+    case ACVP_SUB_HASH_SHA2_512_224:
         md = EVP_sha512_224();
         break;
-    case ACVP_HASH_SHA512_256:
+    case ACVP_SUB_HASH_SHA2_512_256:
         md = EVP_sha512_256();
         break;
-    case ACVP_HASH_SHA3_224:
+    case ACVP_SUB_HASH_SHA3_224:
         md = EVP_sha3_224();
         sha3 = 1;
         break;
-    case ACVP_HASH_SHA3_256:
+    case ACVP_SUB_HASH_SHA3_256:
         md = EVP_sha3_256();
         sha3 = 1;
         break;
-    case ACVP_HASH_SHA3_384:
+    case ACVP_SUB_HASH_SHA3_384:
         md = EVP_sha3_384();
         sha3 = 1;
         break;
-    case ACVP_HASH_SHA3_512:
+    case ACVP_SUB_HASH_SHA3_512:
         md = EVP_sha3_512();
         sha3 = 1;
         break;
-    case ACVP_HASH_SHAKE_128:
+    case ACVP_SUB_HASH_SHAKE_128:
         md = EVP_shake128();
         shake = 1;
         break;
-    case ACVP_HASH_SHAKE_256:
+    case ACVP_SUB_HASH_SHAKE_256:
         md = EVP_shake256();
         shake = 1;
         break;
 #else
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
+    case ACVP_SUB_HASH_SHA2_512_224:
+    case ACVP_SUB_HASH_SHA2_512_256:
+    case ACVP_SUB_HASH_SHA3_224:
+    case ACVP_SUB_HASH_SHA3_256:
+    case ACVP_SUB_HASH_SHA3_384:
+    case ACVP_SUB_HASH_SHA3_512:
+    case ACVP_SUB_HASH_SHAKE_128:
+    case ACVP_SUB_HASH_SHAKE_256:
 #endif
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_CIPHER_END:
     default:
         printf("Error: Unsupported hash algorithm requested by ACVP server\n");
         return ACVP_NO_CAP;

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -179,6 +179,150 @@ typedef enum acvp_cipher {
     ACVP_CIPHER_END
 } ACVP_CIPHER;
 
+
+/*
+ * The following are sub-type algorithms which can be used within
+ * algorithm specific code to avoid having to include all the
+ * above enums in the case statements. 
+ *
+ * To get the sub-type enum call the algorithm specific functions
+ * in acvp.c such as acvp_get_aes_alg(CIPHER).
+ *
+ * These enums MUST maintain the same values as the CIPHER enum
+ * above thus ordering is of the utmost importance.
+ */
+typedef enum acvp_alg_type_aes {
+    ACVP_SUB_AES_GCM = ACVP_AES_GCM,
+    ACVP_SUB_AES_GCM_SIV,
+    ACVP_SUB_AES_CCM,
+    ACVP_SUB_AES_ECB,
+    ACVP_SUB_AES_CBC,
+    ACVP_SUB_AES_CBC_CS1,
+    ACVP_SUB_AES_CBC_CS2,
+    ACVP_SUB_AES_CBC_CS3,
+    ACVP_SUB_AES_CFB1,
+    ACVP_SUB_AES_CFB8,
+    ACVP_SUB_AES_CFB128,
+    ACVP_SUB_AES_OFB,
+    ACVP_SUB_AES_CTR,
+    ACVP_SUB_AES_XTS,
+    ACVP_SUB_AES_XPN,
+    ACVP_SUB_AES_KW,
+    ACVP_SUB_AES_KWP,
+    ACVP_SUB_AES_GMAC
+} ACVP_SUB_AES;
+
+typedef enum acvp_alg_type_tdes {
+    ACVP_SUB_TDES_ECB = ACVP_TDES_ECB,
+    ACVP_SUB_TDES_CBC,
+    ACVP_SUB_TDES_CBCI,
+    ACVP_SUB_TDES_OFB,
+    ACVP_SUB_TDES_OFBI,
+    ACVP_SUB_TDES_CFB1,
+    ACVP_SUB_TDES_CFB8,
+    ACVP_SUB_TDES_CFB64,
+    ACVP_SUB_TDES_CFBP1,
+    ACVP_SUB_TDES_CFBP8,
+    ACVP_SUB_TDES_CFBP64,
+    ACVP_SUB_TDES_CTR,
+    ACVP_SUB_TDES_KW
+} ACVP_SUB_TDES;
+
+typedef enum acvp_alg_type_cmac {
+    ACVP_SUB_CMAC_AES = ACVP_CMAC_AES,
+    ACVP_SUB_CMAC_TDES
+} ACVP_SUB_CMAC;
+
+typedef enum acvp_alg_type_hmac {
+    ACVP_SUB_HMAC_SHA1 = ACVP_HMAC_SHA1,
+    ACVP_SUB_HMAC_SHA2_224,
+    ACVP_SUB_HMAC_SHA2_256,
+    ACVP_SUB_HMAC_SHA2_384,
+    ACVP_SUB_HMAC_SHA2_512,
+    ACVP_SUB_HMAC_SHA2_512_224,
+    ACVP_SUB_HMAC_SHA2_512_256,
+    ACVP_SUB_HMAC_SHA3_224,
+    ACVP_SUB_HMAC_SHA3_256,
+    ACVP_SUB_HMAC_SHA3_384,
+    ACVP_SUB_HMAC_SHA3_512
+} ACVP_SUB_HMAC;
+
+typedef enum acvp_alg_type_hash {
+    ACVP_SUB_HASH_SHA1 = ACVP_HASH_SHA1,
+    ACVP_SUB_HASH_SHA2_224,
+    ACVP_SUB_HASH_SHA2_256,
+    ACVP_SUB_HASH_SHA2_384,
+    ACVP_SUB_HASH_SHA2_512,
+    ACVP_SUB_HASH_SHA2_512_224,
+    ACVP_SUB_HASH_SHA2_512_256,
+    ACVP_SUB_HASH_SHA3_224,
+    ACVP_SUB_HASH_SHA3_256,
+    ACVP_SUB_HASH_SHA3_384,
+    ACVP_SUB_HASH_SHA3_512,
+    ACVP_SUB_HASH_SHAKE_128,
+    ACVP_SUB_HASH_SHAKE_256
+} ACVP_SUB_HASH;
+
+typedef enum acvp_alg_type_dsa {
+    ACVP_SUB_DSA_KEYGEN = ACVP_DSA_KEYGEN,
+    ACVP_SUB_DSA_PQGGEN,
+    ACVP_SUB_DSA_PQGVER,
+    ACVP_SUB_DSA_SIGGEN,
+    ACVP_SUB_DSA_SIGVER,
+} ACVP_SUB_DSA;
+
+typedef enum acvp_alg_type_rsa {
+    ACVP_SUB_RSA_KEYGEN = ACVP_RSA_KEYGEN,
+    ACVP_SUB_RSA_SIGGEN,
+    ACVP_SUB_RSA_SIGVER,
+    ACVP_SUB_RSA_DECPRIM,
+    ACVP_SUB_RSA_SIGPRIM
+} ACVP_SUB_RSA;
+
+typedef enum acvp_alg_type_ecdsa {
+    ACVP_SUB_ECDSA_KEYGEN = ACVP_ECDSA_KEYGEN,
+    ACVP_SUB_ECDSA_KEYVER,
+    ACVP_SUB_ECDSA_SIGGEN,
+    ACVP_SUB_ECDSA_SIGVER
+} ACVP_SUB_ECDSA;
+
+typedef enum acvp_alg_type_drbg {
+    ACVP_SUB_DRBG_HASH = ACVP_HASHDRBG,
+    ACVP_SUB_DRBG_HMAC,
+    ACVP_SUB_DRBG_CTR
+} ACVP_SUB_DRBG;
+
+typedef enum acvp_alg_type_kas {
+    ACVP_SUB_KAS_ECC_CDH = ACVP_KAS_ECC_CDH,
+    ACVP_SUB_KAS_ECC_COMP,
+    ACVP_SUB_KAS_ECC_NOCOMP,
+    ACVP_SUB_KAS_ECC_SSC,
+    ACVP_SUB_KAS_FFC_COMP,
+    ACVP_SUB_KAS_FFC_SSC,
+    ACVP_SUB_KAS_FFC_NOCOMP,
+    ACVP_SUB_KAS_IFC_SSC,
+    ACVP_SUB_KTS_IFC,
+    ACVP_SUB_KAS_KDF_ONESTEP,
+    ACVP_SUB_KAS_HKDF,
+    ACVP_SUB_SAFE_PRIMES_KEYGEN,
+    ACVP_SUB_SAFE_PRIMES_KEYVER
+} ACVP_SUB_KAS;
+
+typedef enum acvp_alg_type_kdf {
+    ACVP_SUB_KDF_TLS = ACVP_KDF135_TLS,
+    ACVP_SUB_KDF_SNMP,
+    ACVP_SUB_KDF_SSH,
+    ACVP_SUB_KDF_SRTP,
+    ACVP_SUB_KDF_IKEV2,
+    ACVP_SUB_KDF_IKEV1,
+    ACVP_SUB_KDF_X963,
+    ACVP_SUB_KDF_108,
+    ACVP_SUB_KDF_PBKDF
+} ACVP_SUB_KDF;
+
+
+#define CIPHER_TO_ALG(alg2) (alg_tbl[cipher].alg.alg2)
+
 /*! @struct ACVP_PREREQ_ALG
  *  @brief This enum lists the prerequisities that are available
  *  to the library during registration. Whereas an ACVP_CIPHER may
@@ -581,8 +725,8 @@ typedef struct acvp_rsa_prim_tc_t {
     char *plaintext;
     int deferred;
     int modulo;
-    int fail;
-    int pass;
+    unsigned int fail;
+    unsigned int pass;
     int key_format;
     unsigned char *n;
     int n_len;
@@ -615,6 +759,14 @@ typedef enum acvp_sym_cipher_parameter {
     ACVP_SYM_CIPH_PARM_SALT_SRC,
     ACVP_SYM_CIPH_PARM_CONFORMANCE
 } ACVP_SYM_CIPH_PARM;
+
+
+/*! @struct ACVP_SYM_CIPHER_DOMAIN_PARM */
+typedef enum acvp_sym_cipher_domain_parameter {
+    ACVP_SYM_CIPH_DOMAIN_IVLEN = 1,
+    ACVP_SYM_CIPH_DOMAIN_PTLEN,
+    ACVP_SYM_CIPH_DOMAIN_AADLEN
+} ACVP_SYM_CIPH_DOMAIN_PARM;
 
 /*! @struct ACVP_SYM_CIPH_TWEAK_MODE */
 typedef enum acvp_sym_xts_tweak_mode {
@@ -1968,7 +2120,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
  */
 ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
                                            ACVP_CIPHER cipher,
-                                           ACVP_SYM_CIPH_PARM parm,
+                                           ACVP_SYM_CIPH_DOMAIN_PARM parm,
                                            int min,
                                            int max,
                                            int increment);
@@ -3662,6 +3814,18 @@ const char *acvp_version(void);
  * @return (char *) protocol version, formated like: 0.5
  */
 const char *acvp_protocol_version(void);
+
+ACVP_SUB_CMAC acvp_get_cmac_alg(ACVP_CIPHER cipher);
+ACVP_SUB_HASH acvp_get_hash_alg(ACVP_CIPHER cipher);
+ACVP_SUB_AES acvp_get_aes_alg(ACVP_CIPHER cipher);
+ACVP_SUB_TDES acvp_get_tdes_alg(ACVP_CIPHER cipher);
+ACVP_SUB_HMAC acvp_get_hmac_alg(ACVP_CIPHER cipher);
+ACVP_SUB_ECDSA acvp_get_ecdsa_alg(ACVP_CIPHER cipher);
+ACVP_SUB_RSA acvp_get_rsa_alg(ACVP_CIPHER cipher);
+ACVP_SUB_DSA acvp_get_dsa_alg(ACVP_CIPHER cipher);
+ACVP_SUB_KDF acvp_get_kdf_alg(ACVP_CIPHER cipher);
+ACVP_SUB_DRBG acvp_get_drbg_alg(ACVP_CIPHER cipher);
+ACVP_SUB_KAS acvp_get_kas_alg(ACVP_CIPHER cipher);
 
 #ifdef __cplusplus
 }

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -879,6 +879,19 @@ struct acvp_alg_handler_t {
     const char *name;
     const char *mode; /** < Should be NULL unless using an asymmetric alg */
     const char *revision;
+    union {
+        ACVP_SUB_AES      aes;
+        ACVP_SUB_TDES     tdes;
+        ACVP_SUB_CMAC     cmac;
+        ACVP_SUB_KDF      kdf;
+        ACVP_SUB_DSA      dsa;
+        ACVP_SUB_RSA      rsa;
+        ACVP_SUB_ECDSA    ecdsa;
+        ACVP_SUB_DRBG     drbg;
+        ACVP_SUB_HMAC     hmac;
+        ACVP_SUB_HASH     hash;
+        ACVP_SUB_KAS      kas;
+    } alg;
 };
 
 typedef struct acvp_vs_list_t {

--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -119,3 +119,14 @@ EXPORTS
   acvp_cap_kts_ifc_set_scheme_parm
   acvp_cap_kts_ifc_set_param_string
   acvp_cap_kts_ifc_set_scheme_string
+  acvp_get_cmac_alg
+  acvp_get_hash_alg
+  acvp_get_aes_alg
+  acvp_get_tdes_alg
+  acvp_get_hmac_alg
+  acvp_get_ecdsa_alg
+  acvp_get_rsa_alg
+  acvp_get_dsa_alg
+  acvp_get_kdf_alg
+  acvp_get_drbg_alg
+  acvp_get_kas_alg

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -69,102 +69,102 @@ static ACVP_RESULT acvp_put_data_from_ctx(ACVP_CTX *ctx);
  * This table is not sparse, it must contain ACVP_OP_MAX entries.
  */
 ACVP_ALG_HANDLER alg_tbl[ACVP_ALG_MAX] = {
-    { ACVP_AES_GCM,           &acvp_aes_kat_handler,             ACVP_ALG_AES_GCM,           NULL, ACVP_REV_AES_GCM},
-    { ACVP_AES_GCM_SIV,       &acvp_aes_kat_handler,             ACVP_ALG_AES_GCM_SIV,       NULL, ACVP_REV_AES_GCM_SIV},
-    { ACVP_AES_CCM,           &acvp_aes_kat_handler,             ACVP_ALG_AES_CCM,           NULL, ACVP_REV_AES_CCM},
-    { ACVP_AES_ECB,           &acvp_aes_kat_handler,             ACVP_ALG_AES_ECB,           NULL, ACVP_REV_AES_ECB},
-    { ACVP_AES_CBC,           &acvp_aes_kat_handler,             ACVP_ALG_AES_CBC,           NULL, ACVP_REV_AES_CBC},
-    { ACVP_AES_CBC_CS1,       &acvp_aes_kat_handler,             ACVP_ALG_AES_CBC_CS1,       NULL, ACVP_REV_AES_CBC_CS1},
-    { ACVP_AES_CBC_CS2,       &acvp_aes_kat_handler,             ACVP_ALG_AES_CBC_CS2,       NULL, ACVP_REV_AES_CBC_CS2},
-    { ACVP_AES_CBC_CS3,       &acvp_aes_kat_handler,             ACVP_ALG_AES_CBC_CS3,       NULL, ACVP_REV_AES_CBC_CS3},
-    { ACVP_AES_CFB1,          &acvp_aes_kat_handler,             ACVP_ALG_AES_CFB1,          NULL, ACVP_REV_AES_CFB1},
-    { ACVP_AES_CFB8,          &acvp_aes_kat_handler,             ACVP_ALG_AES_CFB8,          NULL, ACVP_REV_AES_CFB8},
-    { ACVP_AES_CFB128,        &acvp_aes_kat_handler,             ACVP_ALG_AES_CFB128,        NULL, ACVP_REV_AES_CFB128},
-    { ACVP_AES_OFB,           &acvp_aes_kat_handler,             ACVP_ALG_AES_OFB,           NULL, ACVP_REV_AES_OFB},
-    { ACVP_AES_CTR,           &acvp_aes_kat_handler,             ACVP_ALG_AES_CTR,           NULL, ACVP_REV_AES_CTR},
-    { ACVP_AES_XTS,           &acvp_aes_kat_handler,             ACVP_ALG_AES_XTS,           NULL, ACVP_REV_AES_XTS},
-    { ACVP_AES_KW,            &acvp_aes_kat_handler,             ACVP_ALG_AES_KW,            NULL, ACVP_REV_AES_KW},
-    { ACVP_AES_KWP,           &acvp_aes_kat_handler,             ACVP_ALG_AES_KWP,           NULL, ACVP_REV_AES_KWP},
-    { ACVP_AES_GMAC,          &acvp_aes_kat_handler,             ACVP_ALG_AES_GMAC,          NULL, ACVP_REV_AES_GMAC},
-    { ACVP_AES_XPN,           &acvp_aes_kat_handler,             ACVP_ALG_AES_XPN ,          NULL, ACVP_REV_AES_XPN},
-    { ACVP_TDES_ECB,          &acvp_des_kat_handler,             ACVP_ALG_TDES_ECB,          NULL, ACVP_REV_TDES_ECB},
-    { ACVP_TDES_CBC,          &acvp_des_kat_handler,             ACVP_ALG_TDES_CBC,          NULL, ACVP_REV_TDES_CBC},
-    { ACVP_TDES_CBCI,         &acvp_des_kat_handler,             ACVP_ALG_TDES_CBCI,         NULL, ACVP_REV_TDES_CBCI},
-    { ACVP_TDES_OFB,          &acvp_des_kat_handler,             ACVP_ALG_TDES_OFB,          NULL, ACVP_REV_TDES_OFB},
-    { ACVP_TDES_OFBI,         &acvp_des_kat_handler,             ACVP_ALG_TDES_OFBI,         NULL, ACVP_REV_TDES_OFBI},
-    { ACVP_TDES_CFB1,         &acvp_des_kat_handler,             ACVP_ALG_TDES_CFB1,         NULL, ACVP_REV_TDES_CFB1},
-    { ACVP_TDES_CFB8,         &acvp_des_kat_handler,             ACVP_ALG_TDES_CFB8,         NULL, ACVP_REV_TDES_CFB8},
-    { ACVP_TDES_CFB64,        &acvp_des_kat_handler,             ACVP_ALG_TDES_CFB64,        NULL, ACVP_REV_TDES_CFB64},
-    { ACVP_TDES_CFBP1,        &acvp_des_kat_handler,             ACVP_ALG_TDES_CFBP1,        NULL, ACVP_REV_TDES_CFBP1},
-    { ACVP_TDES_CFBP8,        &acvp_des_kat_handler,             ACVP_ALG_TDES_CFBP8,        NULL, ACVP_REV_TDES_CFBP8},
-    { ACVP_TDES_CFBP64,       &acvp_des_kat_handler,             ACVP_ALG_TDES_CFBP64,       NULL, ACVP_REV_TDES_CFBP64},
-    { ACVP_TDES_CTR,          &acvp_des_kat_handler,             ACVP_ALG_TDES_CTR,          NULL, ACVP_REV_TDES_CTR},
-    { ACVP_TDES_KW,           &acvp_des_kat_handler,             ACVP_ALG_TDES_KW,           NULL, ACVP_REV_TDES_KW},
-    { ACVP_HASH_SHA1,         &acvp_hash_kat_handler,            ACVP_ALG_SHA1,              NULL, ACVP_REV_HASH_SHA1},
-    { ACVP_HASH_SHA224,       &acvp_hash_kat_handler,            ACVP_ALG_SHA224,            NULL, ACVP_REV_HASH_SHA224},
-    { ACVP_HASH_SHA256,       &acvp_hash_kat_handler,            ACVP_ALG_SHA256,            NULL, ACVP_REV_HASH_SHA256},
-    { ACVP_HASH_SHA384,       &acvp_hash_kat_handler,            ACVP_ALG_SHA384,            NULL, ACVP_REV_HASH_SHA384},
-    { ACVP_HASH_SHA512,       &acvp_hash_kat_handler,            ACVP_ALG_SHA512,            NULL, ACVP_REV_HASH_SHA512},
-    { ACVP_HASH_SHA512_224,   &acvp_hash_kat_handler,            ACVP_ALG_SHA512_224,        NULL, ACVP_REV_HASH_SHA512_224},
-    { ACVP_HASH_SHA512_256,   &acvp_hash_kat_handler,            ACVP_ALG_SHA512_256,        NULL, ACVP_REV_HASH_SHA512_256},
-    { ACVP_HASH_SHA3_224,     &acvp_hash_kat_handler,            ACVP_ALG_SHA3_224,          NULL, ACVP_REV_HASH_SHA3_224},
-    { ACVP_HASH_SHA3_256,     &acvp_hash_kat_handler,            ACVP_ALG_SHA3_256,          NULL, ACVP_REV_HASH_SHA3_256},
-    { ACVP_HASH_SHA3_384,     &acvp_hash_kat_handler,            ACVP_ALG_SHA3_384,          NULL, ACVP_REV_HASH_SHA3_384},
-    { ACVP_HASH_SHA3_512,     &acvp_hash_kat_handler,            ACVP_ALG_SHA3_512,          NULL, ACVP_REV_HASH_SHA3_512},
-    { ACVP_HASH_SHAKE_128,    &acvp_hash_kat_handler,            ACVP_ALG_SHAKE_128,         NULL, ACVP_REV_HASH_SHAKE_128},
-    { ACVP_HASH_SHAKE_256,    &acvp_hash_kat_handler,            ACVP_ALG_SHAKE_256,         NULL, ACVP_REV_HASH_SHAKE_256},
-    { ACVP_HASHDRBG,          &acvp_drbg_kat_handler,            ACVP_ALG_HASHDRBG,          NULL, ACVP_REV_HASHDRBG},
-    { ACVP_HMACDRBG,          &acvp_drbg_kat_handler,            ACVP_ALG_HMACDRBG,          NULL, ACVP_REV_HMACDRBG},
-    { ACVP_CTRDRBG,           &acvp_drbg_kat_handler,            ACVP_ALG_CTRDRBG,           NULL, ACVP_REV_CTRDRBG},
-    { ACVP_HMAC_SHA1,         &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA1,         NULL, ACVP_REV_HMAC_SHA1},
-    { ACVP_HMAC_SHA2_224,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_224,     NULL, ACVP_REV_HMAC_SHA2_224},
-    { ACVP_HMAC_SHA2_256,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_256,     NULL, ACVP_REV_HMAC_SHA2_256},
-    { ACVP_HMAC_SHA2_384,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_384,     NULL, ACVP_REV_HMAC_SHA2_384},
-    { ACVP_HMAC_SHA2_512,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_512,     NULL, ACVP_REV_HMAC_SHA2_512},
-    { ACVP_HMAC_SHA2_512_224, &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_512_224, NULL, ACVP_REV_HMAC_SHA2_512_224},
-    { ACVP_HMAC_SHA2_512_256, &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_512_256, NULL, ACVP_REV_HMAC_SHA2_512_256},
-    { ACVP_HMAC_SHA3_224,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA3_224,     NULL, ACVP_REV_HMAC_SHA3_224},
-    { ACVP_HMAC_SHA3_256,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA3_256,     NULL, ACVP_REV_HMAC_SHA3_256},
-    { ACVP_HMAC_SHA3_384,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA3_384,     NULL, ACVP_REV_HMAC_SHA3_384},
-    { ACVP_HMAC_SHA3_512,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA3_512,     NULL, ACVP_REV_HMAC_SHA3_512},
-    { ACVP_CMAC_AES,          &acvp_cmac_kat_handler,            ACVP_ALG_CMAC_AES,          NULL, ACVP_REV_CMAC_AES},
-    { ACVP_CMAC_TDES,         &acvp_cmac_kat_handler,            ACVP_ALG_CMAC_TDES,         NULL, ACVP_REV_CMAC_TDES},
-    { ACVP_DSA_KEYGEN,        &acvp_dsa_kat_handler,             ACVP_ALG_DSA,               ACVP_ALG_DSA_KEYGEN, ACVP_REV_DSA},
-    { ACVP_DSA_PQGGEN,        &acvp_dsa_kat_handler,             ACVP_ALG_DSA,               ACVP_ALG_DSA_PQGGEN, ACVP_REV_DSA},
-    { ACVP_DSA_PQGVER,        &acvp_dsa_kat_handler,             ACVP_ALG_DSA,               ACVP_ALG_DSA_PQGVER, ACVP_REV_DSA},
-    { ACVP_DSA_SIGGEN,        &acvp_dsa_kat_handler,             ACVP_ALG_DSA,               ACVP_ALG_DSA_SIGGEN, ACVP_REV_DSA},
-    { ACVP_DSA_SIGVER,        &acvp_dsa_kat_handler,             ACVP_ALG_DSA,               ACVP_ALG_DSA_SIGVER, ACVP_REV_DSA},
-    { ACVP_RSA_KEYGEN,        &acvp_rsa_keygen_kat_handler,      ACVP_ALG_RSA,               ACVP_MODE_KEYGEN, ACVP_REV_RSA},
-    { ACVP_RSA_SIGGEN,        &acvp_rsa_siggen_kat_handler,      ACVP_ALG_RSA,               ACVP_MODE_SIGGEN, ACVP_REV_RSA},
-    { ACVP_RSA_SIGVER,        &acvp_rsa_sigver_kat_handler,      ACVP_ALG_RSA,               ACVP_MODE_SIGVER, ACVP_REV_RSA},
-    { ACVP_RSA_DECPRIM,       &acvp_rsa_decprim_kat_handler,     ACVP_ALG_RSA,               ACVP_MODE_DECPRIM, ACVP_REV_RSA_PRIM},
-    { ACVP_RSA_SIGPRIM,       &acvp_rsa_sigprim_kat_handler,     ACVP_ALG_RSA,               ACVP_MODE_SIGPRIM, ACVP_REV_RSA_PRIM},
-    { ACVP_ECDSA_KEYGEN,      &acvp_ecdsa_keygen_kat_handler,    ACVP_ALG_ECDSA,             ACVP_MODE_KEYGEN, ACVP_REV_ECDSA},
-    { ACVP_ECDSA_KEYVER,      &acvp_ecdsa_keyver_kat_handler,    ACVP_ALG_ECDSA,             ACVP_MODE_KEYVER, ACVP_REV_ECDSA},
-    { ACVP_ECDSA_SIGGEN,      &acvp_ecdsa_siggen_kat_handler,    ACVP_ALG_ECDSA,             ACVP_MODE_SIGGEN, ACVP_REV_ECDSA},
-    { ACVP_ECDSA_SIGVER,      &acvp_ecdsa_sigver_kat_handler,    ACVP_ALG_ECDSA,             ACVP_MODE_SIGVER, ACVP_REV_ECDSA},
-    { ACVP_KDF135_TLS,        &acvp_kdf135_tls_kat_handler,      ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_TLS, ACVP_REV_KDF135_TLS},
-    { ACVP_KDF135_SNMP,       &acvp_kdf135_snmp_kat_handler,     ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_SNMP, ACVP_REV_KDF135_SNMP},
-    { ACVP_KDF135_SSH,        &acvp_kdf135_ssh_kat_handler,      ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_SSH, ACVP_REV_KDF135_SSH},
-    { ACVP_KDF135_SRTP,       &acvp_kdf135_srtp_kat_handler,     ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_SRTP, ACVP_REV_KDF135_SRTP},
-    { ACVP_KDF135_IKEV2,      &acvp_kdf135_ikev2_kat_handler,    ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_IKEV2, ACVP_REV_KDF135_IKEV2},
-    { ACVP_KDF135_IKEV1,      &acvp_kdf135_ikev1_kat_handler,    ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_IKEV1, ACVP_REV_KDF135_IKEV1},
-    { ACVP_KDF135_X963,       &acvp_kdf135_x963_kat_handler,     ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_X963, ACVP_REV_KDF135_X963},
-    { ACVP_KDF108,            &acvp_kdf108_kat_handler,          ACVP_ALG_KDF108,            NULL, ACVP_REV_KDF108},
-    { ACVP_PBKDF,             &acvp_pbkdf_kat_handler,           ACVP_ALG_PBKDF,             NULL, ACVP_REV_PBKDF},
-    { ACVP_KAS_ECC_CDH,       &acvp_kas_ecc_kat_handler,         ACVP_ALG_KAS_ECC,           ACVP_ALG_KAS_ECC_CDH, ACVP_REV_KAS_ECC},
-    { ACVP_KAS_ECC_COMP,      &acvp_kas_ecc_kat_handler,         ACVP_ALG_KAS_ECC,           ACVP_ALG_KAS_ECC_COMP, ACVP_REV_KAS_ECC},
-    { ACVP_KAS_ECC_SSC,       &acvp_kas_ecc_ssc_kat_handler,     ACVP_ALG_KAS_ECC_SSC,       ACVP_ALG_KAS_ECC_COMP, ACVP_REV_KAS_ECC_SSC},
-    { ACVP_KAS_ECC_NOCOMP,    &acvp_kas_ecc_kat_handler,         ACVP_ALG_KAS_ECC,           ACVP_ALG_KAS_ECC_NOCOMP, ACVP_REV_KAS_ECC},
-    { ACVP_KAS_FFC_COMP,      &acvp_kas_ffc_kat_handler,         ACVP_ALG_KAS_FFC,           ACVP_ALG_KAS_FFC_COMP, ACVP_REV_KAS_FFC},
-    { ACVP_KAS_FFC_NOCOMP,    &acvp_kas_ffc_kat_handler,         ACVP_ALG_KAS_FFC,           ACVP_ALG_KAS_FFC_NOCOMP, ACVP_REV_KAS_FFC},
-    { ACVP_KAS_FFC_SSC,       &acvp_kas_ffc_ssc_kat_handler,     ACVP_ALG_KAS_FFC_SSC,       ACVP_ALG_KAS_FFC_COMP, ACVP_REV_KAS_FFC_SSC},
-    { ACVP_KAS_IFC_SSC,       &acvp_kas_ifc_ssc_kat_handler,     ACVP_ALG_KAS_IFC_SSC,       ACVP_ALG_KAS_IFC_COMP, ACVP_REV_KAS_IFC_SSC},
-    { ACVP_KAS_KDF_ONESTEP,   &acvp_kas_kdf_onestep_kat_handler, ACVP_ALG_KAS_KDF_ALG_STR,   ACVP_ALG_KAS_KDF_ONESTEP, ACVP_REV_KAS_KDF_ONESTEP},
-    { ACVP_KAS_HKDF,          &acvp_kas_hkdf_kat_handler,        ACVP_ALG_KAS_KDF_ALG_STR,   ACVP_ALG_KAS_HKDF, ACVP_REV_KAS_HKDF},
-    { ACVP_KTS_IFC,           &acvp_kts_ifc_kat_handler,         ACVP_ALG_KTS_IFC,           ACVP_ALG_KTS_IFC_COMP, ACVP_REV_KTS_IFC},
-    { ACVP_SAFE_PRIMES_KEYGEN, &acvp_safe_primes_kat_handler,    ACVP_ALG_SAFE_PRIMES_STR,   ACVP_ALG_SAFE_PRIMES_KEYGEN, ACVP_REV_SAFE_PRIMES},
-    { ACVP_SAFE_PRIMES_KEYVER, &acvp_safe_primes_kat_handler,    ACVP_ALG_SAFE_PRIMES_STR,   ACVP_ALG_SAFE_PRIMES_KEYVER, ACVP_REV_SAFE_PRIMES}
+    { ACVP_AES_GCM,           &acvp_aes_kat_handler,             ACVP_ALG_AES_GCM,           NULL, ACVP_REV_AES_GCM, {ACVP_SUB_AES_GCM}},
+    { ACVP_AES_GCM_SIV,       &acvp_aes_kat_handler,             ACVP_ALG_AES_GCM_SIV,       NULL, ACVP_REV_AES_GCM_SIV, {ACVP_SUB_AES_GCM_SIV}},
+    { ACVP_AES_CCM,           &acvp_aes_kat_handler,             ACVP_ALG_AES_CCM,           NULL, ACVP_REV_AES_CCM, {ACVP_SUB_AES_CCM}},
+    { ACVP_AES_ECB,           &acvp_aes_kat_handler,             ACVP_ALG_AES_ECB,           NULL, ACVP_REV_AES_ECB, {ACVP_SUB_AES_ECB}},
+    { ACVP_AES_CBC,           &acvp_aes_kat_handler,             ACVP_ALG_AES_CBC,           NULL, ACVP_REV_AES_CBC, {ACVP_SUB_AES_CBC}},
+    { ACVP_AES_CBC_CS1,       &acvp_aes_kat_handler,             ACVP_ALG_AES_CBC_CS1,       NULL, ACVP_REV_AES_CBC_CS1, {ACVP_SUB_AES_CBC_CS1}},
+    { ACVP_AES_CBC_CS2,       &acvp_aes_kat_handler,             ACVP_ALG_AES_CBC_CS2,       NULL, ACVP_REV_AES_CBC_CS2, {ACVP_SUB_AES_CBC_CS2}},
+    { ACVP_AES_CBC_CS3,       &acvp_aes_kat_handler,             ACVP_ALG_AES_CBC_CS3,       NULL, ACVP_REV_AES_CBC_CS3, {ACVP_SUB_AES_CBC_CS3}},
+    { ACVP_AES_CFB1,          &acvp_aes_kat_handler,             ACVP_ALG_AES_CFB1,          NULL, ACVP_REV_AES_CFB1, {ACVP_SUB_AES_CFB1}},
+    { ACVP_AES_CFB8,          &acvp_aes_kat_handler,             ACVP_ALG_AES_CFB8,          NULL, ACVP_REV_AES_CFB8, {ACVP_SUB_AES_CFB8}},
+    { ACVP_AES_CFB128,        &acvp_aes_kat_handler,             ACVP_ALG_AES_CFB128,        NULL, ACVP_REV_AES_CFB128, {ACVP_SUB_AES_CFB128}},
+    { ACVP_AES_OFB,           &acvp_aes_kat_handler,             ACVP_ALG_AES_OFB,           NULL, ACVP_REV_AES_OFB, {ACVP_SUB_AES_OFB}},
+    { ACVP_AES_CTR,           &acvp_aes_kat_handler,             ACVP_ALG_AES_CTR,           NULL, ACVP_REV_AES_CTR, {ACVP_SUB_AES_CTR}},
+    { ACVP_AES_XTS,           &acvp_aes_kat_handler,             ACVP_ALG_AES_XTS,           NULL, ACVP_REV_AES_XTS, {ACVP_SUB_AES_XTS}},
+    { ACVP_AES_KW,            &acvp_aes_kat_handler,             ACVP_ALG_AES_KW,            NULL, ACVP_REV_AES_KW, {ACVP_SUB_AES_KW}},
+    { ACVP_AES_KWP,           &acvp_aes_kat_handler,             ACVP_ALG_AES_KWP,           NULL, ACVP_REV_AES_KWP, {ACVP_SUB_AES_KWP}},
+    { ACVP_AES_GMAC,          &acvp_aes_kat_handler,             ACVP_ALG_AES_GMAC,          NULL, ACVP_REV_AES_GMAC, {ACVP_SUB_AES_GMAC}},
+    { ACVP_AES_XPN,           &acvp_aes_kat_handler,             ACVP_ALG_AES_XPN ,          NULL, ACVP_REV_AES_XPN, {ACVP_SUB_AES_XPN}},
+    { ACVP_TDES_ECB,          &acvp_des_kat_handler,             ACVP_ALG_TDES_ECB,          NULL, ACVP_REV_TDES_ECB, {ACVP_SUB_TDES_ECB}},
+    { ACVP_TDES_CBC,          &acvp_des_kat_handler,             ACVP_ALG_TDES_CBC,          NULL, ACVP_REV_TDES_CBC, {ACVP_SUB_TDES_CBC}},
+    { ACVP_TDES_CBCI,         &acvp_des_kat_handler,             ACVP_ALG_TDES_CBCI,         NULL, ACVP_REV_TDES_CBCI, {ACVP_SUB_TDES_CBCI}},
+    { ACVP_TDES_OFB,          &acvp_des_kat_handler,             ACVP_ALG_TDES_OFB,          NULL, ACVP_REV_TDES_OFB, {ACVP_SUB_TDES_OFB}},
+    { ACVP_TDES_OFBI,         &acvp_des_kat_handler,             ACVP_ALG_TDES_OFBI,         NULL, ACVP_REV_TDES_OFBI, {ACVP_SUB_TDES_OFBI}},
+    { ACVP_TDES_CFB1,         &acvp_des_kat_handler,             ACVP_ALG_TDES_CFB1,         NULL, ACVP_REV_TDES_CFB1, {ACVP_SUB_TDES_CFB1}},
+    { ACVP_TDES_CFB8,         &acvp_des_kat_handler,             ACVP_ALG_TDES_CFB8,         NULL, ACVP_REV_TDES_CFB8, {ACVP_SUB_TDES_CFB8}},
+    { ACVP_TDES_CFB64,        &acvp_des_kat_handler,             ACVP_ALG_TDES_CFB64,        NULL, ACVP_REV_TDES_CFB64, {ACVP_SUB_TDES_CFB64}},
+    { ACVP_TDES_CFBP1,        &acvp_des_kat_handler,             ACVP_ALG_TDES_CFBP1,        NULL, ACVP_REV_TDES_CFBP1, {ACVP_SUB_TDES_CFBP1}},
+    { ACVP_TDES_CFBP8,        &acvp_des_kat_handler,             ACVP_ALG_TDES_CFBP8,        NULL, ACVP_REV_TDES_CFBP8, {ACVP_SUB_TDES_CFBP8}},
+    { ACVP_TDES_CFBP64,       &acvp_des_kat_handler,             ACVP_ALG_TDES_CFBP64,       NULL, ACVP_REV_TDES_CFBP64, {ACVP_SUB_TDES_CFBP64}},
+    { ACVP_TDES_CTR,          &acvp_des_kat_handler,             ACVP_ALG_TDES_CTR,          NULL, ACVP_REV_TDES_CTR, {ACVP_SUB_TDES_CTR}},
+    { ACVP_TDES_KW,           &acvp_des_kat_handler,             ACVP_ALG_TDES_KW,           NULL, ACVP_REV_TDES_KW, {ACVP_SUB_TDES_KW}},
+    { ACVP_HASH_SHA1,         &acvp_hash_kat_handler,            ACVP_ALG_SHA1,              NULL, ACVP_REV_HASH_SHA1, {ACVP_SUB_HASH_SHA1}},
+    { ACVP_HASH_SHA224,       &acvp_hash_kat_handler,            ACVP_ALG_SHA224,            NULL, ACVP_REV_HASH_SHA224, {ACVP_SUB_HASH_SHA2_224}},
+    { ACVP_HASH_SHA256,       &acvp_hash_kat_handler,            ACVP_ALG_SHA256,            NULL, ACVP_REV_HASH_SHA256, {ACVP_SUB_HASH_SHA2_256}},
+    { ACVP_HASH_SHA384,       &acvp_hash_kat_handler,            ACVP_ALG_SHA384,            NULL, ACVP_REV_HASH_SHA384, {ACVP_SUB_HASH_SHA2_384}},
+    { ACVP_HASH_SHA512,       &acvp_hash_kat_handler,            ACVP_ALG_SHA512,            NULL, ACVP_REV_HASH_SHA512, {ACVP_SUB_HASH_SHA2_512}},
+    { ACVP_HASH_SHA512_224,   &acvp_hash_kat_handler,            ACVP_ALG_SHA512_224,        NULL, ACVP_REV_HASH_SHA512_224, {ACVP_SUB_HASH_SHA2_512_224}},
+    { ACVP_HASH_SHA512_256,   &acvp_hash_kat_handler,            ACVP_ALG_SHA512_256,        NULL, ACVP_REV_HASH_SHA512_256, {ACVP_SUB_HASH_SHA2_512_256}},
+    { ACVP_HASH_SHA3_224,     &acvp_hash_kat_handler,            ACVP_ALG_SHA3_224,          NULL, ACVP_REV_HASH_SHA3_224, {ACVP_SUB_HASH_SHA3_224}},
+    { ACVP_HASH_SHA3_256,     &acvp_hash_kat_handler,            ACVP_ALG_SHA3_256,          NULL, ACVP_REV_HASH_SHA3_256, {ACVP_SUB_HASH_SHA3_256}},
+    { ACVP_HASH_SHA3_384,     &acvp_hash_kat_handler,            ACVP_ALG_SHA3_384,          NULL, ACVP_REV_HASH_SHA3_384, {ACVP_SUB_HASH_SHA3_384}},
+    { ACVP_HASH_SHA3_512,     &acvp_hash_kat_handler,            ACVP_ALG_SHA3_512,          NULL, ACVP_REV_HASH_SHA3_512, {ACVP_SUB_HASH_SHA3_512}},
+    { ACVP_HASH_SHAKE_128,    &acvp_hash_kat_handler,            ACVP_ALG_SHAKE_128,         NULL, ACVP_REV_HASH_SHAKE_128, {ACVP_SUB_HASH_SHAKE_128}},
+    { ACVP_HASH_SHAKE_256,    &acvp_hash_kat_handler,            ACVP_ALG_SHAKE_256,         NULL, ACVP_REV_HASH_SHAKE_256, {ACVP_SUB_HASH_SHAKE_256}},
+    { ACVP_HASHDRBG,          &acvp_drbg_kat_handler,            ACVP_ALG_HASHDRBG,          NULL, ACVP_REV_HASHDRBG, {ACVP_SUB_DRBG_HASH}},
+    { ACVP_HMACDRBG,          &acvp_drbg_kat_handler,            ACVP_ALG_HMACDRBG,          NULL, ACVP_REV_HMACDRBG, {ACVP_SUB_DRBG_HMAC}},
+    { ACVP_CTRDRBG,           &acvp_drbg_kat_handler,            ACVP_ALG_CTRDRBG,           NULL, ACVP_REV_CTRDRBG, {ACVP_SUB_DRBG_CTR}},
+    { ACVP_HMAC_SHA1,         &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA1,         NULL, ACVP_REV_HMAC_SHA1, {ACVP_SUB_HMAC_SHA1}},
+    { ACVP_HMAC_SHA2_224,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_224,     NULL, ACVP_REV_HMAC_SHA2_224, {ACVP_SUB_HMAC_SHA2_224}},
+    { ACVP_HMAC_SHA2_256,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_256,     NULL, ACVP_REV_HMAC_SHA2_256, {ACVP_SUB_HMAC_SHA2_256}},
+    { ACVP_HMAC_SHA2_384,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_384,     NULL, ACVP_REV_HMAC_SHA2_384, {ACVP_SUB_HMAC_SHA2_384}},
+    { ACVP_HMAC_SHA2_512,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_512,     NULL, ACVP_REV_HMAC_SHA2_512, {ACVP_SUB_HMAC_SHA2_512}},
+    { ACVP_HMAC_SHA2_512_224, &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_512_224, NULL, ACVP_REV_HMAC_SHA2_512_224, {ACVP_SUB_HMAC_SHA2_512_224}},
+    { ACVP_HMAC_SHA2_512_256, &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA2_512_256, NULL, ACVP_REV_HMAC_SHA2_512_256, {ACVP_SUB_HMAC_SHA2_512_256}},
+    { ACVP_HMAC_SHA3_224,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA3_224,     NULL, ACVP_REV_HMAC_SHA3_224, {ACVP_SUB_HMAC_SHA3_224}},
+    { ACVP_HMAC_SHA3_256,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA3_256,     NULL, ACVP_REV_HMAC_SHA3_256, {ACVP_SUB_HMAC_SHA3_256}},
+    { ACVP_HMAC_SHA3_384,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA3_384,     NULL, ACVP_REV_HMAC_SHA3_384, {ACVP_SUB_HMAC_SHA3_384}},
+    { ACVP_HMAC_SHA3_512,     &acvp_hmac_kat_handler,            ACVP_ALG_HMAC_SHA3_512,     NULL, ACVP_REV_HMAC_SHA3_512, {ACVP_SUB_HMAC_SHA3_512}},
+    { ACVP_CMAC_AES,          &acvp_cmac_kat_handler,            ACVP_ALG_CMAC_AES,          NULL, ACVP_REV_CMAC_AES, {ACVP_SUB_CMAC_AES}},
+    { ACVP_CMAC_TDES,         &acvp_cmac_kat_handler,            ACVP_ALG_CMAC_TDES,         NULL, ACVP_REV_CMAC_TDES, {ACVP_SUB_CMAC_TDES}},
+    { ACVP_DSA_KEYGEN,        &acvp_dsa_kat_handler,             ACVP_ALG_DSA,               ACVP_ALG_DSA_KEYGEN, ACVP_REV_DSA, {ACVP_SUB_DSA_KEYGEN}},
+    { ACVP_DSA_PQGGEN,        &acvp_dsa_kat_handler,             ACVP_ALG_DSA,               ACVP_ALG_DSA_PQGGEN, ACVP_REV_DSA, {ACVP_SUB_DSA_PQGGEN}},
+    { ACVP_DSA_PQGVER,        &acvp_dsa_kat_handler,             ACVP_ALG_DSA,               ACVP_ALG_DSA_PQGVER, ACVP_REV_DSA, {ACVP_SUB_DSA_PQGVER}},
+    { ACVP_DSA_SIGGEN,        &acvp_dsa_kat_handler,             ACVP_ALG_DSA,               ACVP_ALG_DSA_SIGGEN, ACVP_REV_DSA, {ACVP_SUB_DSA_SIGGEN}},
+    { ACVP_DSA_SIGVER,        &acvp_dsa_kat_handler,             ACVP_ALG_DSA,               ACVP_ALG_DSA_SIGVER, ACVP_REV_DSA, {ACVP_SUB_DSA_SIGVER}},
+    { ACVP_RSA_KEYGEN,        &acvp_rsa_keygen_kat_handler,      ACVP_ALG_RSA,               ACVP_MODE_KEYGEN, ACVP_REV_RSA, {ACVP_SUB_RSA_KEYGEN}},
+    { ACVP_RSA_SIGGEN,        &acvp_rsa_siggen_kat_handler,      ACVP_ALG_RSA,               ACVP_MODE_SIGGEN, ACVP_REV_RSA, {ACVP_SUB_RSA_SIGGEN}},
+    { ACVP_RSA_SIGVER,        &acvp_rsa_sigver_kat_handler,      ACVP_ALG_RSA,               ACVP_MODE_SIGVER, ACVP_REV_RSA, {ACVP_SUB_RSA_SIGVER}},
+    { ACVP_RSA_DECPRIM,       &acvp_rsa_decprim_kat_handler,     ACVP_ALG_RSA,               ACVP_MODE_DECPRIM, ACVP_REV_RSA_PRIM, {ACVP_SUB_RSA_DECPRIM}},
+    { ACVP_RSA_SIGPRIM,       &acvp_rsa_sigprim_kat_handler,     ACVP_ALG_RSA,               ACVP_MODE_SIGPRIM, ACVP_REV_RSA_PRIM, {ACVP_SUB_RSA_SIGPRIM}},
+    { ACVP_ECDSA_KEYGEN,      &acvp_ecdsa_keygen_kat_handler,    ACVP_ALG_ECDSA,             ACVP_MODE_KEYGEN, ACVP_REV_ECDSA, {ACVP_SUB_ECDSA_KEYGEN}},
+    { ACVP_ECDSA_KEYVER,      &acvp_ecdsa_keyver_kat_handler,    ACVP_ALG_ECDSA,             ACVP_MODE_KEYVER, ACVP_REV_ECDSA, {ACVP_SUB_ECDSA_KEYVER}},
+    { ACVP_ECDSA_SIGGEN,      &acvp_ecdsa_siggen_kat_handler,    ACVP_ALG_ECDSA,             ACVP_MODE_SIGGEN, ACVP_REV_ECDSA, {ACVP_SUB_ECDSA_SIGGEN}},
+    { ACVP_ECDSA_SIGVER,      &acvp_ecdsa_sigver_kat_handler,    ACVP_ALG_ECDSA,             ACVP_MODE_SIGVER, ACVP_REV_ECDSA, {ACVP_SUB_ECDSA_SIGVER}},
+    { ACVP_KDF135_TLS,        &acvp_kdf135_tls_kat_handler,      ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_TLS, ACVP_REV_KDF135_TLS, {ACVP_SUB_KDF_TLS}},
+    { ACVP_KDF135_SNMP,       &acvp_kdf135_snmp_kat_handler,     ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_SNMP, ACVP_REV_KDF135_SNMP, {ACVP_SUB_KDF_SNMP}},
+    { ACVP_KDF135_SSH,        &acvp_kdf135_ssh_kat_handler,      ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_SSH, ACVP_REV_KDF135_SSH, {ACVP_SUB_KDF_SSH}},
+    { ACVP_KDF135_SRTP,       &acvp_kdf135_srtp_kat_handler,     ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_SRTP, ACVP_REV_KDF135_SRTP, {ACVP_SUB_KDF_SRTP}},
+    { ACVP_KDF135_IKEV2,      &acvp_kdf135_ikev2_kat_handler,    ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_IKEV2, ACVP_REV_KDF135_IKEV2, {ACVP_SUB_KDF_IKEV2}},
+    { ACVP_KDF135_IKEV1,      &acvp_kdf135_ikev1_kat_handler,    ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_IKEV1, ACVP_REV_KDF135_IKEV1, {ACVP_SUB_KDF_IKEV1}},
+    { ACVP_KDF135_X963,       &acvp_kdf135_x963_kat_handler,     ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_X963, ACVP_REV_KDF135_X963, {ACVP_SUB_KDF_X963}},
+    { ACVP_KDF108,            &acvp_kdf108_kat_handler,          ACVP_ALG_KDF108,            NULL, ACVP_REV_KDF108, {ACVP_SUB_KDF_108}},
+    { ACVP_PBKDF,             &acvp_pbkdf_kat_handler,           ACVP_ALG_PBKDF,             NULL, ACVP_REV_PBKDF, {ACVP_SUB_KDF_PBKDF}},
+    { ACVP_KAS_ECC_CDH,       &acvp_kas_ecc_kat_handler,         ACVP_ALG_KAS_ECC,           ACVP_ALG_KAS_ECC_CDH, ACVP_REV_KAS_ECC, {ACVP_SUB_KAS_ECC_CDH}},
+    { ACVP_KAS_ECC_COMP,      &acvp_kas_ecc_kat_handler,         ACVP_ALG_KAS_ECC,           ACVP_ALG_KAS_ECC_COMP, ACVP_REV_KAS_ECC, {ACVP_SUB_KAS_ECC_COMP}},
+    { ACVP_KAS_ECC_NOCOMP,    &acvp_kas_ecc_kat_handler,         ACVP_ALG_KAS_ECC,           ACVP_ALG_KAS_ECC_NOCOMP, ACVP_REV_KAS_ECC, {ACVP_SUB_KAS_ECC_NOCOMP}},
+    { ACVP_KAS_ECC_SSC,       &acvp_kas_ecc_ssc_kat_handler,     ACVP_ALG_KAS_ECC_SSC,       ACVP_ALG_KAS_ECC_COMP, ACVP_REV_KAS_ECC_SSC, {ACVP_SUB_KAS_ECC_SSC}},
+    { ACVP_KAS_FFC_COMP,      &acvp_kas_ffc_kat_handler,         ACVP_ALG_KAS_FFC,           ACVP_ALG_KAS_FFC_COMP, ACVP_REV_KAS_FFC, {ACVP_SUB_KAS_FFC_COMP}},
+    { ACVP_KAS_FFC_NOCOMP,    &acvp_kas_ffc_kat_handler,         ACVP_ALG_KAS_FFC,           ACVP_ALG_KAS_FFC_NOCOMP, ACVP_REV_KAS_FFC, {ACVP_SUB_KAS_FFC_NOCOMP}},
+    { ACVP_KAS_FFC_SSC,       &acvp_kas_ffc_ssc_kat_handler,     ACVP_ALG_KAS_FFC_SSC,       ACVP_ALG_KAS_FFC_COMP, ACVP_REV_KAS_FFC_SSC, {ACVP_SUB_KAS_FFC_SSC}},
+    { ACVP_KAS_IFC_SSC,       &acvp_kas_ifc_ssc_kat_handler,     ACVP_ALG_KAS_IFC_SSC,       ACVP_ALG_KAS_IFC_COMP, ACVP_REV_KAS_IFC_SSC, {ACVP_SUB_KAS_IFC_SSC}},
+    { ACVP_KAS_KDF_ONESTEP,   &acvp_kas_kdf_onestep_kat_handler, ACVP_ALG_KAS_KDF_ALG_STR,   ACVP_ALG_KAS_KDF_ONESTEP, ACVP_REV_KAS_KDF_ONESTEP, {ACVP_SUB_KAS_KDF_ONESTEP}},
+    { ACVP_KAS_HKDF,          &acvp_kas_hkdf_kat_handler,        ACVP_ALG_KAS_KDF_ALG_STR,   ACVP_ALG_KAS_HKDF, ACVP_REV_KAS_HKDF, {ACVP_SUB_KAS_HKDF}},
+    { ACVP_KTS_IFC,           &acvp_kts_ifc_kat_handler,         ACVP_ALG_KTS_IFC,           ACVP_ALG_KTS_IFC_COMP, ACVP_REV_KTS_IFC, {ACVP_SUB_KTS_IFC}},
+    { ACVP_SAFE_PRIMES_KEYGEN, &acvp_safe_primes_kat_handler,    ACVP_ALG_SAFE_PRIMES_STR,   ACVP_ALG_SAFE_PRIMES_KEYGEN, ACVP_REV_SAFE_PRIMES, {ACVP_SUB_SAFE_PRIMES_KEYGEN}},
+    { ACVP_SAFE_PRIMES_KEYVER, &acvp_safe_primes_kat_handler,    ACVP_ALG_SAFE_PRIMES_STR,   ACVP_ALG_SAFE_PRIMES_KEYVER, ACVP_REV_SAFE_PRIMES, {ACVP_SUB_SAFE_PRIMES_KEYVER}}
 };
 
 /*
@@ -3407,7 +3407,6 @@ ACVP_RESULT acvp_run(ACVP_CTX *ctx, int fips_validation) {
         rv = acvp_transport_delete(ctx, ctx->delete_string);
         if (ctx->save_filename) {
             ACVP_LOG_STATUS("Saving DELETE response to specified file...");
-            JSON_Value *val = NULL;
             val = json_parse_string(ctx->curl_buf);
             if (!val) {
                 ACVP_LOG_ERR("Unable to parse JSON. printing output instead...");
@@ -3699,3 +3698,90 @@ end:
     return rv;
 }
 
+ACVP_SUB_CMAC acvp_get_cmac_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.cmac);
+}
+
+ACVP_SUB_HASH acvp_get_hash_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.hash);
+}
+
+ACVP_SUB_AES acvp_get_aes_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.aes);
+}
+
+ACVP_SUB_TDES acvp_get_tdes_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.tdes);
+}
+
+ACVP_SUB_HMAC acvp_get_hmac_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.hmac);
+}
+
+ACVP_SUB_RSA acvp_get_rsa_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.rsa);
+}
+
+ACVP_SUB_DSA acvp_get_dsa_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.dsa);
+}
+
+ACVP_SUB_ECDSA acvp_get_ecdsa_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.ecdsa);
+}
+
+ACVP_SUB_KDF acvp_get_kdf_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.kdf);
+}
+
+ACVP_SUB_DRBG acvp_get_drbg_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.drbg);
+}
+
+ACVP_SUB_KAS acvp_get_kas_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.kas);
+}

--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -77,6 +77,7 @@ static unsigned char ctext[TEXT_COL_LEN][TEXT_ROW_LEN];
  */
 static ACVP_RESULT acvp_aes_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc, int i) {
     int j = stc->mct_index;
+    ACVP_SUB_AES alg;
 
     if (stc->cipher != ACVP_AES_CFB1) {
         memcpy_s(ctext[j], TEXT_ROW_LEN, stc->ct, stc->ct_len);
@@ -89,8 +90,14 @@ static ACVP_RESULT acvp_aes_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *st
         memcpy_s(mkey[j], KEY_ROW_LEN, stc->key, stc->key_len / 8);
     }
 
-    switch (stc->cipher) {
-    case ACVP_AES_ECB:
+    alg = acvp_get_aes_alg(stc->cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_AES_ECB:
 
         if (stc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
             memcpy_s(stc->pt, ACVP_SYM_PT_BYTE_MAX, ctext[j], stc->ct_len);
@@ -99,9 +106,9 @@ static ACVP_RESULT acvp_aes_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *st
         }
         break;
 
-    case ACVP_AES_CBC:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CFB128:
+    case ACVP_SUB_AES_CBC:
+    case ACVP_SUB_AES_OFB:
+    case ACVP_SUB_AES_CFB128:
         if (j == 0) {
             if (stc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
                 memcpy_s(stc->pt, ACVP_SYM_PT_BYTE_MAX, stc->iv, stc->iv_len);
@@ -119,7 +126,7 @@ static ACVP_RESULT acvp_aes_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *st
         }
         break;
 
-    case ACVP_AES_CFB8:
+    case ACVP_SUB_AES_CFB8:
         if (stc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
             if (j < 16) {
                 memcpy_s(stc->pt, ACVP_SYM_PT_BYTE_MAX, &stc->iv[j], stc->iv_len);
@@ -135,7 +142,7 @@ static ACVP_RESULT acvp_aes_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *st
         }
         break;
 
-    case ACVP_AES_CFB1:
+    case ACVP_SUB_AES_CFB1:
         if (stc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
             if (j < 128) {
                 sb(ptext[j + 1], 0, gb(miv[i], j));
@@ -152,87 +159,18 @@ static ACVP_RESULT acvp_aes_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *st
             stc->ct[0] = ctext[j + 1][0];
         }
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_AES_CBC_CS1:
+    case ACVP_SUB_AES_CBC_CS2:
+    case ACVP_SUB_AES_CBC_CS3:
+    case ACVP_SUB_AES_CCM:
+    case ACVP_SUB_AES_GCM:
+    case ACVP_SUB_AES_GCM_SIV:
+    case ACVP_SUB_AES_CTR:
+    case ACVP_SUB_AES_XTS:
+    case ACVP_SUB_AES_XPN:
+    case ACVP_SUB_AES_KW:
+    case ACVP_SUB_AES_KWP:
+    case ACVP_SUB_AES_GMAC:
     default:
         break;
     }

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -341,6 +341,7 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
         json_array_append_string(mode_arr, ACVP_RFC3686_STR);
     case ACVP_CONFORMANCE_DEFAULT:
     case ACVP_CONFORMANCE_MAX:
+    default:
         break;
     }
 
@@ -580,6 +581,13 @@ static ACVP_RESULT acvp_build_sym_cipher_register_cap(JSON_Object *cap_obj, ACVP
     case ACVP_KAS_FFC_NOCOMP:
     case ACVP_KAS_KDF_ONESTEP:
     case ACVP_KAS_HKDF:
+    case ACVP_RSA_DECPRIM:
+    case ACVP_RSA_SIGPRIM:
+    case ACVP_KAS_FFC_SSC:
+    case ACVP_KAS_IFC_SSC:
+    case ACVP_KTS_IFC:
+    case ACVP_SAFE_PRIMES_KEYGEN:
+    case ACVP_SAFE_PRIMES_KEYVER:
     case ACVP_CIPHER_END:
         break;
     case ACVP_AES_GCM:
@@ -1117,6 +1125,7 @@ static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CIPHER cipher, JSON_Object
     const char *revision = NULL, *tmp = NULL;
     int i = 0, diff = 0;
     ACVP_EC_CURVE track[ACVP_EC_CURVE_END + 1] = { 0 };
+    ACVP_SUB_ECDSA alg;
 
     json_object_set_string(cap_obj, "algorithm", "ECDSA");
 
@@ -1124,8 +1133,14 @@ static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CIPHER cipher, JSON_Object
     if (revision == NULL) return ACVP_INVALID_ARG;
     json_object_set_string(cap_obj, "revision", revision);
 
-    switch (cipher) {
-    case ACVP_ECDSA_KEYGEN:
+    alg = acvp_get_ecdsa_alg(cap_entry->cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_ECDSA_KEYGEN:
         json_object_set_string(cap_obj, "mode", "keyGen");
         if (!cap_entry->cap.ecdsa_keygen_cap) {
             return ACVP_NO_CAP;
@@ -1133,14 +1148,14 @@ static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CIPHER cipher, JSON_Object
         current_curve = cap_entry->cap.ecdsa_keygen_cap->curves;
         current_secret_mode = cap_entry->cap.ecdsa_keygen_cap->secret_gen_modes;
         break;
-    case ACVP_ECDSA_KEYVER:
+    case ACVP_SUB_ECDSA_KEYVER:
         json_object_set_string(cap_obj, "mode", "keyVer");
         if (!cap_entry->cap.ecdsa_keyver_cap) {
             return ACVP_NO_CAP;
         }
         current_curve = cap_entry->cap.ecdsa_keyver_cap->curves;
         break;
-    case ACVP_ECDSA_SIGGEN:
+    case ACVP_SUB_ECDSA_SIGGEN:
         json_object_set_string(cap_obj, "mode", "sigGen");
         if (!cap_entry->cap.ecdsa_siggen_cap) {
             return ACVP_NO_CAP;
@@ -1157,7 +1172,7 @@ static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CIPHER cipher, JSON_Object
         }
         current_curve = cap_entry->cap.ecdsa_siggen_cap->curves;
         break;
-    case ACVP_ECDSA_SIGVER:
+    case ACVP_SUB_ECDSA_SIGVER:
         json_object_set_string(cap_obj, "mode", "sigVer");
         if (!cap_entry->cap.ecdsa_sigver_cap) {
             return ACVP_NO_CAP;
@@ -1174,96 +1189,8 @@ static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CIPHER cipher, JSON_Object
         }
         current_curve = cap_entry->cap.ecdsa_sigver_cap->curves;
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
-
         break;
     }
 

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -993,6 +993,11 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_KAS_FFC_NOCOMP:
         case ACVP_KAS_KDF_ONESTEP:
         case ACVP_KAS_HKDF:
+        case ACVP_KAS_FFC_SSC:
+        case ACVP_KAS_IFC_SSC:
+        case ACVP_KTS_IFC:
+        case ACVP_SAFE_PRIMES_KEYGEN:
+        case ACVP_SAFE_PRIMES_KEYVER:
         case ACVP_CIPHER_END:
         default:
             break;
@@ -1098,6 +1103,11 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_KAS_FFC_NOCOMP:
         case ACVP_KAS_KDF_ONESTEP:
         case ACVP_KAS_HKDF:
+        case ACVP_KAS_FFC_SSC:
+        case ACVP_KAS_IFC_SSC:
+        case ACVP_KTS_IFC:
+        case ACVP_SAFE_PRIMES_KEYGEN:
+        case ACVP_SAFE_PRIMES_KEYVER:
         case ACVP_CIPHER_END:
         default:
             break;
@@ -1201,6 +1211,11 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_KAS_FFC_NOCOMP:
         case ACVP_KAS_KDF_ONESTEP:
         case ACVP_KAS_HKDF:
+        case ACVP_KAS_FFC_SSC:
+        case ACVP_KAS_IFC_SSC:
+        case ACVP_KTS_IFC:
+        case ACVP_SAFE_PRIMES_KEYGEN:
+        case ACVP_SAFE_PRIMES_KEYVER:
         case ACVP_CIPHER_END:
         default:
             break;
@@ -1310,6 +1325,11 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_KAS_FFC_NOCOMP:
         case ACVP_KAS_KDF_ONESTEP:
         case ACVP_KAS_HKDF:
+        case ACVP_KAS_FFC_SSC:
+        case ACVP_KAS_IFC_SSC:
+        case ACVP_KTS_IFC:
+        case ACVP_SAFE_PRIMES_KEYGEN:
+        case ACVP_SAFE_PRIMES_KEYVER:
         case ACVP_CIPHER_END:
         default:
             break;
@@ -1410,6 +1430,11 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_KAS_FFC_NOCOMP:
         case ACVP_KAS_KDF_ONESTEP:
         case ACVP_KAS_HKDF:
+        case ACVP_KAS_FFC_SSC:
+        case ACVP_KAS_IFC_SSC:
+        case ACVP_KTS_IFC:
+        case ACVP_SAFE_PRIMES_KEYGEN:
+        case ACVP_SAFE_PRIMES_KEYVER:
         case ACVP_CIPHER_END:
         default:
             if (value >= 0 && value <= 65536) {
@@ -1435,7 +1460,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
     return retval;
 }
 
-static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACVP_SYM_CIPH_PARM parm,
+static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACVP_SYM_CIPH_DOMAIN_PARM parm,
                                                        int min, int max, int increment) {
 
     ACVP_RESULT retval = ACVP_INVALID_ARG;
@@ -1453,17 +1478,17 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
     switch (cipher) {
     case ACVP_AES_GCM:
         switch (parm) {
-        case ACVP_SYM_CIPH_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
             if (min >= 8 && max <= 1024) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
             if (min >= 0 && max <= 65536) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
             if (min >= 0 && max <= 65536) {
                 retval = ACVP_SUCCESS;
             }
@@ -1474,34 +1499,34 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
         break;
     case ACVP_AES_GCM_SIV:
         switch (parm) {
-        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
             if (min >= 0 && max <= 65536 && increment == 8) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
             if (min >= 0 && max <= 65536 && increment == 8) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         default:
             break;
         }
         break;
     case ACVP_AES_CCM:
         switch (parm) {
-        case ACVP_SYM_CIPH_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
             if (min >= 56 && max <= 104 && increment == 8) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
             if (min >= 0 && max <= 256 && increment == 8) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
             if (min >= 0 && max <= 524288) {
                 retval = ACVP_SUCCESS;
             }
@@ -1514,99 +1539,99 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
     case ACVP_AES_CBC_CS2:
     case ACVP_AES_CBC_CS3:
         switch (parm) {
-        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
             if (min >= 128 && max <= 65536) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_IVLEN:
-        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         default:
             break;
         }
         break;
     case ACVP_AES_CTR:
         switch (parm) {
-        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
             if (min >= 1 && max <= 128) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_IVLEN:
-        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         default:
             break;
         }
         break;
     case ACVP_AES_XTS:
         switch (parm) {
-        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
             if (min >= 128 && max <= 65536) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_IVLEN:
-        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         default:
             break;
         }
         break;
     case ACVP_AES_KW:
         switch (parm) {
-        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
             if (min >= 128 && max <= 65536 && increment % 64 == 0) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_IVLEN:
-        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         default:
             break;
         }
         break;
     case ACVP_AES_KWP:
         switch (parm) {
-        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
             if (min >= 0 && max <= 65536) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_IVLEN:
-        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         default:
             break;
         }
         break;
     case ACVP_AES_GMAC:
         switch (parm) {
-        case ACVP_SYM_CIPH_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
             if (min >= 8 && max <= 1024 && increment % 8 == 0) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
             if (min >= 1 && max <= 65536 && increment % 8 == 0) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
         default:
             break;
         }
         break;
     case ACVP_AES_XPN:
         switch (parm) {
-        case ACVP_SYM_CIPH_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
             if (min >= 8 && max <= 1024) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
             if (min >= 0 && max <= 65536) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
             if (min >= 0 && max <= 65536) {
                 retval = ACVP_SUCCESS;
             }
@@ -1618,13 +1643,13 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
     case ACVP_TDES_CTR:
     case ACVP_TDES_KW:
         switch (parm) {
-        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
             if (min >= 0 && max <= 65536) {
                 retval = ACVP_SUCCESS;
             }
             break;
-        case ACVP_SYM_CIPH_IVLEN:
-        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         default:
             break;
         }
@@ -1707,6 +1732,11 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
     case ACVP_KAS_FFC_NOCOMP:
     case ACVP_KAS_KDF_ONESTEP:
     case ACVP_KAS_HKDF:
+    case ACVP_KAS_FFC_SSC:
+    case ACVP_KAS_IFC_SSC:
+    case ACVP_KTS_IFC:
+    case ACVP_SAFE_PRIMES_KEYGEN:
+    case ACVP_SAFE_PRIMES_KEYVER:
     case ACVP_CIPHER_END:
     default:
         break;
@@ -1886,6 +1916,7 @@ static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG 
         break;
     case ACVP_KAS_FFC_COMP:
     case ACVP_KAS_FFC_NOCOMP:
+    case ACVP_KAS_FFC_SSC:
         if (pre_req == ACVP_PREREQ_DRBG ||
             pre_req == ACVP_PREREQ_HMAC ||
             pre_req == ACVP_PREREQ_CMAC ||
@@ -2035,7 +2066,7 @@ ACVP_RESULT acvp_cap_set_prereq(ACVP_CTX *ctx,
  */
 ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
                                            ACVP_CIPHER cipher,
-                                           ACVP_SYM_CIPH_PARM parm,
+                                           ACVP_SYM_CIPH_DOMAIN_PARM parm,
                                            int min,
                                            int max,
                                            int increment) {
@@ -2140,6 +2171,11 @@ ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
     case ACVP_KAS_FFC_COMP:
     case ACVP_KAS_FFC_NOCOMP:
     case ACVP_KAS_KDF_ONESTEP:
+    case ACVP_KAS_FFC_SSC:
+    case ACVP_KAS_IFC_SSC:
+    case ACVP_KTS_IFC:
+    case ACVP_SAFE_PRIMES_KEYGEN:
+    case ACVP_SAFE_PRIMES_KEYVER:
     case ACVP_KAS_HKDF:
     case ACVP_CIPHER_END:
     default:
@@ -2160,24 +2196,8 @@ ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
         return ACVP_NO_CAP;
     }
 
-    //throw errors for non-domain paramaters
     switch (parm) {
-    case ACVP_SYM_CIPH_KW_MODE:
-    case ACVP_SYM_CIPH_PARM_DIR:
-    case ACVP_SYM_CIPH_PARM_KO:
-    case ACVP_SYM_CIPH_PARM_PERFORM_CTR:
-    case ACVP_SYM_CIPH_PARM_CTR_INCR:
-    case ACVP_SYM_CIPH_PARM_CTR_OVRFLW:
-    case ACVP_SYM_CIPH_PARM_IVGEN_SRC:
-    case ACVP_SYM_CIPH_PARM_IVGEN_MODE:
-    case ACVP_SYM_CIPH_PARM_SALT_SRC:
-    case ACVP_SYM_CIPH_KEYLEN:
-    case ACVP_SYM_CIPH_TAGLEN:
-    case ACVP_SYM_CIPH_TWEAK:
-    case ACVP_SYM_CIPH_PARM_CONFORMANCE:
-        ACVP_LOG_ERR("Invalid parameter %d for acvp_cap_sym_cipher_set_domain. Use acvp_cap_sym_cipher_set_parm.", parm);
-        return ACVP_INVALID_ARG;
-    case ACVP_SYM_CIPH_IVLEN:
+    case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         if (symcap->ivlen) {
             ACVP_LOG_ERR("ivLen already defined using acvp_sym_cipher_set_parm. Please set ivLen using only one function \
                           (Using set_parm for ivLen will eventually be depreciated).");
@@ -2192,7 +2212,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
         symcap->iv_len.max = max;
         symcap->iv_len.increment = increment;
         break;
-    case ACVP_SYM_CIPH_PTLEN:
+    case ACVP_SYM_CIPH_DOMAIN_PTLEN:
         if (symcap->ptlen) {
             ACVP_LOG_ERR("ptLen already defined using acvp_sym_cipher_set_parm. Please set ptLen using only one function \
                           (Using set_parm for ptLen will eventually be depreciated).");
@@ -2207,7 +2227,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
         symcap->payload_len.max = max;
         symcap->payload_len.increment = increment;
         break;
-    case ACVP_SYM_CIPH_AADLEN:
+    case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         if (symcap->aadlen) {
             ACVP_LOG_ERR("aadLen already defined using acvp_sym_cipher_set_parm. Please set aadLen using only one function \
                           (Using set_parm for aadLen will eventually be depreciated).");
@@ -2339,6 +2359,11 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
     case ACVP_KAS_FFC_NOCOMP:
     case ACVP_KAS_KDF_ONESTEP:
     case ACVP_KAS_HKDF:
+    case ACVP_KAS_FFC_SSC:
+    case ACVP_KAS_IFC_SSC:
+    case ACVP_KTS_IFC:
+    case ACVP_SAFE_PRIMES_KEYGEN:
+    case ACVP_SAFE_PRIMES_KEYVER:
     case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
@@ -2512,6 +2537,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
     case ACVP_SYM_CIPH_PARM_IVGEN_MODE:
     case ACVP_SYM_CIPH_PARM_IVGEN_SRC:
     case ACVP_SYM_CIPH_PARM_CONFORMANCE:
+    case ACVP_SYM_CIPH_PARM_SALT_SRC:
     default:
         return ACVP_INVALID_ARG;
     }
@@ -2638,6 +2664,11 @@ ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
     case ACVP_KAS_FFC_NOCOMP:
     case ACVP_KAS_KDF_ONESTEP:
     case ACVP_KAS_HKDF:
+    case ACVP_KAS_FFC_SSC:
+    case ACVP_KAS_IFC_SSC:
+    case ACVP_KTS_IFC:
+    case ACVP_SAFE_PRIMES_KEYGEN:
+    case ACVP_SAFE_PRIMES_KEYVER:
     case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
@@ -2658,6 +2689,7 @@ ACVP_RESULT acvp_cap_hash_enable(ACVP_CTX *ctx,
                                  ACVP_CIPHER cipher,
                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
     ACVP_RESULT result = ACVP_SUCCESS;
+    ACVP_SUB_HASH alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -2667,101 +2699,27 @@ ACVP_RESULT acvp_cap_hash_enable(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
-    switch (cipher) {
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
+    alg = acvp_get_hash_alg(cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_HASH_SHA1:
+    case ACVP_SUB_HASH_SHA2_224:
+    case ACVP_SUB_HASH_SHA2_256:
+    case ACVP_SUB_HASH_SHA2_384:
+    case ACVP_SUB_HASH_SHA2_512:
+    case ACVP_SUB_HASH_SHA2_512_224:
+    case ACVP_SUB_HASH_SHA2_512_256:
+    case ACVP_SUB_HASH_SHA3_224:
+    case ACVP_SUB_HASH_SHA3_256:
+    case ACVP_SUB_HASH_SHA3_384:
+    case ACVP_SUB_HASH_SHA3_512:
+    case ACVP_SUB_HASH_SHAKE_128:
+    case ACVP_SUB_HASH_SHAKE_256:
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_RSA_SIGPRIM:
-    case ACVP_RSA_DECPRIM:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
     default:
         ACVP_LOG_ERR("Invalid parameter 'cipher'");
         return ACVP_INVALID_ARG;
@@ -2802,106 +2760,33 @@ ACVP_RESULT acvp_cap_hash_set_parm(ACVP_CTX *ctx,
                                    int value) {
     ACVP_CAPS_LIST *cap;
     ACVP_HASH_CAP *hash_cap;
+    ACVP_SUB_HASH alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
     }
 
-    switch (cipher) {
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
+    alg = acvp_get_hash_alg(cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_HASH_SHA3_224:
+    case ACVP_SUB_HASH_SHA3_256:
+    case ACVP_SUB_HASH_SHA3_384:
+    case ACVP_SUB_HASH_SHA3_512:
+    case ACVP_SUB_HASH_SHAKE_128:
+    case ACVP_SUB_HASH_SHAKE_256:
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_RSA_SIGPRIM:
-    case ACVP_RSA_DECPRIM:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_HASH_SHA1:
+    case ACVP_SUB_HASH_SHA2_224:
+    case ACVP_SUB_HASH_SHA2_256:
+    case ACVP_SUB_HASH_SHA2_384:
+    case ACVP_SUB_HASH_SHA2_512:
+    case ACVP_SUB_HASH_SHA2_512_224:
+    case ACVP_SUB_HASH_SHA2_512_256:
     default:
         return ACVP_INVALID_ARG;
     }
@@ -2928,101 +2813,22 @@ ACVP_RESULT acvp_cap_hash_set_parm(ACVP_CTX *ctx,
         hash_cap->in_empty = value;
         break;
     case ACVP_HASH_OUT_BIT:
-        switch (cipher) {
-        case ACVP_HASH_SHAKE_128:
-        case ACVP_HASH_SHAKE_256:
+        switch (alg) {
+        case ACVP_SUB_HASH_SHAKE_128:
+        case ACVP_SUB_HASH_SHAKE_256:
             break;
-        case ACVP_CIPHER_START:
-        case ACVP_AES_GCM:
-        case ACVP_AES_GCM_SIV:
-        case ACVP_AES_CCM:
-        case ACVP_AES_ECB:
-        case ACVP_AES_CBC:
-        case ACVP_AES_CBC_CS1:
-        case ACVP_AES_CBC_CS2:
-        case ACVP_AES_CBC_CS3:
-        case ACVP_AES_CFB1:
-        case ACVP_AES_CFB8:
-        case ACVP_AES_CFB128:
-        case ACVP_AES_OFB:
-        case ACVP_AES_CTR:
-        case ACVP_AES_XTS:
-        case ACVP_AES_KW:
-        case ACVP_AES_KWP:
-        case ACVP_AES_GMAC:
-        case ACVP_AES_XPN:
-        case ACVP_TDES_ECB:
-        case ACVP_TDES_CBC:
-        case ACVP_TDES_CBCI:
-        case ACVP_TDES_OFB:
-        case ACVP_TDES_OFBI:
-        case ACVP_TDES_CFB1:
-        case ACVP_TDES_CFB8:
-        case ACVP_TDES_CFB64:
-        case ACVP_TDES_CFBP1:
-        case ACVP_TDES_CFBP8:
-        case ACVP_TDES_CFBP64:
-        case ACVP_TDES_CTR:
-        case ACVP_TDES_KW:
-        case ACVP_HASH_SHA1:
-        case ACVP_HASH_SHA224:
-        case ACVP_HASH_SHA256:
-        case ACVP_HASH_SHA384:
-        case ACVP_HASH_SHA512:
-        case ACVP_HASH_SHA512_224:
-        case ACVP_HASH_SHA512_256:
-        case ACVP_HASH_SHA3_224:
-        case ACVP_HASH_SHA3_256:
-        case ACVP_HASH_SHA3_384:
-        case ACVP_HASH_SHA3_512:
-        case ACVP_HASHDRBG:
-        case ACVP_HMACDRBG:
-        case ACVP_CTRDRBG:
-        case ACVP_HMAC_SHA1:
-        case ACVP_HMAC_SHA2_224:
-        case ACVP_HMAC_SHA2_256:
-        case ACVP_HMAC_SHA2_384:
-        case ACVP_HMAC_SHA2_512:
-        case ACVP_HMAC_SHA2_512_224:
-        case ACVP_HMAC_SHA2_512_256:
-        case ACVP_HMAC_SHA3_224:
-        case ACVP_HMAC_SHA3_256:
-        case ACVP_HMAC_SHA3_384:
-        case ACVP_HMAC_SHA3_512:
-        case ACVP_CMAC_AES:
-        case ACVP_CMAC_TDES:
-        case ACVP_DSA_KEYGEN:
-        case ACVP_DSA_PQGGEN:
-        case ACVP_DSA_PQGVER:
-        case ACVP_DSA_SIGGEN:
-        case ACVP_DSA_SIGVER:
-        case ACVP_RSA_KEYGEN:
-        case ACVP_RSA_SIGGEN:
-        case ACVP_RSA_SIGVER:
-        case ACVP_RSA_SIGPRIM:
-        case ACVP_RSA_DECPRIM:
-        case ACVP_ECDSA_KEYGEN:
-        case ACVP_ECDSA_KEYVER:
-        case ACVP_ECDSA_SIGGEN:
-        case ACVP_ECDSA_SIGVER:
-        case ACVP_KDF135_TLS:
-        case ACVP_KDF135_SNMP:
-        case ACVP_KDF135_SSH:
-        case ACVP_KDF135_SRTP:
-        case ACVP_KDF135_IKEV2:
-        case ACVP_KDF135_IKEV1:
-        case ACVP_KDF135_X963:
-        case ACVP_KDF108:
-        case ACVP_PBKDF:
-        case ACVP_KAS_ECC_CDH:
-        case ACVP_KAS_ECC_COMP:
-        case ACVP_KAS_ECC_NOCOMP:
-        case ACVP_KAS_ECC_SSC:
-        case ACVP_KAS_FFC_COMP:
-        case ACVP_KAS_FFC_NOCOMP:
-        case ACVP_KAS_KDF_ONESTEP:
-        case ACVP_KAS_HKDF:
-        case ACVP_CIPHER_END:
+        case ACVP_SUB_HASH_SHA3_224:
+        case ACVP_SUB_HASH_SHA3_256:
+        case ACVP_SUB_HASH_SHA3_384:
+        case ACVP_SUB_HASH_SHA3_512:
+        case ACVP_SUB_HASH_SHA1:
+        case ACVP_SUB_HASH_SHA2_224:
+        case ACVP_SUB_HASH_SHA2_256:
+        case ACVP_SUB_HASH_SHA2_384:
+        case ACVP_SUB_HASH_SHA2_512:
+        case ACVP_SUB_HASH_SHA2_512_224:
+        case ACVP_SUB_HASH_SHA2_512_256:
+            break;
         default:
             ACVP_LOG_ERR("parm 'ACVP_HASH_OUT_BIT' only allowed for ACVP_HASH_SHAKE_* ");
             return ACVP_INVALID_ARG;
@@ -3051,106 +2857,33 @@ ACVP_RESULT acvp_cap_hash_set_domain(ACVP_CTX *ctx,
     ACVP_CAPS_LIST *cap;
     ACVP_HASH_CAP *hash_cap;
     ACVP_JSON_DOMAIN_OBJ *domain;
+    ACVP_SUB_HASH alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
     }
 
-    switch (cipher) {
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
+    alg = acvp_get_hash_alg(cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_HASH_SHA3_224:
+    case ACVP_SUB_HASH_SHA3_256:
+    case ACVP_SUB_HASH_SHA3_384:
+    case ACVP_SUB_HASH_SHA3_512:
+    case ACVP_SUB_HASH_SHAKE_128:
+    case ACVP_SUB_HASH_SHAKE_256:
+    case ACVP_SUB_HASH_SHA1:
+    case ACVP_SUB_HASH_SHA2_224:
+    case ACVP_SUB_HASH_SHA2_256:
+    case ACVP_SUB_HASH_SHA2_384:
+    case ACVP_SUB_HASH_SHA2_512:
+    case ACVP_SUB_HASH_SHA2_512_224:
+    case ACVP_SUB_HASH_SHA2_512_256:
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_RSA_SIGPRIM:
-    case ACVP_RSA_DECPRIM:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
     }
@@ -3227,6 +2960,7 @@ static ACVP_RESULT acvp_validate_hmac_parm_value(ACVP_CIPHER cipher,
                                                  int value) {
     ACVP_RESULT retval = ACVP_INVALID_ARG;
     int max_val = 0;
+    ACVP_SUB_HMAC alg;
 
     switch (parm) {
     case ACVP_HMAC_KEYLEN:
@@ -3237,110 +2971,33 @@ static ACVP_RESULT acvp_validate_hmac_parm_value(ACVP_CIPHER cipher,
         }
         break;
     case ACVP_HMAC_MACLEN:
-        switch (cipher) {
-        case ACVP_HMAC_SHA1:
+        alg = acvp_get_hmac_alg(cipher);
+        if (alg == 0) {
+            return ACVP_INVALID_ARG;
+        }
+
+        switch (alg) {
+        case ACVP_SUB_HMAC_SHA1:
             max_val = 160;
             break;
-        case ACVP_HMAC_SHA2_224:
-        case ACVP_HMAC_SHA2_512_224:
-        case ACVP_HMAC_SHA3_224:
+        case ACVP_SUB_HMAC_SHA2_224:
+        case ACVP_SUB_HMAC_SHA2_512_224:
+        case ACVP_SUB_HMAC_SHA3_224:
             max_val = 224;
             break;
-        case ACVP_HMAC_SHA2_256:
-        case ACVP_HMAC_SHA2_512_256:
-        case ACVP_HMAC_SHA3_256:
+        case ACVP_SUB_HMAC_SHA2_256:
+        case ACVP_SUB_HMAC_SHA2_512_256:
+        case ACVP_SUB_HMAC_SHA3_256:
             max_val = 256;
             break;
-        case ACVP_HMAC_SHA2_384:
-        case ACVP_HMAC_SHA3_384:
+        case ACVP_SUB_HMAC_SHA2_384:
+        case ACVP_SUB_HMAC_SHA3_384:
             max_val = 384;
             break;
-        case ACVP_HMAC_SHA2_512:
-        case ACVP_HMAC_SHA3_512:
+        case ACVP_SUB_HMAC_SHA2_512:
+        case ACVP_SUB_HMAC_SHA3_512:
             max_val = 512;
             break;
-        case ACVP_CIPHER_START:
-        case ACVP_AES_GCM:
-        case ACVP_AES_GCM_SIV:
-        case ACVP_AES_CCM:
-        case ACVP_AES_ECB:
-        case ACVP_AES_CBC:
-        case ACVP_AES_CBC_CS1:
-        case ACVP_AES_CBC_CS2:
-        case ACVP_AES_CBC_CS3:
-        case ACVP_AES_CFB1:
-        case ACVP_AES_CFB8:
-        case ACVP_AES_CFB128:
-        case ACVP_AES_OFB:
-        case ACVP_AES_CTR:
-        case ACVP_AES_XTS:
-        case ACVP_AES_KW:
-        case ACVP_AES_KWP:
-        case ACVP_AES_GMAC:
-        case ACVP_AES_XPN:
-        case ACVP_TDES_ECB:
-        case ACVP_TDES_CBC:
-        case ACVP_TDES_CBCI:
-        case ACVP_TDES_OFB:
-        case ACVP_TDES_OFBI:
-        case ACVP_TDES_CFB1:
-        case ACVP_TDES_CFB8:
-        case ACVP_TDES_CFB64:
-        case ACVP_TDES_CFBP1:
-        case ACVP_TDES_CFBP8:
-        case ACVP_TDES_CFBP64:
-        case ACVP_TDES_CTR:
-        case ACVP_TDES_KW:
-        case ACVP_HASH_SHA1:
-        case ACVP_HASH_SHA224:
-        case ACVP_HASH_SHA256:
-        case ACVP_HASH_SHA384:
-        case ACVP_HASH_SHA512:
-        case ACVP_HASH_SHA512_224:
-        case ACVP_HASH_SHA512_256:
-        case ACVP_HASH_SHA3_224:
-        case ACVP_HASH_SHA3_256:
-        case ACVP_HASH_SHA3_384:
-        case ACVP_HASH_SHA3_512:
-        case ACVP_HASH_SHAKE_128:
-        case ACVP_HASH_SHAKE_256:
-        case ACVP_HASHDRBG:
-        case ACVP_HMACDRBG:
-        case ACVP_CTRDRBG:
-        case ACVP_CMAC_AES:
-        case ACVP_CMAC_TDES:
-        case ACVP_DSA_KEYGEN:
-        case ACVP_DSA_PQGGEN:
-        case ACVP_DSA_PQGVER:
-        case ACVP_DSA_SIGGEN:
-        case ACVP_DSA_SIGVER:
-        case ACVP_RSA_KEYGEN:
-        case ACVP_RSA_SIGGEN:
-        case ACVP_RSA_SIGVER:
-        case ACVP_RSA_SIGPRIM:
-        case ACVP_RSA_DECPRIM:
-        case ACVP_ECDSA_KEYGEN:
-        case ACVP_ECDSA_KEYVER:
-        case ACVP_ECDSA_SIGGEN:
-        case ACVP_ECDSA_SIGVER:
-        case ACVP_KDF135_TLS:
-        case ACVP_KDF135_SNMP:
-        case ACVP_KDF135_SSH:
-        case ACVP_KDF135_SRTP:
-        case ACVP_KDF135_IKEV2:
-        case ACVP_KDF135_IKEV1:
-        case ACVP_KDF135_X963:
-        case ACVP_KDF108:
-        case ACVP_PBKDF:
-        case ACVP_KAS_ECC_CDH:
-        case ACVP_KAS_ECC_COMP:
-        case ACVP_KAS_ECC_NOCOMP:
-        case ACVP_KAS_ECC_SSC:
-        case ACVP_KAS_FFC_COMP:
-        case ACVP_KAS_FFC_NOCOMP:
-        case ACVP_KAS_KDF_ONESTEP:
-        case ACVP_KAS_HKDF:
-        case ACVP_CIPHER_END:
         default:
             break;
         }
@@ -3362,6 +3019,7 @@ ACVP_RESULT acvp_cap_hmac_enable(ACVP_CTX *ctx,
                                  ACVP_CIPHER cipher,
                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
     ACVP_RESULT result = ACVP_SUCCESS;
+    ACVP_SUB_HMAC alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -3372,101 +3030,24 @@ ACVP_RESULT acvp_cap_hmac_enable(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
-    switch (cipher) {
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
+    alg = acvp_get_hmac_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_HMAC_SHA1:
+    case ACVP_SUB_HMAC_SHA2_224:
+    case ACVP_SUB_HMAC_SHA2_256:
+    case ACVP_SUB_HMAC_SHA2_384:
+    case ACVP_SUB_HMAC_SHA2_512:
+    case ACVP_SUB_HMAC_SHA2_512_224:
+    case ACVP_SUB_HMAC_SHA2_512_256:
+    case ACVP_SUB_HMAC_SHA3_224:
+    case ACVP_SUB_HMAC_SHA3_256:
+    case ACVP_SUB_HMAC_SHA3_384:
+    case ACVP_SUB_HMAC_SHA3_512:
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_RSA_SIGPRIM:
-    case ACVP_RSA_DECPRIM:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
     }
@@ -3620,6 +3201,7 @@ ACVP_RESULT acvp_cap_cmac_enable(ACVP_CTX *ctx,
                                  ACVP_CIPHER cipher,
                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
     ACVP_RESULT result = ACVP_SUCCESS;
+    ACVP_SUB_CMAC alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -3629,101 +3211,15 @@ ACVP_RESULT acvp_cap_cmac_enable(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
-    switch (cipher) {
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
+    alg = acvp_get_cmac_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_CMAC_AES:
+    case ACVP_SUB_CMAC_TDES:
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_RSA_SIGPRIM:
-    case ACVP_RSA_DECPRIM:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
     }
@@ -4226,6 +3722,7 @@ ACVP_RESULT acvp_cap_drbg_set_parm(ACVP_CTX *ctx,
     ACVP_DRBG_CAP_MODE_LIST *drbg_cap_mode_list_tmp;
     ACVP_CAPS_LIST *cap_list;
     ACVP_RESULT result;
+    ACVP_SUB_DRBG alg;
 
     /*
      * Validate input
@@ -4275,106 +3772,21 @@ ACVP_RESULT acvp_cap_drbg_set_parm(ACVP_CTX *ctx,
     /*
      * Add the value to the cap
      */
-    switch (cipher) {
-    case ACVP_HASHDRBG:
+    alg = acvp_get_drbg_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_DRBG_HASH:
         result = acvp_add_hash_drbg_cap_parm(&drbg_cap_mode_list->cap_mode, mode, param, value);
         break;
-    case ACVP_HMACDRBG:
+    case ACVP_SUB_DRBG_HMAC:
         result = acvp_add_hmac_drbg_cap_parm(&drbg_cap_mode_list->cap_mode, mode, param, value);
         break;
-    case ACVP_CTRDRBG:
+    case ACVP_SUB_DRBG_CTR:
         result = acvp_add_ctr_drbg_cap_parm(&drbg_cap_mode_list->cap_mode, mode, param, value);
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_RSA_SIGPRIM:
-    case ACVP_RSA_DECPRIM:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
     }
@@ -5147,6 +4559,7 @@ static ACVP_RESULT internal_cap_rsa_sig_enable(ACVP_CTX *ctx,
                                                int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
     ACVP_CAP_TYPE type = 0;
     ACVP_RESULT result = ACVP_SUCCESS;
+    ACVP_SUB_RSA alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -5156,106 +4569,23 @@ static ACVP_RESULT internal_cap_rsa_sig_enable(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
-    switch (cipher) {
-    case ACVP_RSA_SIGGEN:
+    alg = acvp_get_rsa_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_RSA_SIGGEN:
         type = ACVP_RSA_SIGGEN_TYPE;
         break;
-    case ACVP_RSA_SIGVER:
+    case ACVP_SUB_RSA_SIGVER:
         type = ACVP_RSA_SIGVER_TYPE;
         break;
-    case ACVP_RSA_SIGPRIM:
-    case ACVP_RSA_DECPRIM:
+    case ACVP_SUB_RSA_SIGPRIM:
+    case ACVP_SUB_RSA_DECPRIM:
         type = ACVP_RSA_PRIM_TYPE;
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_RSA_KEYGEN:
     default:
         return ACVP_INVALID_ARG;
     }
@@ -5270,6 +4600,7 @@ ACVP_RESULT acvp_cap_rsa_sig_enable(ACVP_CTX *ctx,
                                     int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
     ACVP_RESULT result = ACVP_SUCCESS;
     const char *cap_message_str = NULL;
+    ACVP_SUB_RSA alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -5280,102 +4611,21 @@ ACVP_RESULT acvp_cap_rsa_sig_enable(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
-    switch (cipher) {
-    case ACVP_RSA_SIGGEN:
+    alg = acvp_get_rsa_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_RSA_SIGGEN:
         cap_message_str = "ACVP_RSA_SIGGEN";
         break;
-    case ACVP_RSA_SIGVER:
+    case ACVP_SUB_RSA_SIGVER:
         cap_message_str = "ACVP_RSA_SIGVER";
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_RSA_KEYGEN:
+    case ACVP_SUB_RSA_DECPRIM:
+    case ACVP_SUB_RSA_SIGPRIM:
     default:
         ACVP_LOG_ERR("Invalid parameter 'cipher'");
         return ACVP_INVALID_ARG;
@@ -5449,6 +4699,9 @@ ACVP_RESULT acvp_cap_rsa_prim_set_parm(ACVP_CTX *ctx,
         }
         cap_list->cap.rsa_prim_cap->key_format_crt = value;
         break;
+    case ACVP_RSA_PARM_FIXED_PUB_EXP_VAL:
+    case ACVP_RSA_PARM_RAND_PQ:
+    case ACVP_RSA_PARM_INFO_GEN_BY_SERVER:
     default:
         rv = ACVP_INVALID_ARG;
         break;
@@ -5522,6 +4775,7 @@ ACVP_RESULT acvp_cap_ecdsa_set_parm(ACVP_CTX *ctx,
     ACVP_NAME_LIST *current_secret_mode;
     ACVP_ECDSA_CAP *cap;
     const char *string = NULL;
+    ACVP_SUB_ECDSA alg;
 
     cap_list = acvp_locate_cap_entry(ctx, cipher);
     if (!cap_list) {
@@ -5529,106 +4783,24 @@ ACVP_RESULT acvp_cap_ecdsa_set_parm(ACVP_CTX *ctx,
         return ACVP_NO_CAP;
     }
 
-    switch (cipher) {
-    case ACVP_ECDSA_KEYGEN:
+    alg = acvp_get_ecdsa_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_ECDSA_KEYGEN:
         cap = cap_list->cap.ecdsa_keygen_cap;
         break;
-    case ACVP_ECDSA_KEYVER:
+    case ACVP_SUB_ECDSA_KEYVER:
         cap = cap_list->cap.ecdsa_keyver_cap;
         break;
-    case ACVP_ECDSA_SIGGEN:
+    case ACVP_SUB_ECDSA_SIGGEN:
         cap = cap_list->cap.ecdsa_siggen_cap;
         break;
-    case ACVP_ECDSA_SIGVER:
+    case ACVP_SUB_ECDSA_SIGVER:
         cap = cap_list->cap.ecdsa_sigver_cap;
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
     }
@@ -5757,6 +4929,7 @@ ACVP_RESULT acvp_cap_ecdsa_enable(ACVP_CTX *ctx,
                                   int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
     ACVP_CAP_TYPE type = 0;
     ACVP_RESULT result = ACVP_SUCCESS;
+    ACVP_SUB_ECDSA alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -5767,106 +4940,24 @@ ACVP_RESULT acvp_cap_ecdsa_enable(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
-    switch (cipher) {
-    case ACVP_ECDSA_KEYGEN:
+    alg = acvp_get_ecdsa_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_ECDSA_KEYGEN:
         type = ACVP_ECDSA_KEYGEN_TYPE;
         break;
-    case ACVP_ECDSA_KEYVER:
+    case ACVP_SUB_ECDSA_KEYVER:
         type = ACVP_ECDSA_KEYVER_TYPE;
         break;
-    case ACVP_ECDSA_SIGGEN:
+    case ACVP_SUB_ECDSA_SIGGEN:
         type = ACVP_ECDSA_SIGGEN_TYPE;
         break;
-    case ACVP_ECDSA_SIGVER:
+    case ACVP_SUB_ECDSA_SIGVER:
         type = ACVP_ECDSA_SIGVER_TYPE;
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
     default:
         ACVP_LOG_ERR("Invalid parameter 'cipher'");
         return ACVP_INVALID_ARG;
@@ -7305,6 +6396,8 @@ ACVP_RESULT acvp_cap_kas_ecc_set_prereq(ACVP_CTX *ctx,
     case ACVP_PREREQ_KAS:
     case ACVP_PREREQ_SAFE_PRIMES:
     case ACVP_PREREQ_TDES:
+    case ACVP_PREREQ_RSADP:
+    case ACVP_PREREQ_RSA:
     default:
         ACVP_LOG_ERR("\nUnsupported KAS-ECC prereq %d", pre_req);
         return ACVP_INVALID_ARG;
@@ -7336,6 +6429,7 @@ ACVP_RESULT acvp_cap_kas_ecc_enable(ACVP_CTX *ctx,
                                     int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
     ACVP_CAP_TYPE type = 0;
     ACVP_RESULT result = ACVP_SUCCESS;
+    ACVP_SUB_KAS alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -7345,106 +6439,33 @@ ACVP_RESULT acvp_cap_kas_ecc_enable(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
-    switch (cipher) {
-    case ACVP_KAS_ECC_CDH:
+    alg = acvp_get_kas_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_KAS_ECC_CDH:
         type = ACVP_KAS_ECC_CDH_TYPE;
         break;
-    case ACVP_KAS_ECC_COMP:
+    case ACVP_SUB_KAS_ECC_COMP:
         type = ACVP_KAS_ECC_COMP_TYPE;
         break;
-    case ACVP_KAS_ECC_NOCOMP:
+    case ACVP_SUB_KAS_ECC_NOCOMP:
         type = ACVP_KAS_ECC_NOCOMP_TYPE;
         break;
-    case ACVP_KAS_ECC_SSC:
+    case ACVP_SUB_KAS_ECC_SSC:
         type = ACVP_KAS_ECC_SSC_TYPE;
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_KAS_FFC_COMP:
+    case ACVP_SUB_KAS_FFC_NOCOMP:
+    case ACVP_SUB_KAS_FFC_SSC: 
+    case ACVP_SUB_KAS_IFC_SSC: 
+    case ACVP_SUB_KTS_IFC: 
+    case ACVP_SUB_KAS_KDF_ONESTEP:
+    case ACVP_SUB_KAS_HKDF:
+    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
+    case ACVP_SUB_SAFE_PRIMES_KEYVER:
     default:
         ACVP_LOG_ERR("Invalid parameter 'cipher'");
         return ACVP_INVALID_ARG;
@@ -7471,104 +6492,32 @@ ACVP_RESULT acvp_cap_kas_ecc_set_parm(ACVP_CTX *ctx,
     ACVP_KAS_ECC_CAP_MODE *kas_ecc_cap_mode;
     ACVP_PARAM_LIST *current_func;
     ACVP_PARAM_LIST *current_curve;
+    ACVP_SUB_KAS alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
     }
 
-    switch (cipher) {
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
+    alg = acvp_get_kas_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_KAS_ECC_CDH:
+    case ACVP_SUB_KAS_ECC_COMP:
+    case ACVP_SUB_KAS_ECC_NOCOMP:
+    case ACVP_SUB_KAS_ECC_SSC:
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_KAS_FFC_COMP:
+    case ACVP_SUB_KAS_FFC_NOCOMP:
+    case ACVP_SUB_KAS_FFC_SSC: 
+    case ACVP_SUB_KAS_IFC_SSC: 
+    case ACVP_SUB_KTS_IFC: 
+    case ACVP_SUB_KAS_KDF_ONESTEP:
+    case ACVP_SUB_KAS_HKDF:
+    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
+    case ACVP_SUB_SAFE_PRIMES_KEYVER:
     default:
         ACVP_LOG_ERR("Invalid cipher");
         return ACVP_INVALID_ARG;
@@ -7668,6 +6617,7 @@ ACVP_RESULT acvp_cap_kas_ecc_set_parm(ACVP_CTX *ctx,
         case ACVP_KAS_ECC_ED:
         case ACVP_KAS_ECC_EE:
         case ACVP_KAS_ECC_NONE:
+        case ACVP_KAS_ECC_HASH:
         default:
             ACVP_LOG_ERR("\nUnsupported KAS-ECC param %d", param);
             return ACVP_INVALID_ARG;
@@ -7701,105 +6651,32 @@ ACVP_RESULT acvp_cap_kas_ecc_set_scheme(ACVP_CTX *ctx,
     ACVP_KAS_ECC_PSET *last_pset = NULL;
     ACVP_PARAM_LIST *current_role;
     ACVP_PARAM_LIST *current_hash;
+    ACVP_SUB_KAS alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
     }
 
-    switch (cipher) {
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
+    alg = acvp_get_kas_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_KAS_ECC_CDH:
+    case ACVP_SUB_KAS_ECC_COMP:
+    case ACVP_SUB_KAS_ECC_NOCOMP:
+    case ACVP_SUB_KAS_ECC_SSC:
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_FFC_SSC:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_KAS_FFC_COMP:
+    case ACVP_SUB_KAS_FFC_NOCOMP:
+    case ACVP_SUB_KAS_FFC_SSC:
+    case ACVP_SUB_KAS_IFC_SSC: 
+    case ACVP_SUB_KTS_IFC: 
+    case ACVP_SUB_KAS_KDF_ONESTEP:
+    case ACVP_SUB_KAS_HKDF:
+    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
+    case ACVP_SUB_SAFE_PRIMES_KEYVER:
     default:
         ACVP_LOG_ERR("Invalid cipher");
         return ACVP_INVALID_ARG;
@@ -7902,6 +6779,7 @@ ACVP_RESULT acvp_cap_kas_ecc_set_scheme(ACVP_CTX *ctx,
             break;
         case ACVP_KAS_ECC_CURVE:
         case ACVP_KAS_ECC_FUNCTION:
+        case ACVP_KAS_ECC_HASH:
         default:
             ACVP_LOG_ERR("\nUnsupported KAS-ECC param %d", param);
             return ACVP_INVALID_ARG;
@@ -7981,6 +6859,8 @@ ACVP_RESULT acvp_cap_kas_ffc_set_prereq(ACVP_CTX *ctx,
     case ACVP_PREREQ_ECDSA:
     case ACVP_PREREQ_KAS:
     case ACVP_PREREQ_TDES:
+    case ACVP_PREREQ_RSADP:
+    case ACVP_PREREQ_RSA:
     default:
         ACVP_LOG_ERR("\nUnsupported KAS-FFC prereq %d", pre_req);
         return ACVP_INVALID_ARG;
@@ -8012,6 +6892,7 @@ ACVP_RESULT acvp_cap_kas_ffc_enable(ACVP_CTX *ctx,
                                     int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
     ACVP_CAP_TYPE type = 0;
     ACVP_RESULT result = ACVP_SUCCESS;
+    ACVP_SUB_KAS alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -8021,105 +6902,31 @@ ACVP_RESULT acvp_cap_kas_ffc_enable(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
-    switch (cipher) {
-    case ACVP_KAS_FFC_SSC:
+    alg = acvp_get_kas_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_KAS_FFC_SSC:
         type = ACVP_KAS_FFC_SSC_TYPE;
         break;
-    case ACVP_KAS_FFC_COMP:
+    case ACVP_SUB_KAS_FFC_COMP:
         type = ACVP_KAS_FFC_COMP_TYPE;
         break;
-    case ACVP_KAS_FFC_NOCOMP:
+    case ACVP_SUB_KAS_FFC_NOCOMP:
         type = ACVP_KAS_FFC_NOCOMP_TYPE;
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_KAS_ECC_CDH:
+    case ACVP_SUB_KAS_ECC_COMP:
+    case ACVP_SUB_KAS_ECC_NOCOMP:
+    case ACVP_SUB_KAS_ECC_SSC:
+    case ACVP_SUB_KAS_IFC_SSC: 
+    case ACVP_SUB_KTS_IFC: 
+    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
+    case ACVP_SUB_SAFE_PRIMES_KEYVER:
+    case ACVP_SUB_KAS_KDF_ONESTEP:
+    case ACVP_SUB_KAS_HKDF:
     default:
         ACVP_LOG_ERR("Invalid parameter 'cipher'");
         return ACVP_INVALID_ARG;
@@ -8146,104 +6953,32 @@ ACVP_RESULT acvp_cap_kas_ffc_set_parm(ACVP_CTX *ctx,
     ACVP_KAS_FFC_CAP_MODE *kas_ffc_cap_mode;
     ACVP_PARAM_LIST *current_func;
     ACVP_PARAM_LIST *current_genmeth;
+    ACVP_SUB_KAS alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
     }
 
-    switch (cipher) {
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_FFC_SSC:
+    alg = acvp_get_kas_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_KAS_FFC_COMP:
+    case ACVP_SUB_KAS_FFC_NOCOMP:
+    case ACVP_SUB_KAS_FFC_SSC:
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_KAS_ECC_CDH:
+    case ACVP_SUB_KAS_ECC_COMP:
+    case ACVP_SUB_KAS_ECC_NOCOMP:
+    case ACVP_SUB_KAS_ECC_SSC: 
+    case ACVP_SUB_KAS_IFC_SSC: 
+    case ACVP_SUB_KTS_IFC: 
+    case ACVP_SUB_KAS_KDF_ONESTEP:
+    case ACVP_SUB_KAS_HKDF:
+    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
+    case ACVP_SUB_SAFE_PRIMES_KEYVER:
     default:
         ACVP_LOG_ERR("Invalid cipher");
         return ACVP_INVALID_ARG;
@@ -8294,6 +7029,8 @@ ACVP_RESULT acvp_cap_kas_ffc_set_parm(ACVP_CTX *ctx,
         case ACVP_KAS_FFC_FFDHE4096:
         case ACVP_KAS_FFC_FFDHE6144:
         case ACVP_KAS_FFC_FFDHE8192:
+        case ACVP_KAS_FFC_HASH:
+        case ACVP_KAS_FFC_GEN_METH:
         default:
             ACVP_LOG_ERR("\nUnsupported KAS-FFC param %d", param);
             return ACVP_INVALID_ARG;
@@ -8474,6 +7211,8 @@ ACVP_RESULT acvp_cap_kas_ffc_set_scheme(ACVP_CTX *ctx,
             break;
         case ACVP_KAS_FFC_FUNCTION:
         case ACVP_KAS_FFC_CURVE:
+        case ACVP_KAS_FFC_HASH:
+        case ACVP_KAS_FFC_GEN_METH:
         default:
             ACVP_LOG_ERR("\nUnsupported KAS-FFC param %d", param);
             return ACVP_INVALID_ARG;
@@ -8636,6 +7375,9 @@ ACVP_RESULT acvp_cap_kas_ifc_set_exponent(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
+    if (param != ACVP_KAS_IFC_FIXEDPUBEXP) {
+        return ACVP_INVALID_ARG;
+    }        
     kas_ifc_cap->fixed_pub_exp = calloc(len + 1, sizeof(char));
     strcpy_s(kas_ifc_cap->fixed_pub_exp, len + 1, value);
     return ACVP_SUCCESS;
@@ -8646,6 +7388,7 @@ ACVP_RESULT acvp_cap_kas_kdf_enable(ACVP_CTX *ctx,
                                     int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
     ACVP_CAP_TYPE type = 0;
     ACVP_RESULT result = ACVP_SUCCESS;
+    ACVP_SUB_KAS alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -8655,104 +7398,29 @@ ACVP_RESULT acvp_cap_kas_kdf_enable(ACVP_CTX *ctx,
         return ACVP_INVALID_ARG;
     }
 
-    switch (cipher) {
-    case ACVP_KAS_KDF_ONESTEP:
+    alg = acvp_get_kas_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_KAS_KDF_ONESTEP:
         type = ACVP_KAS_KDF_ONESTEP_TYPE;
         break;
-    case ACVP_KAS_HKDF:
+    case ACVP_SUB_KAS_HKDF:
         type = ACVP_KAS_HKDF_TYPE;
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_ECC_SSC:
-    case ACVP_KAS_FFC_SSC:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KTS_IFC:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_KAS_ECC_CDH:
+    case ACVP_SUB_KAS_ECC_COMP:
+    case ACVP_SUB_KAS_ECC_NOCOMP:
+    case ACVP_SUB_KAS_ECC_SSC:
+    case ACVP_SUB_KAS_FFC_COMP:
+    case ACVP_SUB_KAS_FFC_NOCOMP:
+    case ACVP_SUB_KAS_FFC_SSC:
+    case ACVP_SUB_KAS_IFC_SSC:
+    case ACVP_SUB_KTS_IFC:
+    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
+    case ACVP_SUB_SAFE_PRIMES_KEYVER:
     default:
         ACVP_LOG_ERR("Invalid parameter 'cipher'");
         return ACVP_INVALID_ARG;
@@ -8776,6 +7444,7 @@ ACVP_RESULT acvp_cap_kas_kdf_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KA
     ACVP_PARAM_LIST *plist = NULL;
     ACVP_NAME_LIST *nlist = NULL;
     const char* tmp = NULL;
+    ACVP_SUB_KAS alg;
 
     /*
      * Validate input
@@ -8801,8 +7470,14 @@ ACVP_RESULT acvp_cap_kas_kdf_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KA
         return ACVP_NO_CAP;
     }
 
-    switch (cipher) {
-    case ACVP_KAS_KDF_ONESTEP:
+    alg = acvp_get_kas_alg(cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_KAS_KDF_ONESTEP:
         if (!cap_list->cap.kas_kdf_onestep_cap) {
             ACVP_LOG_ERR("KAS-KDF onestep cap entry not found.");
             return ACVP_NO_CAP;
@@ -8925,12 +7600,13 @@ ACVP_RESULT acvp_cap_kas_kdf_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KA
                 nlist->next->name = tmp;
             }
             break;
+        case ACVP_KAS_KDF_Z:
         default:
             ACVP_LOG_ERR("Invalid parameter specified");
             return ACVP_INVALID_ARG;
         }
         break;
-    case ACVP_KAS_HKDF:
+    case ACVP_SUB_KAS_HKDF:
         if (!cap_list->cap.kas_hkdf_cap) {
             ACVP_LOG_ERR("KAS-HKDF entry not found.");
             return ACVP_NO_CAP;
@@ -9057,11 +7733,23 @@ ACVP_RESULT acvp_cap_kas_kdf_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KA
         case ACVP_KAS_KDF_ONESTEP_AUX_FUNCTION:
             ACVP_LOG_ERR("Cannot set aux functions for HKDF. use HMAC_ALG instead.");
             return ACVP_INVALID_ARG;
+        case ACVP_KAS_KDF_Z:
         default:
             ACVP_LOG_ERR("Invalid parameter specified");
             return ACVP_INVALID_ARG;
         }
         break;
+    case ACVP_SUB_KAS_ECC_CDH:
+    case ACVP_SUB_KAS_ECC_COMP:
+    case ACVP_SUB_KAS_ECC_NOCOMP:
+    case ACVP_SUB_KAS_ECC_SSC:
+    case ACVP_SUB_KAS_FFC_COMP:
+    case ACVP_SUB_KAS_FFC_NOCOMP:
+    case ACVP_SUB_KAS_FFC_SSC:
+    case ACVP_SUB_KAS_IFC_SSC:
+    case ACVP_SUB_KTS_IFC:
+    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
+    case ACVP_SUB_SAFE_PRIMES_KEYVER:
     default:
         ACVP_LOG_ERR("Invalid cipher specified");
         return ACVP_INVALID_ARG;
@@ -9073,6 +7761,7 @@ ACVP_RESULT acvp_cap_kas_kdf_set_domain(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
                                         int min, int max, int increment) {
     ACVP_CAPS_LIST *cap_list = NULL;
     ACVP_RESULT result = ACVP_SUCCESS;
+    ACVP_SUB_KAS alg;
 
     /*
      * Validate input
@@ -9098,8 +7787,14 @@ ACVP_RESULT acvp_cap_kas_kdf_set_domain(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
         ACVP_LOG_ERR("Invalid domain given");
     }
 
-    switch (cipher) {
-    case ACVP_KAS_KDF_ONESTEP:
+    alg = acvp_get_kas_alg(cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value");
+        return 1;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_KAS_KDF_ONESTEP:
         if (!cap_list->cap.kas_kdf_onestep_cap) {
             ACVP_LOG_ERR("KAS-KDF onestep cap entry not found.");
             return ACVP_NO_CAP;
@@ -9108,7 +7803,7 @@ ACVP_RESULT acvp_cap_kas_kdf_set_domain(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
         cap_list->cap.kas_kdf_onestep_cap->z.max = max;
         cap_list->cap.kas_kdf_onestep_cap->z.increment = increment;
         break;
-    case ACVP_KAS_HKDF:
+    case ACVP_SUB_KAS_HKDF:
         if (!cap_list->cap.kas_hkdf_cap) {
             ACVP_LOG_ERR("KAS-HKDF entry not found.");
             return ACVP_NO_CAP;
@@ -9117,6 +7812,17 @@ ACVP_RESULT acvp_cap_kas_kdf_set_domain(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
         cap_list->cap.kas_hkdf_cap->z.max = max;
         cap_list->cap.kas_hkdf_cap->z.increment = increment;
         break;
+    case ACVP_SUB_KAS_ECC_CDH:
+    case ACVP_SUB_KAS_ECC_COMP:
+    case ACVP_SUB_KAS_ECC_NOCOMP:
+    case ACVP_SUB_KAS_ECC_SSC:
+    case ACVP_SUB_KAS_FFC_COMP:
+    case ACVP_SUB_KAS_FFC_NOCOMP:
+    case ACVP_SUB_KAS_FFC_SSC:
+    case ACVP_SUB_KAS_IFC_SSC:
+    case ACVP_SUB_KTS_IFC:
+    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
+    case ACVP_SUB_SAFE_PRIMES_KEYVER:
     default:
         ACVP_LOG_ERR("Invalid cipher specified");
         return ACVP_INVALID_ARG;
@@ -9233,6 +7939,8 @@ ACVP_RESULT acvp_cap_kts_ifc_set_parm(ACVP_CTX *ctx,
         break;
     case ACVP_KTS_IFC_IUT_ID:
     case ACVP_KTS_IFC_FIXEDPUBEXP:
+    case ACVP_KTS_IFC_KEYPAIR_GEN:
+    case ACVP_KTS_IFC_PARTIAL_VAL:
     default:
         ACVP_LOG_ERR("Invalid param");
         return ACVP_INVALID_ARG;
@@ -9316,6 +8024,9 @@ ACVP_RESULT acvp_cap_kts_ifc_set_scheme_parm(ACVP_CTX *ctx,
             current_scheme->hash->param = value;
         }
         break;
+    case ACVP_KTS_IFC_AD_PATTERN:
+    case ACVP_KTS_IFC_ENCODING:
+    case ACVP_KTS_IFC_MAC_METHODS:
     default:
         ACVP_LOG_ERR("Invalid param");
         return ACVP_INVALID_ARG;
@@ -9362,6 +8073,12 @@ ACVP_RESULT acvp_cap_kts_ifc_set_param_string(ACVP_CTX *ctx,
         kts_ifc_cap->iut_id = calloc(len + 1, sizeof(char));
         strcpy_s(kts_ifc_cap->iut_id, len + 1, value);
         break;
+    case ACVP_KTS_IFC_KEYGEN_METHOD:
+    case ACVP_KTS_IFC_SCHEME:
+    case ACVP_KTS_IFC_FUNCTION:
+    case ACVP_KTS_IFC_MODULO:
+    case ACVP_KTS_IFC_KEYPAIR_GEN:
+    case ACVP_KTS_IFC_PARTIAL_VAL:
     default:
         ACVP_LOG_ERR("Invalid param");
         return ACVP_INVALID_ARG;
@@ -9428,6 +8145,12 @@ ACVP_RESULT acvp_cap_kts_ifc_set_scheme_string(ACVP_CTX *ctx,
         current_scheme->encodings = calloc(len + 1, sizeof(char));
         strcpy_s(current_scheme->encodings, len + 1, value);
         break;
+    case ACVP_KTS_IFC_NULL_ASSOC_DATA:
+    case ACVP_KTS_IFC_HASH:
+    case ACVP_KTS_IFC_ROLE:
+    case ACVP_KTS_IFC_L:
+    case ACVP_KTS_IFC_MAC_METHODS:
+    case ACVP_KTS_IFC_FIXEDPUBEXP:
     default:
         ACVP_LOG_ERR("Invalid param");
         return ACVP_INVALID_ARG;
@@ -9475,6 +8198,7 @@ ACVP_RESULT acvp_cap_safe_primes_set_parm(ACVP_CTX *ctx,
     ACVP_SAFE_PRIMES_CAP *safe_primes_cap;
     ACVP_SAFE_PRIMES_CAP_MODE *safe_primes_cap_mode;
     ACVP_PARAM_LIST *current_genmeth;
+    ACVP_SUB_KAS alg;
 
     if (!ctx) {
         return ACVP_NO_CTX;
@@ -9505,8 +8229,14 @@ ACVP_RESULT acvp_cap_safe_primes_set_parm(ACVP_CTX *ctx,
     if (!safe_primes_cap_mode) {
         return ACVP_NO_CAP;
     }
-    switch (cipher) {
-    case ACVP_SAFE_PRIMES_KEYVER:
+    alg = acvp_get_kas_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    
+    switch (alg) {
+    case ACVP_SUB_SAFE_PRIMES_KEYVER:
         switch (param) {
         case ACVP_SAFE_PRIMES_GENMETH:
             current_genmeth = safe_primes_cap_mode->genmeth;
@@ -9525,7 +8255,7 @@ ACVP_RESULT acvp_cap_safe_primes_set_parm(ACVP_CTX *ctx,
             break;
         }
         break;
-    case ACVP_SAFE_PRIMES_KEYGEN:
+    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
         switch (param) {
         case ACVP_SAFE_PRIMES_GENMETH:
             current_genmeth = safe_primes_cap_mode->genmeth;
@@ -9544,6 +8274,17 @@ ACVP_RESULT acvp_cap_safe_primes_set_parm(ACVP_CTX *ctx,
             break;
         }
         break;
+    case ACVP_SUB_KAS_ECC_CDH:
+    case ACVP_SUB_KAS_ECC_COMP:
+    case ACVP_SUB_KAS_ECC_NOCOMP:
+    case ACVP_SUB_KAS_ECC_SSC:
+    case ACVP_SUB_KAS_FFC_SSC:
+    case ACVP_SUB_KAS_FFC_COMP:
+    case ACVP_SUB_KAS_FFC_NOCOMP:
+    case ACVP_SUB_KAS_IFC_SSC:
+    case ACVP_SUB_KTS_IFC:
+    case ACVP_SUB_KAS_KDF_ONESTEP:
+    case ACVP_SUB_KAS_HKDF:
     default:
         break;
     }

--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -81,16 +81,22 @@ static void shiftin(unsigned char *dst, int dst_max, unsigned char *src, int nbi
  * performs the iteration depdedent upon the cipher type and direction.
  */
 static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx,
-                                           ACVP_SYM_CIPHER_TC *stc,
-                                           int i) {
+                                           ACVP_SYM_CIPHER_TC *stc) {
     int j = stc->mct_index;
     int n;
+    ACVP_SUB_TDES alg;
 
     memcpy_s(ctext[j], TEXT_ROW_LEN,  stc->ct, stc->ct_len);
     memcpy_s(ptext[j], TEXT_ROW_LEN, stc->pt, stc->pt_len);
 
-    switch (stc->cipher) {
-    case ACVP_TDES_CBC:
+    alg = acvp_get_tdes_alg(stc->cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    
+    switch (alg) {
+    case ACVP_SUB_TDES_CBC:
         if (stc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
             if (j == 0) {
                 memcpy_s(stc->pt, ACVP_SYM_PT_BYTE_MAX, old_iv, 8);
@@ -113,7 +119,7 @@ static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx,
             }
         }
         break;
-    case ACVP_TDES_CFB64:
+    case ACVP_SUB_TDES_CFB64:
         if (stc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
             if (j == 0) {
                 memcpy_s(stc->pt, ACVP_SYM_PT_BYTE_MAX, old_iv, 8);
@@ -135,7 +141,7 @@ static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx,
         }
         break;
 
-    case ACVP_TDES_OFB:
+    case ACVP_SUB_TDES_OFB:
         if (stc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
             if (j == 0) {
                 memcpy_s(stc->pt, ACVP_SYM_PT_BYTE_MAX, old_iv, 8);
@@ -154,8 +160,8 @@ static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx,
             }
         }
         break;
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
+    case ACVP_SUB_TDES_CFB1:
+    case ACVP_SUB_TDES_CFB8:
         if (stc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
             if (j == 0) {
                 memcpy_s(stc->pt, ACVP_SYM_PT_BYTE_MAX, old_iv, 8);
@@ -174,94 +180,20 @@ static ACVP_RESULT acvp_des_mct_iterate_tc(ACVP_CTX *ctx,
         }
         break;
 
-    case ACVP_TDES_ECB:
+    case ACVP_SUB_TDES_ECB:
         if (stc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
             memcpy_s(stc->pt, ACVP_SYM_PT_BYTE_MAX, stc->ct, stc->ct_len);
         } else {
             memcpy_s(stc->ct, ACVP_SYM_CT_BYTE_MAX, stc->pt, stc->pt_len);
         }
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_TDES_CBCI:
+    case ACVP_SUB_TDES_OFBI:
+    case ACVP_SUB_TDES_CFBP1:
+    case ACVP_SUB_TDES_CFBP8:
+    case ACVP_SUB_TDES_CFBP64:
+    case ACVP_SUB_TDES_CTR:
+    case ACVP_SUB_TDES_KW:
     default:
         break;
     }
@@ -462,6 +394,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
     char *tmp = NULL;
 #define NK_LEN 32 /* Longest key + 8 */
     unsigned char nk[NK_LEN];
+    ACVP_SUB_TDES alg;
 
     tmp = calloc(1, ACVP_SYM_CT_MAX + 1);
     if (!tmp) {
@@ -469,100 +402,33 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
         return ACVP_MALLOC_FAIL;
     }
 
-    switch (stc->cipher) {
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_ECB:
+    alg = acvp_get_tdes_alg(stc->cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        free(tmp);
+        return ACVP_INVALID_ARG;
+    }
+    
+    switch (alg) {
+    case ACVP_SUB_TDES_CBC:
+    case ACVP_SUB_TDES_OFB:
+    case ACVP_SUB_TDES_CFB64:
+    case ACVP_SUB_TDES_ECB:
         bit_len = 64;
         break;
-    case ACVP_TDES_CFB8:
+    case ACVP_SUB_TDES_CFB8:
         bit_len = 8;
         break;
-    case ACVP_TDES_CFB1:
+    case ACVP_SUB_TDES_CFB1:
         bit_len = 1;
         break;
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_TDES_CBCI:
+    case ACVP_SUB_TDES_OFBI:
+    case ACVP_SUB_TDES_CFBP1:
+    case ACVP_SUB_TDES_CFBP8:
+    case ACVP_SUB_TDES_CFBP64:
+    case ACVP_SUB_TDES_CTR:
+    case ACVP_SUB_TDES_KW:
     default:
         ACVP_LOG_ERR("unsupported algorithm (%d)", stc->cipher);
         free(tmp);
@@ -608,7 +474,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
             } else {
                 shiftin(nk, NK_LEN, stc->pt, bit_len);
             }
-            rv = acvp_des_mct_iterate_tc(ctx, stc, i);
+            rv = acvp_des_mct_iterate_tc(ctx, stc);
             if (rv != ACVP_SUCCESS) {
                 ACVP_LOG_ERR("Failed the MCT iteration changes");
                 free(tmp);

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -43,9 +43,7 @@ static ACVP_RESULT acvp_hash_release_tc(ACVP_HASH_TC *stc);
  * performs the iteration depdedent upon the hash type
  * and direction.
  */
-static ACVP_RESULT acvp_hash_mct_iterate_tc(ACVP_CTX *ctx,
-                                            ACVP_HASH_TC *stc,
-                                            int i) {
+static ACVP_RESULT acvp_hash_mct_iterate_tc(ACVP_HASH_TC *stc) {
 
     /* feed hash into the next message for MCT */
     memcpy_s(stc->m1, ACVP_HASH_MD_BYTE_MAX, stc->m2, stc->md_len);
@@ -163,7 +161,7 @@ static ACVP_RESULT acvp_hash_mct_tc(ACVP_CTX *ctx,
             /*
              * Adjust the parameters for next iteration if needed.
              */
-            rv = acvp_hash_mct_iterate_tc(ctx, stc, i);
+            rv = acvp_hash_mct_iterate_tc(stc);
             if (rv != ACVP_SUCCESS) {
                 ACVP_LOG_ERR("Failed the MCT iteration changes");
                 free(msg);

--- a/src/acvp_kas_ecc.c
+++ b/src/acvp_kas_ecc.c
@@ -746,6 +746,7 @@ ACVP_RESULT acvp_kas_ecc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     const char *alg_str = NULL;
     char *json_result = NULL;
     const char *mode_str = NULL;
+    ACVP_SUB_KAS alg;
 
     if (!ctx) {
         ACVP_LOG_ERR("No ctx for handler operation");
@@ -797,8 +798,15 @@ ACVP_RESULT acvp_kas_ecc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         stc.cipher = ACVP_KAS_ECC_NOCOMP;
     }
 
-    switch (stc.cipher) {
-    case ACVP_KAS_ECC_CDH:
+    alg = acvp_get_kas_alg(stc.cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        rv = ACVP_INVALID_ARG;
+        goto err;
+    }
+    
+    switch (alg) {
+    case ACVP_SUB_KAS_ECC_CDH:
         cap = acvp_locate_cap_entry(ctx, ACVP_KAS_ECC_CDH);
         if (!cap) {
             ACVP_LOG_ERR("ACVP server requesting unsupported capability");
@@ -811,7 +819,7 @@ ACVP_RESULT acvp_kas_ecc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         }
 
         break;
-    case ACVP_KAS_ECC_COMP:
+    case ACVP_SUB_KAS_ECC_COMP:
         cap = acvp_locate_cap_entry(ctx, ACVP_KAS_ECC_COMP);
         if (!cap) {
             ACVP_LOG_ERR("ACVP server requesting unsupported capability");
@@ -824,94 +832,17 @@ ACVP_RESULT acvp_kas_ecc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         }
 
         break;
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_PBKDF:
-    case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KAS_KDF_ONESTEP:
-    case ACVP_KAS_HKDF:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_KAS_ECC_NOCOMP:
+    case ACVP_SUB_KAS_ECC_SSC:
+    case ACVP_SUB_KAS_FFC_COMP:
+    case ACVP_SUB_KAS_FFC_NOCOMP:
+    case ACVP_SUB_KAS_FFC_SSC:
+    case ACVP_SUB_KAS_IFC_SSC:
+    case ACVP_SUB_KTS_IFC:
+    case ACVP_SUB_KAS_KDF_ONESTEP:
+    case ACVP_SUB_KAS_HKDF:
+    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
+    case ACVP_SUB_SAFE_PRIMES_KEYVER:
     default:
         ACVP_LOG_ERR("ACVP server requesting unsupported KAS-ECC mode");
         rv = ACVP_UNSUPPORTED_OP;

--- a/src/acvp_kas_ffc.c
+++ b/src/acvp_kas_ffc.c
@@ -553,6 +553,7 @@ ACVP_RESULT acvp_kas_ffc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     const char *alg_str = NULL;
     char *json_result = NULL;
     const char *mode_str = NULL;
+    ACVP_SUB_KAS alg;
 
     if (!ctx) {
         ACVP_LOG_ERR("No ctx for handler operation");
@@ -602,8 +603,15 @@ ACVP_RESULT acvp_kas_ffc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         stc.cipher = ACVP_KAS_FFC_NOCOMP;
     }
 
-    switch (stc.cipher) {
-    case ACVP_KAS_FFC_COMP:
+    alg = acvp_get_kas_alg(stc.cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        rv = ACVP_INVALID_ARG;
+        goto err;
+    }
+    
+    switch (alg) {
+    case ACVP_SUB_KAS_FFC_COMP:
         cap = acvp_locate_cap_entry(ctx, ACVP_KAS_FFC_COMP);
         if (!cap) {
             ACVP_LOG_ERR("ACVP server requesting unsupported capability");
@@ -617,92 +625,18 @@ ACVP_RESULT acvp_kas_ffc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         break;
 
-    case ACVP_CIPHER_START:
-    case ACVP_AES_GCM:
-    case ACVP_AES_GCM_SIV:
-    case ACVP_AES_CCM:
-    case ACVP_AES_ECB:
-    case ACVP_AES_CBC:
-    case ACVP_AES_CBC_CS1:
-    case ACVP_AES_CBC_CS2:
-    case ACVP_AES_CBC_CS3:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
-    case ACVP_AES_CFB128:
-    case ACVP_AES_OFB:
-    case ACVP_AES_CTR:
-    case ACVP_AES_XTS:
-    case ACVP_AES_KW:
-    case ACVP_AES_KWP:
-    case ACVP_AES_GMAC:
-    case ACVP_AES_XPN:
-    case ACVP_TDES_ECB:
-    case ACVP_TDES_CBC:
-    case ACVP_TDES_CBCI:
-    case ACVP_TDES_OFB:
-    case ACVP_TDES_OFBI:
-    case ACVP_TDES_CFB1:
-    case ACVP_TDES_CFB8:
-    case ACVP_TDES_CFB64:
-    case ACVP_TDES_CFBP1:
-    case ACVP_TDES_CFBP8:
-    case ACVP_TDES_CFBP64:
-    case ACVP_TDES_CTR:
-    case ACVP_TDES_KW:
-    case ACVP_HASH_SHA1:
-    case ACVP_HASH_SHA224:
-    case ACVP_HASH_SHA256:
-    case ACVP_HASH_SHA384:
-    case ACVP_HASH_SHA512:
-    case ACVP_HASH_SHA512_224:
-    case ACVP_HASH_SHA512_256:
-    case ACVP_HASH_SHA3_224:
-    case ACVP_HASH_SHA3_256:
-    case ACVP_HASH_SHA3_384:
-    case ACVP_HASH_SHA3_512:
-    case ACVP_HASH_SHAKE_128:
-    case ACVP_HASH_SHAKE_256:
-    case ACVP_HASHDRBG:
-    case ACVP_HMACDRBG:
-    case ACVP_CTRDRBG:
-    case ACVP_HMAC_SHA1:
-    case ACVP_HMAC_SHA2_224:
-    case ACVP_HMAC_SHA2_256:
-    case ACVP_HMAC_SHA2_384:
-    case ACVP_HMAC_SHA2_512:
-    case ACVP_HMAC_SHA2_512_224:
-    case ACVP_HMAC_SHA2_512_256:
-    case ACVP_HMAC_SHA3_224:
-    case ACVP_HMAC_SHA3_256:
-    case ACVP_HMAC_SHA3_384:
-    case ACVP_HMAC_SHA3_512:
-    case ACVP_CMAC_AES:
-    case ACVP_CMAC_TDES:
-    case ACVP_DSA_KEYGEN:
-    case ACVP_DSA_PQGGEN:
-    case ACVP_DSA_PQGVER:
-    case ACVP_DSA_SIGGEN:
-    case ACVP_DSA_SIGVER:
-    case ACVP_RSA_KEYGEN:
-    case ACVP_RSA_SIGGEN:
-    case ACVP_RSA_SIGVER:
-    case ACVP_ECDSA_KEYGEN:
-    case ACVP_ECDSA_KEYVER:
-    case ACVP_ECDSA_SIGGEN:
-    case ACVP_ECDSA_SIGVER:
-    case ACVP_KDF135_TLS:
-    case ACVP_KDF135_SNMP:
-    case ACVP_KDF135_SSH:
-    case ACVP_KDF135_SRTP:
-    case ACVP_KDF135_IKEV2:
-    case ACVP_KDF135_IKEV1:
-    case ACVP_KDF135_X963:
-    case ACVP_KDF108:
-    case ACVP_KAS_ECC_CDH:
-    case ACVP_KAS_ECC_COMP:
-    case ACVP_KAS_ECC_NOCOMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_CIPHER_END:
+    case ACVP_SUB_KAS_ECC_CDH:
+    case ACVP_SUB_KAS_ECC_COMP:
+    case ACVP_SUB_KAS_ECC_NOCOMP:
+    case ACVP_SUB_KAS_ECC_SSC:
+    case ACVP_SUB_KAS_FFC_NOCOMP:
+    case ACVP_SUB_KAS_FFC_SSC:
+    case ACVP_SUB_KAS_IFC_SSC:
+    case ACVP_SUB_KTS_IFC:
+    case ACVP_SUB_KAS_KDF_ONESTEP:
+    case ACVP_SUB_KAS_HKDF:
+    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
+    case ACVP_SUB_SAFE_PRIMES_KEYVER:
     default:
         ACVP_LOG_ERR("ACVP server requesting unsupported KAS-FFC mode");
         rv = ACVP_UNSUPPORTED_OP;

--- a/src/acvp_kas_ifc.c
+++ b/src/acvp_kas_ifc.c
@@ -74,8 +74,7 @@ end:
     return rv;
 }
 
-static ACVP_RESULT acvp_kas_ifc_ssc_val_output_tc(ACVP_CTX *ctx,
-                                                  ACVP_KAS_IFC_TC *stc,
+static ACVP_RESULT acvp_kas_ifc_ssc_val_output_tc(ACVP_KAS_IFC_TC *stc,
                                                   JSON_Object *tc_rsp) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     int diff1 = 1, diff2 = 1;
@@ -252,7 +251,12 @@ static ACVP_KAS_IFC_TEST_TYPE read_test_type(const char *str) {
 }
 
 static ACVP_RSA_KEY_FORMAT read_key_gen(const char *str){
-    return ACVP_KAS_IFC_RSAKPG1_BASIC;
+    int diff;
+
+    strcmp_s("rsakpg1-basic", 13, str, &diff);
+    if (!diff) return ACVP_KAS_IFC_RSAKPG1_BASIC;
+
+    return 0;
 }
 
 static ACVP_RESULT acvp_kas_ifc_ssc(ACVP_CTX *ctx,
@@ -595,7 +599,7 @@ static ACVP_RESULT acvp_kas_ifc_ssc(ACVP_CTX *ctx,
              * Output the test case results using JSON
              */
             if (stc->test_type == ACVP_KAS_IFC_TT_VAL) {
-                rv = acvp_kas_ifc_ssc_val_output_tc(ctx, stc, r_tobj);
+                rv = acvp_kas_ifc_ssc_val_output_tc(stc, r_tobj);
             } else {
                 rv = acvp_kas_ifc_ssc_output_tc(ctx, stc, r_tobj);
             }

--- a/src/acvp_kas_kdf.c
+++ b/src/acvp_kas_kdf.c
@@ -866,27 +866,27 @@ static ACVP_RESULT acvp_kas_kdf_process(ACVP_CTX *ctx,
             }
             //Since z len is not included, check our capabilities to ensure its within the domain we set
             if (cipher == ACVP_KAS_HKDF) {
-                ACVP_CAPS_LIST *cap = acvp_locate_cap_entry(ctx, ACVP_KAS_HKDF);
-                if (!cap) {
+                ACVP_CAPS_LIST *hcap = acvp_locate_cap_entry(ctx, ACVP_KAS_HKDF);
+                if (!hcap) {
                     ACVP_LOG_ERR("Could not locate capabilities object for KAS-HKDF to determine z length validity");
                     rv = ACVP_MISSING_ARG;
                     goto err;
                 }
                 tmp = strnlen_s(z, ACVP_KAS_KDF_Z_STR_MAX + 1) << 2;
-                if (tmp > cap->cap.kas_hkdf_cap->z.max || tmp < cap->cap.kas_hkdf_cap->z.min ||
-                        tmp % cap->cap.kas_hkdf_cap->z.increment != 0) {
+                if (tmp > hcap->cap.kas_hkdf_cap->z.max || tmp < hcap->cap.kas_hkdf_cap->z.min ||
+                        tmp % hcap->cap.kas_hkdf_cap->z.increment != 0) {
                     ACVP_LOG_ERR("Invalid length of data for 'z'");
                 }
             } else {
-                ACVP_CAPS_LIST *cap = acvp_locate_cap_entry(ctx, ACVP_KAS_KDF_ONESTEP);
-                if (!cap) {
+                ACVP_CAPS_LIST *ocap = acvp_locate_cap_entry(ctx, ACVP_KAS_KDF_ONESTEP);
+                if (!ocap) {
                     ACVP_LOG_ERR("Could not locate capabilities object for KAS-KDF-ONESTEP to determine z length validity");
                     rv = ACVP_MISSING_ARG;
                     goto err;
                 }
                 tmp = strnlen_s(z, ACVP_KAS_KDF_Z_STR_MAX + 1) << 2;
-                if (tmp > cap->cap.kas_kdf_onestep_cap->z.max || tmp < cap->cap.kas_kdf_onestep_cap->z.min ||
-                        tmp % cap->cap.kas_kdf_onestep_cap->z.increment != 0) {
+                if (tmp > ocap->cap.kas_kdf_onestep_cap->z.max || tmp < ocap->cap.kas_kdf_onestep_cap->z.min ||
+                        tmp % ocap->cap.kas_kdf_onestep_cap->z.increment != 0) {
                     ACVP_LOG_ERR("Invalid length of data for 'z'");
                 }
             }
@@ -953,6 +953,10 @@ static ACVP_RESULT acvp_kas_kdf_process(ACVP_CTX *ctx,
                         goto err;
                     }
                     break;
+                case ACVP_KAS_KDF_PATTERN_MAX:
+                case ACVP_KAS_KDF_PATTERN_L:
+                case ACVP_KAS_KDF_PATTERN_LITERAL:
+                case ACVP_KAS_KDF_PATTERN_NONE:
                 default:
                     break;
                 }

--- a/src/acvp_kts_ifc.c
+++ b/src/acvp_kts_ifc.c
@@ -184,7 +184,12 @@ static ACVP_KTS_IFC_TEST_TYPE read_test_type(const char *str) {
 }
 
 static ACVP_RSA_KEY_FORMAT read_key_gen(const char *str){
-    return ACVP_KTS_IFC_RSAKPG1_BASIC;
+    int diff;
+
+    strcmp_s("rsakpg1-basic", 13, str, &diff);
+    if (!diff) return ACVP_KAS_IFC_RSAKPG1_BASIC;
+
+    return 0;
 }
 
 static ACVP_RESULT acvp_kts_ifc(ACVP_CTX *ctx,

--- a/src/acvp_operating_env.c
+++ b/src/acvp_operating_env.c
@@ -663,7 +663,7 @@ static ACVP_RESULT match_dependencies_page(ACVP_CTX *ctx,
     JSON_Array *data_array = NULL;
     const char *next = NULL, *name = NULL, *type = NULL, *description = NULL;
     int i = 0, data_count = 0;
-    ACVP_DEPENDENCY tmp_dep = {0, 0, 0, 0, 0};
+    ACVP_DEPENDENCY tmp_dep = {0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
     if (!ctx) return ACVP_NO_CTX;
     if (dep == NULL) {

--- a/src/acvp_rsa_prim.c
+++ b/src/acvp_rsa_prim.c
@@ -118,7 +118,6 @@ static ACVP_RESULT acvp_rsa_sigprim_release_tc(ACVP_RSA_PRIM_TC *stc) {
 
 static ACVP_RESULT acvp_rsa_decprim_init_tc(ACVP_CTX *ctx,
                                             ACVP_RSA_PRIM_TC *stc,
-                                            unsigned int tc_id,
                                             int modulo,
                                             int deferred,
                                             int pass,
@@ -155,7 +154,6 @@ static ACVP_RESULT acvp_rsa_decprim_init_tc(ACVP_CTX *ctx,
 
 static ACVP_RESULT acvp_rsa_sigprim_init_tc(ACVP_CTX *ctx,
                                             ACVP_RSA_PRIM_TC *stc,
-                                            unsigned int tc_id,
                                             unsigned int modulo,
                                             unsigned int keyformat,
                                             const char *d_str,
@@ -403,7 +401,7 @@ ACVP_RESULT acvp_rsa_decprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                     goto err;
                 }
 
-                rv = acvp_rsa_decprim_init_tc(ctx, &stc, tc_id, mod, deferred, pass, 
+                rv = acvp_rsa_decprim_init_tc(ctx, &stc, mod, deferred, pass, 
                                               fail, cipher, cipher_len);
 
                 /* Process the current test vector... */
@@ -666,7 +664,7 @@ ACVP_RESULT acvp_rsa_sigprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
 
 
-            rv = acvp_rsa_sigprim_init_tc(ctx, &stc, tc_id,
+            rv = acvp_rsa_sigprim_init_tc(ctx, &stc, 
                                           mod, keyformat,
                                           d_str, e_str,
                                           n_str, msg);

--- a/src/acvp_safe_primes.c
+++ b/src/acvp_safe_primes.c
@@ -183,6 +183,7 @@ ACVP_RESULT acvp_safe_primes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     const char *mode_str = NULL, *x = NULL, *y = NULL;
     unsigned int i, g_cnt;
     int j, t_cnt, tc_id, tg_id;
+    ACVP_SUB_KAS alg;
 
     if (!ctx) {
         ACVP_LOG_ERR("No ctx for handler operation");
@@ -281,9 +282,15 @@ ACVP_RESULT acvp_safe_primes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         ACVP_LOG_VERBOSE("         group: %s", dgm_str);
 
 
-        switch (alg_id)
-        {
-        case ACVP_SAFE_PRIMES_KEYGEN:
+        alg = acvp_get_kas_alg(alg_id);
+        if (alg == 0) {
+            ACVP_LOG_ERR("Invalid cipher value");
+            rv = ACVP_INVALID_ARG;
+            goto err;
+        }
+    
+        switch (alg) {
+        case ACVP_SUB_SAFE_PRIMES_KEYGEN:
 
             tests = json_object_get_array(groupobj, "tests");
             t_cnt = json_array_get_count(tests);
@@ -357,7 +364,7 @@ ACVP_RESULT acvp_safe_primes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             }
             break;
         
-        case ACVP_SAFE_PRIMES_KEYVER:
+        case ACVP_SUB_SAFE_PRIMES_KEYVER:
             tests = json_object_get_array(groupobj, "tests");
             t_cnt = json_array_get_count(tests);
 
@@ -445,6 +452,17 @@ ACVP_RESULT acvp_safe_primes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 json_array_append_value(r_tarr, r_tval);
             }
             break;
+        case ACVP_SUB_KAS_ECC_CDH:
+        case ACVP_SUB_KAS_ECC_COMP:
+        case ACVP_SUB_KAS_ECC_NOCOMP:
+        case ACVP_SUB_KAS_ECC_SSC:
+        case ACVP_SUB_KAS_FFC_COMP:
+        case ACVP_SUB_KAS_FFC_NOCOMP:
+        case ACVP_SUB_KAS_FFC_SSC:
+        case ACVP_SUB_KAS_IFC_SSC:
+        case ACVP_SUB_KTS_IFC:
+        case ACVP_SUB_KAS_HKDF:
+        case ACVP_SUB_KAS_KDF_ONESTEP:
         default:
             break;
         }

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -1378,7 +1378,7 @@ static void acvp_http_user_agent_check_env_for_var(ACVP_CTX *ctx, char *var_stri
     }
 }
 
-static void acvp_http_user_agent_check_compiler_ver(ACVP_CTX *ctx, char *comp_string) {
+static void acvp_http_user_agent_check_compiler_ver(char *comp_string) {
     char versionBuffer[16];
 
 #ifdef __GNUC__
@@ -1511,7 +1511,7 @@ void acvp_http_user_agent_handler(ACVP_CTX *ctx) {
 #endif
 
     //gets compiler version, or checks environment for it
-    acvp_http_user_agent_check_compiler_ver(ctx, comp);
+    acvp_http_user_agent_check_compiler_ver(comp);
 
 #elif defined WIN32
 
@@ -1634,7 +1634,7 @@ void acvp_http_user_agent_handler(ACVP_CTX *ctx) {
     }
 
     //gets compiler version
-    acvp_http_user_agent_check_compiler_ver(ctx, comp);
+    acvp_http_user_agent_check_compiler_ver(comp);
 
 #else
     /*******************************************************
@@ -1645,7 +1645,7 @@ void acvp_http_user_agent_handler(ACVP_CTX *ctx) {
     acvp_http_user_agent_check_env_for_var(ctx, osver, ACVP_USER_AGENT_OSVER);
     acvp_http_user_agent_check_env_for_var(ctx, arch, ACVP_USER_AGENT_ARCH);
     acvp_http_user_agent_check_env_for_var(ctx, proc, ACVP_USER_AGENT_PROC);
-    acvp_http_user_agent_check_compiler_ver(ctx, comp);
+    acvp_http_user_agent_check_compiler_ver(comp);
 #endif
 
     acvp_http_user_agent_string_clean(osname);

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -619,6 +619,8 @@ const char* acvp_lookup_hmac_alg_str(ACVP_HMAC_ALG_VAL alg) {
             return ACVP_STR_SHA3_384;
         case ACVP_HMAC_ALG_SHA3_512:
             return ACVP_STR_SHA3_512;
+        case ACVP_HMAC_ALG_MIN:
+        case ACVP_HMAC_ALG_MAX:
         default:
             return NULL;
     }

--- a/test/test_acvp_aes.c
+++ b/test/test_acvp_aes.c
@@ -129,7 +129,7 @@ static void setup(void) {
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_KEYLEN, 256);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PTLEN, 128, 65536, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
     
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &dummy_handler_success);
@@ -142,7 +142,7 @@ static void setup(void) {
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_KEYLEN, 256);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_PTLEN, 128, 65536, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &dummy_handler_success);
@@ -155,7 +155,7 @@ static void setup(void) {
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_KEYLEN, 256);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PTLEN, 128, 65536, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
     /*
@@ -794,9 +794,9 @@ static void setup_fail(void) {
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_TAGLEN, 128);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PTLEN, 0, 65536, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_AADLEN, 0, 65536, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_DOMAIN_AADLEN, 0, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
 }
@@ -919,7 +919,7 @@ Test(AES_CAPABILITY, good) {
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_KEYLEN, 256);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PTLEN, 128, 65536, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
     
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &dummy_handler_success);
@@ -932,7 +932,7 @@ Test(AES_CAPABILITY, good) {
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_KEYLEN, 256);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_PTLEN, 128, 65536, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &dummy_handler_success);
@@ -945,7 +945,7 @@ Test(AES_CAPABILITY, good) {
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_KEYLEN, 256);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PTLEN, 128, 65536, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
     /*
@@ -1228,9 +1228,9 @@ Test(AES_CAPABILITY, good) {
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_TAGLEN, 128);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_PTLEN, 0, 65536, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_AADLEN, 0, 65536, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XPN, ACVP_SYM_CIPH_DOMAIN_AADLEN, 0, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
     teardown_ctx(&ctx);

--- a/test/test_acvp_capabilities.c
+++ b/test/test_acvp_capabilities.c
@@ -925,7 +925,7 @@ Test(EnableCapAES, cipher_domain_no_ctx, .fini = teardown) {
     setup_empty_ctx(&ctx);
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XPN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(NULL, ACVP_AES_XPN, ACVP_SYM_CIPH_PTLEN, 0, 128, 8);
+    rv = acvp_cap_sym_cipher_set_domain(NULL, ACVP_AES_XPN, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 128, 8);
     cr_assert(rv == ACVP_NO_CTX);
 }
 
@@ -936,11 +936,11 @@ Test(EnableCapAES, cipher_domain_bad_values, .fini = teardown) {
     setup_empty_ctx(&ctx);
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PTLEN, -64, 128, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_DOMAIN_PTLEN, -64, 128, 8);
     cr_assert(rv == ACVP_INVALID_ARG);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PTLEN, 128, 64, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 64, 8);
     cr_assert(rv == ACVP_INVALID_ARG);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PTLEN, 0, 128, 0);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 128, 0);
     cr_assert(rv == ACVP_INVALID_ARG);
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_KEYLEN, 0, 0, 8);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -955,7 +955,7 @@ Test(EnableCapAES, dup_payload_registration, .fini = teardown) {
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PTLEN, 33333);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PTLEN, 0, 1024, 8);
+    rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 1024, 8);
     cr_assert(rv == ACVP_INVALID_ARG);
 
 }


### PR DESCRIPTION
Create sub-cipher enums to help address cflag -Wswitch-enum
Create DOMAIN enums for similar reasons
Fix some other warnings that were exposed when using --enable-cflags configure option
Modified UT accordingly

Feel free to critique the re-architecture, I'm open for suggestions. Converting enums to enums was trickier than I imagined.