### PR TITLE
Misc. updates and fixes

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1831,6 +1831,7 @@ end:
 
     return rv;
 }
+#endif
 
 static int enable_kas_kdf(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
@@ -1962,6 +1963,7 @@ end:
    return rv;
 }
 
+#ifndef OPENSSL_NO_DSA
 static int enable_dsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -349,7 +349,7 @@ typedef enum acvp_prereq_mode_t {
 
 /*! @struct ACVP_CONFORMANCE
  *  @brief this enum lists different conformances that can be claimed
- *  in libacvp. These are largely algorithm specific
+ *  in libacvp. These are largely algorithm specific.
  */
 typedef enum acvp_conformance_t {
     ACVP_CONFORMANCE_DEFAULT = 0,
@@ -906,7 +906,7 @@ typedef struct acvp_sym_cipher_tc_t {
     unsigned char *tag;          /* Aead tag */
     unsigned char *iv_ret;       /* updated IV used for TDES MCT */
     unsigned char *iv_ret_after; /* updated IV used for TDES MCT */
-    unsigned char *salt;
+    unsigned char *salt;         /* For use with AES-XPN */
     ACVP_SYM_KW_MODE kwcipher;
     ACVP_SYM_CIPH_TWEAK_MODE tw_mode;
     unsigned int seq_num;     

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1552,8 +1552,8 @@ typedef struct acvp_modules_t {
 typedef struct acvp_dependency_t {
     unsigned int id; /**< For library tracking purposes */
     char *url; /**< Returned from the server */
-    char *type;
     char *name;
+    char *type;
     char *description;
     char *series;
     char *family;
@@ -1806,7 +1806,7 @@ ACVP_RESULT acvp_build_validation(ACVP_CTX *ctx, char **out, int *out_len);
  */
 void acvp_oe_free_operating_env(ACVP_CTX *ctx);
 
-ACVP_RESULT acvp_oe_verify_fips_operating_env(ACVP_CTX *ctx);
+ACVP_RESULT acvp_verify_fips_validation_metadata(ACVP_CTX *ctx);
 
 ACVP_RESULT acvp_notify_large(ACVP_CTX *ctx,
                               const char *url,

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -30,8 +30,6 @@ static ACVP_RESULT acvp_login(ACVP_CTX *ctx, int refresh);
 
 static ACVP_RESULT acvp_validate_test_session(ACVP_CTX *ctx);
 
-static ACVP_RESULT fips_metadata_ready(ACVP_CTX *ctx);
-
 static ACVP_RESULT acvp_append_vsid_url(ACVP_CTX *ctx, const char *vsid_url);
 
 static ACVP_RESULT acvp_parse_login(ACVP_CTX *ctx);
@@ -1194,7 +1192,7 @@ ACVP_RESULT acvp_upload_vectors_from_file(ACVP_CTX *ctx, const char *rsp_filenam
     }
 
     if (fips_validation) {
-        rv = fips_metadata_ready(ctx);
+        rv = acvp_verify_fips_validation_metadata(ctx);
         if (ACVP_SUCCESS != rv) {
             ACVP_LOG_ERR("Validation metadata not ready");
             goto end;
@@ -1508,7 +1506,7 @@ ACVP_RESULT acvp_resume_test_session(ACVP_CTX *ctx, const char *request_filename
     }
 
     if (fips_validation) {
-        rv = fips_metadata_ready(ctx);
+        rv = acvp_verify_fips_validation_metadata(ctx);
         if (ACVP_SUCCESS != rv) {
             ACVP_LOG_ERR("Validation metadata not ready");
             return ACVP_UNSUPPORTED_OP;
@@ -3130,34 +3128,6 @@ end:
     return rv;
 }
 
-static ACVP_RESULT fips_metadata_ready(ACVP_CTX *ctx) {
-    ACVP_RESULT rv = 0;
-
-    if (ctx == NULL) return ACVP_NO_CTX;
-
-    if (ctx->fips.module == NULL) {
-        ACVP_LOG_ERR("Need to specify 'Module' via acvp_oe_set_fips_validation_metadata()");
-        return ACVP_UNSUPPORTED_OP;
-    }
-
-    if (ctx->fips.oe == NULL) {
-        ACVP_LOG_ERR("Need to specify 'Operating Environment' via acvp_oe_set_fips_validation_metadata()");
-        return ACVP_UNSUPPORTED_OP;
-    }
-
-    /*
-     * Verify that the selected FIPS metadata is sane.
-     * A.k.a. check that the resources exist on the server DB, if required.
-     */
-    rv = acvp_oe_verify_fips_operating_env(ctx);
-    if (ACVP_SUCCESS != rv) {
-        ACVP_LOG_ERR("Failed to verify the FIPS metadata with server");
-        return rv;
-    }
-
-    return ACVP_SUCCESS;
-}
-
 static ACVP_RESULT acvp_validate_test_session(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     char *validation = NULL;
@@ -3437,9 +3407,9 @@ ACVP_RESULT acvp_run(ACVP_CTX *ctx, int fips_validation) {
     }
 
     if (fips_validation) {
-        rv = fips_metadata_ready(ctx);
+        rv = acvp_verify_fips_validation_metadata(ctx);
         if (ACVP_SUCCESS != rv) {
-            ACVP_LOG_ERR("Validation metadata not ready");
+            ACVP_LOG_ERR("Issue(s) with validation metadata, not continuing with session.");
             return ACVP_UNSUPPORTED_OP;
         }
 

--- a/src/acvp_operating_env.c
+++ b/src/acvp_operating_env.c
@@ -2330,12 +2330,12 @@ static ACVP_RESULT query_module(ACVP_CTX *ctx,
             }
         }
 
-      //  if (module->version) {
-        //    rv = acvp_kv_list_append(&parameters, "version[0]=eq:", module->version);
-          //  if (ACVP_SUCCESS != rv) {
-            //    ACVP_LOG_ERR("Failed acvp_kv_list_append()");
-              //  goto end;
-           // }
+        if (module->version) {
+            rv = acvp_kv_list_append(&parameters, "version[0]=eq:", module->version);
+            if (ACVP_SUCCESS != rv) {
+                ACVP_LOG_ERR("Failed acvp_kv_list_append()");
+                goto end;
+            }
         }
 
         if (module->description) {

--- a/src/acvp_operating_env.c
+++ b/src/acvp_operating_env.c
@@ -614,22 +614,59 @@ ACVP_RESULT acvp_oe_module_set_type_version_desc(ACVP_CTX *ctx,
 static int compare_dependencies(const ACVP_DEPENDENCY *a, const ACVP_DEPENDENCY *b) {
     int diff = 0;
 
-    if (!a->type || !a->name || !a->description) {
+    //Name is the only required field as per the spec
+    if (!a->name || !b->name) {
         return 0;
     }
 
-    if (!b->type || !b->name || !b->description) {
+    //for each other value libacvp supports, check to see if its in both, if so, compare
+    if (a->type && b->type) {
+        strcmp_s(a->type, ACVP_OE_STR_MAX, b->type, &diff);
+        if (diff != 0) return 0;
+    } else if ((!a->type && b->type) || (a->type && b->type)) {
+        //if one has a value but the other does not, they are not equal.
         return 0;
     }
 
-    strcmp_s(a->type, ACVP_OE_STR_MAX, b->type, &diff);
-    if (diff != 0) return 0;
+    if (a->description && b->description) {
+        strcmp_s(a->description, ACVP_OE_STR_MAX, b->description, &diff);
+        if (diff != 0) return 0;
+    } else if ((!a->description && b->description) || (a->description && b->description)) {
+        //if one has a value but the other does not, they are not equal.
+        return 0;
+    }
 
-    strcmp_s(a->name, ACVP_OE_STR_MAX, b->name, &diff);
-    if (diff != 0) return 0;
+    if (a->series && b->series) {
+        strcmp_s(a->series, ACVP_OE_STR_MAX, b->series, &diff);
+        if (diff != 0) return 0;
+    } else if ((!a->series && b->series) || (a->series && b->series)) {
+        //if one has a value but the other does not, they are not equal.
+        return 0;
+    }
 
-    strcmp_s(a->description, ACVP_OE_STR_MAX, b->description, &diff);
-    if (diff != 0) return 0;
+    if (a->family && b->family) {
+        strcmp_s(a->family, ACVP_OE_STR_MAX, b->family, &diff);
+        if (diff != 0) return 0;
+    } else if ((!a->family && b->family) || (a->family && b->family)) {
+        //if one has a value but the other does not, they are not equal.
+        return 0;
+    }
+
+    if (a->version && b->version) {
+        strcmp_s(a->version, ACVP_OE_STR_MAX, b->version, &diff);
+        if (diff != 0) return 0;
+    } else if ((!a->version && b->version) || (a->version && b->version)) {
+        //if one has a value but the other does not, they are not equal.
+        return 0;
+    }
+
+    if (a->manufacturer && b->manufacturer) {
+        strcmp_s(a->manufacturer, ACVP_OE_STR_MAX, b->manufacturer, &diff);
+        if (diff != 0) return 0;
+    } else if ((!a->manufacturer && b->manufacturer) || (a->manufacturer && b->manufacturer)) {
+        //if one has a value but the other does not, they are not equal.
+        return 0;
+    }
 
     /* Reached the end, we have a full match */
     return 1;
@@ -661,7 +698,8 @@ static ACVP_RESULT match_dependencies_page(ACVP_CTX *ctx,
     JSON_Value *val = NULL;
     JSON_Object *obj = NULL, *links_obj = NULL;
     JSON_Array *data_array = NULL;
-    const char *next = NULL, *name = NULL, *type = NULL, *description = NULL;
+    const char *next = NULL, *name = NULL, *type = NULL, *description = NULL, *series = NULL,
+               *family = NULL, *version = NULL, *manufacturer = NULL;
     int i = 0, data_count = 0;
     ACVP_DEPENDENCY tmp_dep = {0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
@@ -699,14 +737,22 @@ static ACVP_RESULT match_dependencies_page(ACVP_CTX *ctx,
             goto end;
         }
 
-        // Soft copy so don't need to free
+        // Soft copy so don't need to free (also removes const)
         type = json_object_get_string(dep_obj, "type");
         name = json_object_get_string(dep_obj, "name");
         description = json_object_get_string(dep_obj, "description");
+        series = json_object_get_string(dep_obj, "series");
+        family = json_object_get_string(dep_obj, "family");
+        version = json_object_get_string(dep_obj, "version");
+        manufacturer = json_object_get_string(dep_obj, "manufacturer");
 
         if (type) tmp_dep.type = strdup(type);
         if (name) tmp_dep.name = strdup(name);
         if (description) tmp_dep.description = strdup(description);
+        if (series) tmp_dep.series = strdup(series);
+        if (family) tmp_dep.family = strdup(family);
+        if (version) tmp_dep.version = strdup(version);
+        if (manufacturer) tmp_dep.manufacturer = strdup(manufacturer);
 
         this_match = compare_dependencies(dep, &tmp_dep);
         if (this_match) {
@@ -727,7 +773,7 @@ static ACVP_RESULT match_dependencies_page(ACVP_CTX *ctx,
                 rv = ACVP_MALLOC_FAIL;
                 goto end;
             }
-            ACVP_LOG_INFO("Dependencies Match");
+            ACVP_LOG_INFO("Found a matching dependency! Url: %s", url);
             strcpy_s(dep->url, ACVP_ATTR_URL_MAX + 1, url);
             *match = 1; 
             goto end;
@@ -844,7 +890,7 @@ static ACVP_RESULT query_dependency(ACVP_CTX *ctx,
         }
     }
 
-
+    ACVP_LOG_INFO("Querying the server for a matching dependency entry...");
     do {
         /* Query the server DB. */
         if (parameters) {
@@ -870,6 +916,7 @@ static ACVP_RESULT query_dependency(ACVP_CTX *ctx,
         }
 
         endpoint = next_endpoint;
+        ACVP_LOG_INFO("No matching dependency on this page, moving to next page...");
     } while (endpoint);
 
 end:
@@ -1043,7 +1090,7 @@ static ACVP_RESULT match_oes_page(ACVP_CTX *ctx,
 
             strcpy_s(oe->url, ACVP_ATTR_URL_MAX + 1, url);
             *match = 1;
-            ACVP_LOG_INFO("OE Match");
+            ACVP_LOG_INFO("Found a matching OE! Url: %s", url);
             goto end;
         }
     }
@@ -1134,6 +1181,7 @@ static ACVP_RESULT query_oe(ACVP_CTX *ctx,
         }
     }
 
+    ACVP_LOG_INFO("Querying the server for a matching OE entry...");
     do {
         /* Query the server DB. */
         if (parameters) {
@@ -1159,6 +1207,7 @@ static ACVP_RESULT query_oe(ACVP_CTX *ctx,
         }
         
         endpoint = next_endpoint;
+        ACVP_LOG_INFO("No matching OE on this page, moving to next page...");
     } while (endpoint);
 
 end:
@@ -1812,7 +1861,7 @@ static ACVP_RESULT match_vendors_page(ACVP_CTX *ctx,
         }
 
         strcpy_s(vendor->url, ACVP_ATTR_URL_MAX + 1, url);
-        ACVP_LOG_INFO("Vendors Match");
+        ACVP_LOG_INFO("Found a matching vendor! Url: %s", url);
         *match = 1;
         goto end;
     }
@@ -1920,7 +1969,7 @@ static ACVP_RESULT query_vendor(ACVP_CTX *ctx,
         }
     }
 
-
+    ACVP_LOG_INFO("Querying the server for a matching vendor entry...");
     do {
         /* Query the server DB. */
         if (parameters) {
@@ -1945,6 +1994,7 @@ static ACVP_RESULT query_vendor(ACVP_CTX *ctx,
             break;
         }
         endpoint = next_endpoint;
+        ACVP_LOG_INFO("No matching vendor on this page, moving to next page...");
     } while (endpoint);
 
 end:
@@ -2171,7 +2221,7 @@ static ACVP_RESULT match_modules_page(ACVP_CTX *ctx,
             }
 
             strcpy_s(module->url, ACVP_ATTR_URL_MAX + 1, url);
-            ACVP_LOG_INFO("Modules Match");
+            ACVP_LOG_INFO("Found a matching module! Url: %s", url);
             *match = 1; 
             goto end;
         }
@@ -2280,12 +2330,12 @@ static ACVP_RESULT query_module(ACVP_CTX *ctx,
             }
         }
 
-        if (module->version) {
-            rv = acvp_kv_list_append(&parameters, "version[0]=eq:", module->version);
-            if (ACVP_SUCCESS != rv) {
-                ACVP_LOG_ERR("Failed acvp_kv_list_append()");
-                goto end;
-            }
+      //  if (module->version) {
+        //    rv = acvp_kv_list_append(&parameters, "version[0]=eq:", module->version);
+          //  if (ACVP_SUCCESS != rv) {
+            //    ACVP_LOG_ERR("Failed acvp_kv_list_append()");
+              //  goto end;
+           // }
         }
 
         if (module->description) {
@@ -2319,6 +2369,7 @@ static ACVP_RESULT query_module(ACVP_CTX *ctx,
         }
     }
 
+    ACVP_LOG_INFO("Querying the server for a matching module entry...");
     do {
         /* Query the server DB. */
         if (parameters) {
@@ -2344,6 +2395,7 @@ static ACVP_RESULT query_module(ACVP_CTX *ctx,
         }
         
         endpoint = next_endpoint;
+        ACVP_LOG_INFO("No matching module on this page, moving to next page...");
     } while (endpoint);
     
 end:
@@ -2421,29 +2473,53 @@ static ACVP_RESULT verify_fips_module(ACVP_CTX *ctx) {
  *
  * @return ACVP_RESULT
  */
-ACVP_RESULT acvp_oe_verify_fips_operating_env(ACVP_CTX *ctx) {
+ACVP_RESULT acvp_verify_fips_validation_metadata(ACVP_CTX *ctx) {
     ACVP_RESULT rv = 0;
 
     if (!ctx) return ACVP_NO_CTX;
+
+    if (ctx->fips.module == NULL) {
+        ACVP_LOG_ERR("Need to specify 'Module' via acvp_oe_set_fips_validation_metadata()");
+        return ACVP_UNSUPPORTED_OP;
+    }
+
+    if (ctx->fips.oe == NULL) {
+        ACVP_LOG_ERR("Need to specify 'Operating Environment' via acvp_oe_set_fips_validation_metadata()");
+        return ACVP_UNSUPPORTED_OP;
+    }
+
+    ACVP_LOG_STATUS("Checking validation metadata for correctness and pre-existing server entries...");
 
     /*
      * Verify the Module.
      * This includes the linked Vendor.
      */
+    ACVP_LOG_INFO("Verifying module (includes vendor)...");
     rv = verify_fips_module(ctx);
     if (rv != ACVP_SUCCESS) {
         ACVP_LOG_ERR("Unable to verify Vendor");
         return rv;
+    }
+    if (!ctx->fips.module->url) {
+        ACVP_LOG_STATUS("Module was not found on server; a new one will be created when the validation request is "
+                        "submitted. If you believe this to be in error, please cancel the session or request and "
+                        "try to locate the module on the server");
     }
 
     /*
      * Verify the OE.
      * This includes the linked Dependencies.
      */
+    ACVP_LOG_INFO("Verifying OE (includes dependencies)...");
     rv = verify_fips_oe(ctx);
     if (rv != ACVP_SUCCESS) {
         ACVP_LOG_ERR("Unable to verify Module");
         return rv;
+    }
+    if (!ctx->fips.oe->url) {
+        ACVP_LOG_STATUS("OE was not found on server; a new one will be created when the validation request is "
+                        "submitted. If you believe this to be in error, please cancel the session or request and "
+                        "try to locate the OE on the server");
     }
 
     return ACVP_SUCCESS;
@@ -3409,7 +3485,7 @@ ACVP_RESULT acvp_oe_set_fips_validation_metadata(ACVP_CTX *ctx,
     ACVP_MODULE *module = NULL;
     ACVP_OE *oe = NULL;
 
-    if (ctx == NULL) return ACVP_NO_CTX;
+    if (!ctx) return ACVP_NO_CTX;
 
     /*
      * Check that everything needed for the FIPS validation is sane.

--- a/src/acvp_operating_env.c
+++ b/src/acvp_operating_env.c
@@ -623,7 +623,7 @@ static int compare_dependencies(const ACVP_DEPENDENCY *a, const ACVP_DEPENDENCY 
     if (a->type && b->type) {
         strcmp_s(a->type, ACVP_OE_STR_MAX, b->type, &diff);
         if (diff != 0) return 0;
-    } else if ((!a->type && b->type) || (a->type && b->type)) {
+    } else if ((!a->type && b->type) || (a->type && !b->type)) {
         //if one has a value but the other does not, they are not equal.
         return 0;
     }
@@ -631,7 +631,7 @@ static int compare_dependencies(const ACVP_DEPENDENCY *a, const ACVP_DEPENDENCY 
     if (a->description && b->description) {
         strcmp_s(a->description, ACVP_OE_STR_MAX, b->description, &diff);
         if (diff != 0) return 0;
-    } else if ((!a->description && b->description) || (a->description && b->description)) {
+    } else if ((!a->description && b->description) || (a->description && !b->description)) {
         //if one has a value but the other does not, they are not equal.
         return 0;
     }
@@ -639,7 +639,7 @@ static int compare_dependencies(const ACVP_DEPENDENCY *a, const ACVP_DEPENDENCY 
     if (a->series && b->series) {
         strcmp_s(a->series, ACVP_OE_STR_MAX, b->series, &diff);
         if (diff != 0) return 0;
-    } else if ((!a->series && b->series) || (a->series && b->series)) {
+    } else if ((!a->series && b->series) || (a->series && !b->series)) {
         //if one has a value but the other does not, they are not equal.
         return 0;
     }
@@ -647,7 +647,7 @@ static int compare_dependencies(const ACVP_DEPENDENCY *a, const ACVP_DEPENDENCY 
     if (a->family && b->family) {
         strcmp_s(a->family, ACVP_OE_STR_MAX, b->family, &diff);
         if (diff != 0) return 0;
-    } else if ((!a->family && b->family) || (a->family && b->family)) {
+    } else if ((!a->family && b->family) || (a->family && !b->family)) {
         //if one has a value but the other does not, they are not equal.
         return 0;
     }
@@ -655,7 +655,7 @@ static int compare_dependencies(const ACVP_DEPENDENCY *a, const ACVP_DEPENDENCY 
     if (a->version && b->version) {
         strcmp_s(a->version, ACVP_OE_STR_MAX, b->version, &diff);
         if (diff != 0) return 0;
-    } else if ((!a->version && b->version) || (a->version && b->version)) {
+    } else if ((!a->version && b->version) || (a->version && !b->version)) {
         //if one has a value but the other does not, they are not equal.
         return 0;
     }
@@ -663,7 +663,7 @@ static int compare_dependencies(const ACVP_DEPENDENCY *a, const ACVP_DEPENDENCY 
     if (a->manufacturer && b->manufacturer) {
         strcmp_s(a->manufacturer, ACVP_OE_STR_MAX, b->manufacturer, &diff);
         if (diff != 0) return 0;
-    } else if ((!a->manufacturer && b->manufacturer) || (a->manufacturer && b->manufacturer)) {
+    } else if ((!a->manufacturer && b->manufacturer) || (a->manufacturer && !b->manufacturer)) {
         //if one has a value but the other does not, they are not equal.
         return 0;
     }

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -9,9 +9,9 @@
  */
 
 #ifdef USE_MURL
-# include "../murl/murl.h"
+#include "../murl/murl.h"
 #elif !defined ACVP_OFFLINE
-# include <curl/curl.h>
+#include <curl/curl.h>
 #endif
 
 #include <stdio.h>
@@ -1192,47 +1192,47 @@ static void log_network_status(ACVP_CTX *ctx,
 
     switch(action) {
     case ACVP_NET_GET:
-        ACVP_LOG_INFO("GET...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+        ACVP_LOG_VERBOSE("GET...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                       curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_GET_VS:
-        ACVP_LOG_INFO("GET Vector Set...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+        ACVP_LOG_VERBOSE("GET Vector Set...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                          curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_GET_VS_RESULT:
-        ACVP_LOG_INFO("GET Vector Set Result...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+        ACVP_LOG_VERBOSE("GET Vector Set Result...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_GET_VS_SAMPLE:
-        ACVP_LOG_INFO("GET Vector Set Sample...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+        ACVP_LOG_VERBOSE("GET Vector Set Sample...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_POST:
-        ACVP_LOG_INFO("POST...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
+        ACVP_LOG_VERBOSE("POST...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_POST_LOGIN:
-        ACVP_LOG_INFO("POST Login...\n\tStatus: %d\n\tUrl: %s\n\tResp: Recieved\n",
+        ACVP_LOG_VERBOSE("POST Login...\n\tStatus: %d\n\tUrl: %s\n\tResp: Recieved\n",
                       curl_code, url);
         break;
     case ACVP_NET_POST_REG:
-        ACVP_LOG_INFO("POST Registration...\n\tStatus: %d\n\tUrl: %s\n\tResp: Recieved\n",
+        ACVP_LOG_VERBOSE("POST Registration...\n\tStatus: %d\n\tUrl: %s\n\tResp: Recieved\n",
                         curl_code, url);
         break;
     case ACVP_NET_POST_VS_RESP:
-        ACVP_LOG_INFO("POST Response Submission...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+        ACVP_LOG_VERBOSE("POST Response Submission...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                       curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_PUT:
-        ACVP_LOG_INFO("PUT...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
+        ACVP_LOG_VERBOSE("PUT...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_PUT_VALIDATION:
-        ACVP_LOG_INFO("PUT testSession Validation...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
+        ACVP_LOG_VERBOSE("PUT testSession Validation...\n\tStatus: %d\n\tUrl: %s\n\tResp: %s\n",
                         curl_code, url, ctx->curl_buf);
         break;
     case ACVP_NET_DELETE:
-        ACVP_LOG_INFO("DELETE...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
+        ACVP_LOG_VERBOSE("DELETE...\n\tStatus: %d\n\tUrl: %s\n\tResp:\n%s\n",
                        curl_code, url, ctx->curl_buf);
         break;
     default:
@@ -1374,7 +1374,7 @@ static void acvp_http_user_agent_check_env_for_var(ACVP_CTX *ctx, char *var_stri
             strncpy_s(var_string, maxLength + 1, envVal, maxLength);
         }
     } else {
-        ACVP_LOG_WARN("Unable to collect info for HTTP user-agent - please define %s (%d char max.)", var, maxLength);
+        ACVP_LOG_INFO("Unable to collect info for HTTP user-agent - consider defining %s (%d char max.) This is optional and will not affect testing.", var, maxLength);
     }
 }
 

--- a/test/test_acvp_operating_env.c
+++ b/test/test_acvp_operating_env.c
@@ -84,11 +84,11 @@ Test(FIPS_VALIDATION_METADATA, set_fips_validation_metadata, .init = setup, .fin
 }
 
 /*
- * Test  acvp_oe_verify_fips_operating_env
+ * Test  acvp_verify_fips_validation_metadata
  */
 Test(VERIFY_FIPS_OPERATING_ENV, verify_fips_operating_env, .init = setup, .fini = teardown) {
 
-    rv = acvp_oe_verify_fips_operating_env(NULL);
+    rv = acvp_verify_fips_validation_metadata(NULL);
     cr_assert(rv == ACVP_NO_CTX);
 
     rv = acvp_oe_ingest_metadata(ctx, "json/meta.json");
@@ -97,7 +97,7 @@ Test(VERIFY_FIPS_OPERATING_ENV, verify_fips_operating_env, .init = setup, .fini 
     rv = acvp_oe_set_fips_validation_metadata(ctx, 1, 1);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_oe_verify_fips_operating_env(ctx);
+    rv = acvp_verify_fips_validation_metadata(ctx);
 #ifdef ACVP_OFFLINE
     cr_assert(rv == ACVP_TRANSPORT_FAIL);
 #else


### PR DESCRIPTION
- Removes kas_kdf enable from NO_DSA block
- moves most network activity logging to verbose
- Fixes issue with OE/dependency lookup requiring a description, checks more fields
- Adds and expands some log lines to metadata lookup (more to come)
- Remove fips_metadata_ready for being redundant and move its checks to acvp_operating_env function calls
- Some misc changes
...
- Upcoming: 
- Many more additions to "info" level logging (That contains interesting/useful info, instead of truncated network logging) 
- work on build system if necessary 
- big documentation updates