### PR TITLE
Revert "Fix LDL setting for offline builds"

### DIFF
--- a/app/app_hmac.c
+++ b/app/app_hmac.c
@@ -37,12 +37,7 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
 
     alg = acvp_get_hmac_alg(tc->cipher);
     if (alg == 0) {
-        printf("Invalid cipher value\n");
-        return 1;
-    }
-
-    if (!tc->key || !tc->msg) {
-        printf("Test case missing key\n");
+        printf("Invalid cipher value");
         return 1;
     }
 

--- a/configure
+++ b/configure
@@ -10962,7 +10962,7 @@ pre_libs="$LIBS"
 # script modifies LDFLAGS to correctly search for libs. we unset these changes so
 # makefile.am have complete control over linker flags
 pre_ldflags="$LDFLAGS"
-if test "$is_freebsd" != "1" && test "x$ANDROID_NDK_ROOT" = "x" ; then
+if test "$is_freebsd" != "1" && test "x$enable_offline" = "xfalse" ; then
     LIBS="-ldl $LIBS"
 fi
 if test "x$enable_offline" != "xfalse" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,7 @@ pre_libs="$LIBS"
 # script modifies LDFLAGS to correctly search for libs. we unset these changes so
 # makefile.am have complete control over linker flags
 pre_ldflags="$LDFLAGS"
-if test "$is_freebsd" != "1" && test "x$ANDROID_NDK_ROOT" = "x" ; then
+if test "$is_freebsd" != "1" && test "x$enable_offline" = "xfalse" ; then
     LIBS="-ldl $LIBS"
 fi
 if test "x$enable_offline" != "xfalse" ; then

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,7 +1,7 @@
 noinst_PROGRAMS = runtest
 runtest_SOURCES = ut_common.c
 tmp_cflags = -g -O0 -Wall -DNO_SSL_DL $(SAFEC_CFLAGS) $(CRITERION_CFLAGS) $(LIBACVP_CFLAGS) -I../include
-tmp_ldflags= $(CRITERION_LDFLAGS) $(SAFEC_LDFLAGS) $(LIBACVP_LDFLAGS)
+tmp_ldflags= -ldl $(CRITERION_LDFLAGS) $(SAFEC_LDFLAGS) $(LIBACVP_LDFLAGS)
 if ! LIB_NOT_SUPPORTED
 runtest_SOURCES += create_session.c \
       test_acvp_utils.c \
@@ -76,7 +76,6 @@ tmp_cflags += $(SSL_CFLAGS) $(FOM_CFLAGS) -I../app
 tmp_ldflags += $(SSL_LDFLAGS) $(FOM_LDFLAGS)
 endif
 
-tmp_ldflags += -ldl
 runtest_CFLAGS = ${tmp_cflags}
 runtest_LDFLAGS = ${tmp_ldflags}
 

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -514,8 +514,8 @@ runtest_SOURCES = ut_common.c $(am__append_1) $(am__append_4)
 tmp_cflags = -g -O0 -Wall -DNO_SSL_DL $(SAFEC_CFLAGS) \
 	$(CRITERION_CFLAGS) $(LIBACVP_CFLAGS) -I../include \
 	$(am__append_2) $(am__append_5)
-tmp_ldflags = $(CRITERION_LDFLAGS) $(SAFEC_LDFLAGS) $(LIBACVP_LDFLAGS) \
-	$(am__append_3) $(am__append_6) -ldl
+tmp_ldflags = -ldl $(CRITERION_LDFLAGS) $(SAFEC_LDFLAGS) \
+	$(LIBACVP_LDFLAGS) $(am__append_3) $(am__append_6)
 @APP_NOT_SUPPORTED_FALSE@APP_LINK = ../app/acvp_app-app_utils.o \
 @APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_sha.o \
 @APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_hmac.o \


### PR DESCRIPTION
Reverts the PR that made changes to ldl flagging and such. These worked for some cases, but caused some issues elsewhere. For now, static SSL libs to be used with acvp should be built with no-dso and preferably no-threads to minimize clashes while we work out something long term.