### PR TITLE
Added app wrapper code

### DIFF
--- a/app/Makefile.am
+++ b/app/Makefile.am
@@ -1,24 +1,28 @@
+tmp_sources = app_main.c \
+              app_aes.c \
+              app_cli.c \
+              app_cmac.c \
+              app_des.c \
+              app_drbg.c \
+              app_dsa.c \
+              app_ecdsa.c \
+              app_hmac.c \
+              app_kas.c \
+              app_kdf.c \
+              app_kas_kdf.c \
+              app_rsa.c \
+              app_sha.c \
+              app_utils.c \
+              app_fips_lcl.h \
+              app_fips_init_lcl.h \
+              app_lcl.h \
+              ketopt.h
+
+if !BUILD_APP_AS_LIB
 bin_PROGRAMS = acvp_app
+
 acvp_app_includedir=$(includedir)/acvp
-acvp_app_SOURCES = app_main.c \
-				   app_aes.c \
-				   app_cli.c \
-				   app_cmac.c \
-				   app_des.c \
-				   app_drbg.c \
-				   app_dsa.c \
-				   app_ecdsa.c \
-				   app_hmac.c \
-				   app_kas.c \
-				   app_kdf.c \
-                                   app_kas_kdf.c \
-				   app_rsa.c \
-				   app_sha.c \
-				   app_utils.c \
-				   app_fips_lcl.h \
-				   app_fips_init_lcl.h \
-				   app_lcl.h \
-				   ketopt.h
+acvp_app_SOURCES = ${tmp_sources}
 acvp_app_CFLAGS = -g -fPIE $(LIBACVP_CFLAGS) $(SSL_CFLAGS) $(FOM_CFLAGS) $(SAFEC_CFLAGS)
 acvp_app_LDFLAGS = $(LIBACVP_LDFLAGS) $(SSL_LDFLAGS) $(FOM_LDFLAGS)
 
@@ -28,4 +32,23 @@ endif
 
 if USE_FOM
 acvp_app_LDADD = $(FOM_OBJ_DIR)/fipscanister.o
+endif
+
+else
+lib_LTLIBRARIES = libacvp_app.la
+libacvp_app_includedir=${includedir}/acvp
+libacvp_app_la_SOURCES = ${tmp_sources}
+
+AM_CFLAGS = -g -fPIE $(LIBACVP_CFLAGS) $(SSL_CFLAGS) $(FOM_CFLAGS) $(SAFEC_CFLAGS) -DACVP_APP_LIB_WRAPPER
+libacvp_app_la_LIBADD = $(LIBACVP_LDFLAGS) $(SSL_LDFLAGS) $(FOM_LDFLAGS)
+
+libacvp_app_include_HEADERS = $(top_srcdir)/app/libacvp_app.h
+
+if USE_LDL_CHECK
+libacvp_app_la_LIBADD += -ldl
+endif
+
+if USE_FOM
+libacvp_app_la_LIBADD += $(FOM_OBJ_DIR)/fipscanister.o
+endif
 endif

--- a/app/Makefile.in
+++ b/app/Makefile.in
@@ -14,6 +14,8 @@
 
 @SET_MAKE@
 
+
+
 VPATH = @srcdir@
 am__is_gnu_make = { \
   if test -z '$(MAKELEVEL)'; then \
@@ -88,8 +90,10 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
-bin_PROGRAMS = acvp_app$(EXEEXT)
-@USE_LDL_CHECK_TRUE@am__append_1 = -ldl
+@BUILD_APP_AS_LIB_FALSE@bin_PROGRAMS = acvp_app$(EXEEXT)
+@BUILD_APP_AS_LIB_FALSE@@USE_LDL_CHECK_TRUE@am__append_1 = -ldl
+@BUILD_APP_AS_LIB_TRUE@@USE_LDL_CHECK_TRUE@am__append_2 = -ldl
+@BUILD_APP_AS_LIB_TRUE@@USE_FOM_TRUE@am__append_3 = $(FOM_OBJ_DIR)/fipscanister.o
 subdir = app
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
@@ -98,26 +102,80 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
-DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
+DIST_COMMON = $(srcdir)/Makefile.am \
+	$(am__libacvp_app_include_HEADERS_DIST) $(am__DIST_COMMON)
 mkinstalldirs = $(install_sh) -d
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
-am__installdirs = "$(DESTDIR)$(bindir)"
+am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)" \
+	"$(DESTDIR)$(libacvp_app_includedir)"
 PROGRAMS = $(bin_PROGRAMS)
-am_acvp_app_OBJECTS = acvp_app-app_main.$(OBJEXT) \
-	acvp_app-app_aes.$(OBJEXT) acvp_app-app_cli.$(OBJEXT) \
-	acvp_app-app_cmac.$(OBJEXT) acvp_app-app_des.$(OBJEXT) \
-	acvp_app-app_drbg.$(OBJEXT) acvp_app-app_dsa.$(OBJEXT) \
-	acvp_app-app_ecdsa.$(OBJEXT) acvp_app-app_hmac.$(OBJEXT) \
-	acvp_app-app_kas.$(OBJEXT) acvp_app-app_kdf.$(OBJEXT) \
-	acvp_app-app_kas_kdf.$(OBJEXT) acvp_app-app_rsa.$(OBJEXT) \
-	acvp_app-app_sha.$(OBJEXT) acvp_app-app_utils.$(OBJEXT)
-acvp_app_OBJECTS = $(am_acvp_app_OBJECTS)
-@USE_FOM_TRUE@acvp_app_DEPENDENCIES = $(FOM_OBJ_DIR)/fipscanister.o
+am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
+am__vpath_adj = case $$p in \
+    $(srcdir)/*) f=`echo "$$p" | sed "s|^$$srcdirstrip/||"`;; \
+    *) f=$$p;; \
+  esac;
+am__strip_dir = f=`echo $$p | sed -e 's|^.*/||'`;
+am__install_max = 40
+am__nobase_strip_setup = \
+  srcdirstrip=`echo "$(srcdir)" | sed 's/[].[^$$\\*|]/\\\\&/g'`
+am__nobase_strip = \
+  for p in $$list; do echo "$$p"; done | sed -e "s|$$srcdirstrip/||"
+am__nobase_list = $(am__nobase_strip_setup); \
+  for p in $$list; do echo "$$p $$p"; done | \
+  sed "s| $$srcdirstrip/| |;"' / .*\//!s/ .*/ ./; s,\( .*\)/[^/]*$$,\1,' | \
+  $(AWK) 'BEGIN { files["."] = "" } { files[$$2] = files[$$2] " " $$1; \
+    if (++n[$$2] == $(am__install_max)) \
+      { print $$2, files[$$2]; n[$$2] = 0; files[$$2] = "" } } \
+    END { for (dir in files) print dir, files[dir] }'
+am__base_list = \
+  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\n/ /g' | \
+  sed '$$!N;$$!N;$$!N;$$!N;s/\n/ /g'
+am__uninstall_files_from_dir = { \
+  test -z "$$files" \
+    || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
+    || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
+         $(am__cd) "$$dir" && rm -f $$files; }; \
+  }
+LTLIBRARIES = $(lib_LTLIBRARIES)
+am__DEPENDENCIES_1 =
+@BUILD_APP_AS_LIB_TRUE@libacvp_app_la_DEPENDENCIES =  \
+@BUILD_APP_AS_LIB_TRUE@	$(am__DEPENDENCIES_1) \
+@BUILD_APP_AS_LIB_TRUE@	$(am__DEPENDENCIES_1) \
+@BUILD_APP_AS_LIB_TRUE@	$(am__DEPENDENCIES_1) \
+@BUILD_APP_AS_LIB_TRUE@	$(am__DEPENDENCIES_1) $(am__append_3)
+am__libacvp_app_la_SOURCES_DIST = app_main.c app_aes.c app_cli.c \
+	app_cmac.c app_des.c app_drbg.c app_dsa.c app_ecdsa.c \
+	app_hmac.c app_kas.c app_kdf.c app_kas_kdf.c app_rsa.c \
+	app_sha.c app_utils.c app_fips_lcl.h app_fips_init_lcl.h \
+	app_lcl.h ketopt.h
+am__objects_1 = app_main.lo app_aes.lo app_cli.lo app_cmac.lo \
+	app_des.lo app_drbg.lo app_dsa.lo app_ecdsa.lo app_hmac.lo \
+	app_kas.lo app_kdf.lo app_kas_kdf.lo app_rsa.lo app_sha.lo \
+	app_utils.lo
+@BUILD_APP_AS_LIB_TRUE@am_libacvp_app_la_OBJECTS = $(am__objects_1)
+libacvp_app_la_OBJECTS = $(am_libacvp_app_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
+@BUILD_APP_AS_LIB_TRUE@am_libacvp_app_la_rpath = -rpath $(libdir)
+am__acvp_app_SOURCES_DIST = app_main.c app_aes.c app_cli.c app_cmac.c \
+	app_des.c app_drbg.c app_dsa.c app_ecdsa.c app_hmac.c \
+	app_kas.c app_kdf.c app_kas_kdf.c app_rsa.c app_sha.c \
+	app_utils.c app_fips_lcl.h app_fips_init_lcl.h app_lcl.h \
+	ketopt.h
+am__objects_2 = acvp_app-app_main.$(OBJEXT) acvp_app-app_aes.$(OBJEXT) \
+	acvp_app-app_cli.$(OBJEXT) acvp_app-app_cmac.$(OBJEXT) \
+	acvp_app-app_des.$(OBJEXT) acvp_app-app_drbg.$(OBJEXT) \
+	acvp_app-app_dsa.$(OBJEXT) acvp_app-app_ecdsa.$(OBJEXT) \
+	acvp_app-app_hmac.$(OBJEXT) acvp_app-app_kas.$(OBJEXT) \
+	acvp_app-app_kdf.$(OBJEXT) acvp_app-app_kas_kdf.$(OBJEXT) \
+	acvp_app-app_rsa.$(OBJEXT) acvp_app-app_sha.$(OBJEXT) \
+	acvp_app-app_utils.$(OBJEXT)
+@BUILD_APP_AS_LIB_FALSE@am_acvp_app_OBJECTS = $(am__objects_2)
+acvp_app_OBJECTS = $(am_acvp_app_OBJECTS)
+@BUILD_APP_AS_LIB_FALSE@@USE_FOM_TRUE@acvp_app_DEPENDENCIES = $(FOM_OBJ_DIR)/fipscanister.o
 acvp_app_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(acvp_app_CFLAGS) \
 	$(CFLAGS) $(acvp_app_LDFLAGS) $(LDFLAGS) -o $@
@@ -150,7 +208,14 @@ am__depfiles_remade = ./$(DEPDIR)/acvp_app-app_aes.Po \
 	./$(DEPDIR)/acvp_app-app_main.Po \
 	./$(DEPDIR)/acvp_app-app_rsa.Po \
 	./$(DEPDIR)/acvp_app-app_sha.Po \
-	./$(DEPDIR)/acvp_app-app_utils.Po
+	./$(DEPDIR)/acvp_app-app_utils.Po ./$(DEPDIR)/app_aes.Plo \
+	./$(DEPDIR)/app_cli.Plo ./$(DEPDIR)/app_cmac.Plo \
+	./$(DEPDIR)/app_des.Plo ./$(DEPDIR)/app_drbg.Plo \
+	./$(DEPDIR)/app_dsa.Plo ./$(DEPDIR)/app_ecdsa.Plo \
+	./$(DEPDIR)/app_hmac.Plo ./$(DEPDIR)/app_kas.Plo \
+	./$(DEPDIR)/app_kas_kdf.Plo ./$(DEPDIR)/app_kdf.Plo \
+	./$(DEPDIR)/app_main.Plo ./$(DEPDIR)/app_rsa.Plo \
+	./$(DEPDIR)/app_sha.Plo ./$(DEPDIR)/app_utils.Plo
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
@@ -170,13 +235,17 @@ AM_V_CCLD = $(am__v_CCLD_@AM_V@)
 am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
 am__v_CCLD_1 = 
-SOURCES = $(acvp_app_SOURCES)
-DIST_SOURCES = $(acvp_app_SOURCES)
+SOURCES = $(libacvp_app_la_SOURCES) $(acvp_app_SOURCES)
+DIST_SOURCES = $(am__libacvp_app_la_SOURCES_DIST) \
+	$(am__acvp_app_SOURCES_DIST)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
     *) (install-info --version) >/dev/null 2>&1;; \
   esac
+am__libacvp_app_include_HEADERS_DIST =  \
+	$(top_srcdir)/app/libacvp_app.h
+HEADERS = $(libacvp_app_include_HEADERS)
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 # Read a list of newline-separated strings from the standard input,
 # and print each of them once, without duplicates.  Input order is
@@ -328,31 +397,41 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-acvp_app_includedir = $(includedir)/acvp
-acvp_app_SOURCES = app_main.c \
-				   app_aes.c \
-				   app_cli.c \
-				   app_cmac.c \
-				   app_des.c \
-				   app_drbg.c \
-				   app_dsa.c \
-				   app_ecdsa.c \
-				   app_hmac.c \
-				   app_kas.c \
-				   app_kdf.c \
-                                   app_kas_kdf.c \
-				   app_rsa.c \
-				   app_sha.c \
-				   app_utils.c \
-				   app_fips_lcl.h \
-				   app_fips_init_lcl.h \
-				   app_lcl.h \
-				   ketopt.h
+tmp_sources = app_main.c \
+              app_aes.c \
+              app_cli.c \
+              app_cmac.c \
+              app_des.c \
+              app_drbg.c \
+              app_dsa.c \
+              app_ecdsa.c \
+              app_hmac.c \
+              app_kas.c \
+              app_kdf.c \
+              app_kas_kdf.c \
+              app_rsa.c \
+              app_sha.c \
+              app_utils.c \
+              app_fips_lcl.h \
+              app_fips_init_lcl.h \
+              app_lcl.h \
+              ketopt.h
 
-acvp_app_CFLAGS = -g -fPIE $(LIBACVP_CFLAGS) $(SSL_CFLAGS) $(FOM_CFLAGS) $(SAFEC_CFLAGS)
-acvp_app_LDFLAGS = $(LIBACVP_LDFLAGS) $(SSL_LDFLAGS) $(FOM_LDFLAGS) \
-	$(am__append_1)
-@USE_FOM_TRUE@acvp_app_LDADD = $(FOM_OBJ_DIR)/fipscanister.o
+@BUILD_APP_AS_LIB_FALSE@acvp_app_includedir = $(includedir)/acvp
+@BUILD_APP_AS_LIB_FALSE@acvp_app_SOURCES = ${tmp_sources}
+@BUILD_APP_AS_LIB_FALSE@acvp_app_CFLAGS = -g -fPIE $(LIBACVP_CFLAGS) $(SSL_CFLAGS) $(FOM_CFLAGS) $(SAFEC_CFLAGS)
+@BUILD_APP_AS_LIB_FALSE@acvp_app_LDFLAGS = $(LIBACVP_LDFLAGS) \
+@BUILD_APP_AS_LIB_FALSE@	$(SSL_LDFLAGS) $(FOM_LDFLAGS) \
+@BUILD_APP_AS_LIB_FALSE@	$(am__append_1)
+@BUILD_APP_AS_LIB_FALSE@@USE_FOM_TRUE@acvp_app_LDADD = $(FOM_OBJ_DIR)/fipscanister.o
+@BUILD_APP_AS_LIB_TRUE@lib_LTLIBRARIES = libacvp_app.la
+@BUILD_APP_AS_LIB_TRUE@libacvp_app_includedir = ${includedir}/acvp
+@BUILD_APP_AS_LIB_TRUE@libacvp_app_la_SOURCES = ${tmp_sources}
+@BUILD_APP_AS_LIB_TRUE@AM_CFLAGS = -g -fPIE $(LIBACVP_CFLAGS) $(SSL_CFLAGS) $(FOM_CFLAGS) $(SAFEC_CFLAGS) -DACVP_APP_LIB_WRAPPER
+@BUILD_APP_AS_LIB_TRUE@libacvp_app_la_LIBADD = $(LIBACVP_LDFLAGS) \
+@BUILD_APP_AS_LIB_TRUE@	$(SSL_LDFLAGS) $(FOM_LDFLAGS) \
+@BUILD_APP_AS_LIB_TRUE@	$(am__append_2) $(am__append_3)
+@BUILD_APP_AS_LIB_TRUE@libacvp_app_include_HEADERS = $(top_srcdir)/app/libacvp_app.h
 all: all-am
 
 .SUFFIXES:
@@ -436,6 +515,44 @@ clean-binPROGRAMS:
 	echo " rm -f" $$list; \
 	rm -f $$list
 
+install-libLTLIBRARIES: $(lib_LTLIBRARIES)
+	@$(NORMAL_INSTALL)
+	@list='$(lib_LTLIBRARIES)'; test -n "$(libdir)" || list=; \
+	list2=; for p in $$list; do \
+	  if test -f $$p; then \
+	    list2="$$list2 $$p"; \
+	  else :; fi; \
+	done; \
+	test -z "$$list2" || { \
+	  echo " $(MKDIR_P) '$(DESTDIR)$(libdir)'"; \
+	  $(MKDIR_P) "$(DESTDIR)$(libdir)" || exit 1; \
+	  echo " $(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=install $(INSTALL) $(INSTALL_STRIP_FLAG) $$list2 '$(DESTDIR)$(libdir)'"; \
+	  $(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=install $(INSTALL) $(INSTALL_STRIP_FLAG) $$list2 "$(DESTDIR)$(libdir)"; \
+	}
+
+uninstall-libLTLIBRARIES:
+	@$(NORMAL_UNINSTALL)
+	@list='$(lib_LTLIBRARIES)'; test -n "$(libdir)" || list=; \
+	for p in $$list; do \
+	  $(am__strip_dir) \
+	  echo " $(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=uninstall rm -f '$(DESTDIR)$(libdir)/$$f'"; \
+	  $(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=uninstall rm -f "$(DESTDIR)$(libdir)/$$f"; \
+	done
+
+clean-libLTLIBRARIES:
+	-test -z "$(lib_LTLIBRARIES)" || rm -f $(lib_LTLIBRARIES)
+	@list='$(lib_LTLIBRARIES)'; \
+	locs=`for p in $$list; do echo $$p; done | \
+	      sed 's|^[^/]*$$|.|; s|/[^/]*$$||; s|$$|/so_locations|' | \
+	      sort -u`; \
+	test -z "$$locs" || { \
+	  echo rm -f $${locs}; \
+	  rm -f $${locs}; \
+	}
+
+libacvp_app.la: $(libacvp_app_la_OBJECTS) $(libacvp_app_la_DEPENDENCIES) $(EXTRA_libacvp_app_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(LINK) $(am_libacvp_app_la_rpath) $(libacvp_app_la_OBJECTS) $(libacvp_app_la_LIBADD) $(LIBS)
+
 acvp_app$(EXEEXT): $(acvp_app_OBJECTS) $(acvp_app_DEPENDENCIES) $(EXTRA_acvp_app_DEPENDENCIES) 
 	@rm -f acvp_app$(EXEEXT)
 	$(AM_V_CCLD)$(acvp_app_LINK) $(acvp_app_OBJECTS) $(acvp_app_LDADD) $(LIBS)
@@ -461,6 +578,21 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_app-app_rsa.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_app-app_sha.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_app-app_utils.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_aes.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_cli.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_cmac.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_des.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_drbg.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_dsa.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_ecdsa.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_hmac.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_kas.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_kas_kdf.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_kdf.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_main.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_rsa.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_sha.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_utils.Plo@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
 	@$(MKDIR_P) $(@D)
@@ -707,6 +839,27 @@ mostlyclean-libtool:
 
 clean-libtool:
 	-rm -rf .libs _libs
+install-libacvp_app_includeHEADERS: $(libacvp_app_include_HEADERS)
+	@$(NORMAL_INSTALL)
+	@list='$(libacvp_app_include_HEADERS)'; test -n "$(libacvp_app_includedir)" || list=; \
+	if test -n "$$list"; then \
+	  echo " $(MKDIR_P) '$(DESTDIR)$(libacvp_app_includedir)'"; \
+	  $(MKDIR_P) "$(DESTDIR)$(libacvp_app_includedir)" || exit 1; \
+	fi; \
+	for p in $$list; do \
+	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
+	  echo "$$d$$p"; \
+	done | $(am__base_list) | \
+	while read files; do \
+	  echo " $(INSTALL_HEADER) $$files '$(DESTDIR)$(libacvp_app_includedir)'"; \
+	  $(INSTALL_HEADER) $$files "$(DESTDIR)$(libacvp_app_includedir)" || exit $$?; \
+	done
+
+uninstall-libacvp_app_includeHEADERS:
+	@$(NORMAL_UNINSTALL)
+	@list='$(libacvp_app_include_HEADERS)'; test -n "$(libacvp_app_includedir)" || list=; \
+	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
+	dir='$(DESTDIR)$(libacvp_app_includedir)'; $(am__uninstall_files_from_dir)
 
 ID: $(am__tagged_files)
 	$(am__define_uniq_tagged_files); mkid -fID $$unique
@@ -795,9 +948,11 @@ distdir-am: $(DISTFILES)
 	done
 check-am: all-am
 check: check-am
-all-am: Makefile $(PROGRAMS)
+all-am: Makefile $(PROGRAMS) $(LTLIBRARIES) $(HEADERS)
+install-binPROGRAMS: install-libLTLIBRARIES
+
 installdirs:
-	for dir in "$(DESTDIR)$(bindir)"; do \
+	for dir in "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)" "$(DESTDIR)$(libacvp_app_includedir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-am
@@ -833,7 +988,8 @@ maintainer-clean-generic:
 	@echo "it deletes files that may require special tools to rebuild."
 clean: clean-am
 
-clean-am: clean-binPROGRAMS clean-generic clean-libtool mostlyclean-am
+clean-am: clean-binPROGRAMS clean-generic clean-libLTLIBRARIES \
+	clean-libtool mostlyclean-am
 
 distclean: distclean-am
 		-rm -f ./$(DEPDIR)/acvp_app-app_aes.Po
@@ -851,6 +1007,21 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/acvp_app-app_rsa.Po
 	-rm -f ./$(DEPDIR)/acvp_app-app_sha.Po
 	-rm -f ./$(DEPDIR)/acvp_app-app_utils.Po
+	-rm -f ./$(DEPDIR)/app_aes.Plo
+	-rm -f ./$(DEPDIR)/app_cli.Plo
+	-rm -f ./$(DEPDIR)/app_cmac.Plo
+	-rm -f ./$(DEPDIR)/app_des.Plo
+	-rm -f ./$(DEPDIR)/app_drbg.Plo
+	-rm -f ./$(DEPDIR)/app_dsa.Plo
+	-rm -f ./$(DEPDIR)/app_ecdsa.Plo
+	-rm -f ./$(DEPDIR)/app_hmac.Plo
+	-rm -f ./$(DEPDIR)/app_kas.Plo
+	-rm -f ./$(DEPDIR)/app_kas_kdf.Plo
+	-rm -f ./$(DEPDIR)/app_kdf.Plo
+	-rm -f ./$(DEPDIR)/app_main.Plo
+	-rm -f ./$(DEPDIR)/app_rsa.Plo
+	-rm -f ./$(DEPDIR)/app_sha.Plo
+	-rm -f ./$(DEPDIR)/app_utils.Plo
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -867,13 +1038,13 @@ info: info-am
 
 info-am:
 
-install-data-am:
+install-data-am: install-libacvp_app_includeHEADERS
 
 install-dvi: install-dvi-am
 
 install-dvi-am:
 
-install-exec-am: install-binPROGRAMS
+install-exec-am: install-binPROGRAMS install-libLTLIBRARIES
 
 install-html: install-html-am
 
@@ -911,6 +1082,21 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/acvp_app-app_rsa.Po
 	-rm -f ./$(DEPDIR)/acvp_app-app_sha.Po
 	-rm -f ./$(DEPDIR)/acvp_app-app_utils.Po
+	-rm -f ./$(DEPDIR)/app_aes.Plo
+	-rm -f ./$(DEPDIR)/app_cli.Plo
+	-rm -f ./$(DEPDIR)/app_cmac.Plo
+	-rm -f ./$(DEPDIR)/app_des.Plo
+	-rm -f ./$(DEPDIR)/app_drbg.Plo
+	-rm -f ./$(DEPDIR)/app_dsa.Plo
+	-rm -f ./$(DEPDIR)/app_ecdsa.Plo
+	-rm -f ./$(DEPDIR)/app_hmac.Plo
+	-rm -f ./$(DEPDIR)/app_kas.Plo
+	-rm -f ./$(DEPDIR)/app_kas_kdf.Plo
+	-rm -f ./$(DEPDIR)/app_kdf.Plo
+	-rm -f ./$(DEPDIR)/app_main.Plo
+	-rm -f ./$(DEPDIR)/app_rsa.Plo
+	-rm -f ./$(DEPDIR)/app_sha.Plo
+	-rm -f ./$(DEPDIR)/app_utils.Plo
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 
@@ -927,23 +1113,27 @@ ps: ps-am
 
 ps-am:
 
-uninstall-am: uninstall-binPROGRAMS
+uninstall-am: uninstall-binPROGRAMS uninstall-libLTLIBRARIES \
+	uninstall-libacvp_app_includeHEADERS
 
 .MAKE: install-am install-strip
 
 .PHONY: CTAGS GTAGS TAGS all all-am am--depfiles check check-am clean \
-	clean-binPROGRAMS clean-generic clean-libtool cscopelist-am \
-	ctags ctags-am distclean distclean-compile distclean-generic \
-	distclean-libtool distclean-tags distdir dvi dvi-am html \
-	html-am info info-am install install-am install-binPROGRAMS \
-	install-data install-data-am install-dvi install-dvi-am \
-	install-exec install-exec-am install-html install-html-am \
-	install-info install-info-am install-man install-pdf \
+	clean-binPROGRAMS clean-generic clean-libLTLIBRARIES \
+	clean-libtool cscopelist-am ctags ctags-am distclean \
+	distclean-compile distclean-generic distclean-libtool \
+	distclean-tags distdir dvi dvi-am html html-am info info-am \
+	install install-am install-binPROGRAMS install-data \
+	install-data-am install-dvi install-dvi-am install-exec \
+	install-exec-am install-html install-html-am install-info \
+	install-info-am install-libLTLIBRARIES \
+	install-libacvp_app_includeHEADERS install-man install-pdf \
 	install-pdf-am install-ps install-ps-am install-strip \
 	installcheck installcheck-am installdirs maintainer-clean \
 	maintainer-clean-generic mostlyclean mostlyclean-compile \
 	mostlyclean-generic mostlyclean-libtool pdf pdf-am ps ps-am \
-	tags tags-am uninstall uninstall-am uninstall-binPROGRAMS
+	tags tags-am uninstall uninstall-am uninstall-binPROGRAMS \
+	uninstall-libLTLIBRARIES uninstall-libacvp_app_includeHEADERS
 
 .PRECIOUS: Makefile
 

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -3432,7 +3432,7 @@ ACVP_RESULT acvp_app_run_vector_test_file(const char *path, const char *output, 
 #endif
 
     rv = acvp_run_vectors_from_file(ctx, path, output);
-    goto end;
+
 end:
     /*
      * Free all memory associated with

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -137,6 +137,7 @@ static void app_cleanup(ACVP_CTX *ctx) {
 #endif
 }
 
+#ifndef ACVP_APP_LIB_WRAPPER
 int main(int argc, char **argv) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     ACVP_CTX *ctx = NULL;
@@ -440,6 +441,7 @@ end:
 
     return rv;
 }
+#endif
 
 static int enable_aes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
@@ -3377,4 +3379,67 @@ end:
 
     return rv;
 }
+#endif
+
+#ifdef ACVP_APP_LIB_WRAPPER
+ACVP_RESULT acvp_app_run_vector_test_file(const char *path, const char *output, ACVP_LOG_LVL lvl, ACVP_RESULT (*logger)(char *)) {
+    ACVP_RESULT rv = ACVP_SUCCESS;
+    ACVP_CTX *ctx = NULL;
+
+#ifdef ACVP_NO_RUNTIME
+    fips_selftest_fail = 0;
+    fips_mode = 0;
+    fips_algtest_init_nofips();
+#endif
+
+    /*
+     * We begin the libacvp usage flow here.
+     * First, we create a test session context.
+     */
+    rv = acvp_create_test_session(&ctx, logger, lvl);
+    if (rv != ACVP_SUCCESS) {
+        printf("Failed to create ACVP context: %s\n", acvp_lookup_error_string(rv));
+        goto end;
+    }
+
+    /*
+    * We need to register all the crypto module capabilities that will be
+    * validated. Each has their own method for readability.
+    */
+    if (enable_aes(ctx)) goto end;
+    if (enable_tdes(ctx)) goto end;
+    if (enable_hash(ctx)) goto end;
+    if (enable_cmac(ctx)) goto end;
+    if (enable_hmac(ctx)) goto end;
+#ifdef OPENSSL_KDF_SUPPORT
+    if (enable_kdf(ctx)) goto end;
+#endif
+#ifndef OPENSSL_NO_DSA
+    if (enable_dsa(ctx)) goto end;
+#endif
+    if (enable_rsa(ctx)) goto end;
+    if (enable_ecdsa(ctx)) goto end;
+    if (enable_drbg(ctx)) goto end;
+    if (enable_kas_ecc(ctx)) goto end;
+    if (enable_kas_ifc(ctx)) goto end;
+    if (enable_kts_ifc(ctx)) goto end;
+#ifndef OPENSSL_NO_DSA
+    if (enable_kas_ffc(ctx)) goto end;
+#endif
+    if (enable_kas_kdf(ctx)) goto end;
+#ifndef OPENSSL_NO_DSA
+    if (enable_safe_primes(ctx)) goto end;
+#endif
+
+    rv = acvp_run_vectors_from_file(ctx, path, output);
+    goto end;
+end:
+    /*
+     * Free all memory associated with
+     * both the application and libacvp.
+     */
+    app_cleanup(ctx);
+
+    return rv;
+   }
 #endif

--- a/app/libacvp_app.h
+++ b/app/libacvp_app.h
@@ -1,0 +1,39 @@
+/*****************************************************************************
+* Copyright (c) 2021, Cisco Systems, Inc.
+* All rights reserved.
+
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * NOTE: This header is only use when building acvp_app as a library. It allows
+ * other development systems with proprietary setups (e.g. xcode) to easily integrate
+ * acvp_app's crpyto processing code without  as much overhead and the need to frequently 
+ * update. It is only developed to be use with static offline builds, and NOT intended to
+ * be used inside production code or products.
+ */
+
+#include "acvp/acvp.h"
+
+ACVP_RESULT acvp_app_run_vector_test_file(const char *path, const char *output, ACVP_LOG_LVL lvl, ACVP_RESULT (*logger)(char *));
+
+

--- a/configure
+++ b/configure
@@ -778,6 +778,8 @@ LIBOBJS
 SAFEC_LDFLAGS
 SAFEC_CFLAGS
 SAFEC_STUB_DIR
+BUILD_APP_AS_LIB_FALSE
+BUILD_APP_AS_LIB_TRUE
 USE_LDL_CHECK_FALSE
 USE_LDL_CHECK_TRUE
 UNIT_TEST_SUPPORTED_FALSE
@@ -940,6 +942,7 @@ enable_gcov
 with_criterion_dir
 enable_offline_ldl_check
 enable_lib_check
+enable_wrapper_library
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1597,6 +1600,10 @@ Optional Features:
                           configure. This is ONLY recommended if you have
                           issues with detection and you know the library
                           exists
+  --enable-wrapper-library
+                          Designed for use with offline builds, turns acvp_app
+                          into a single API library for processing offline
+                          tests
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -4854,13 +4861,13 @@ if ${lt_cv_nm_interface+:} false; then :
 else
   lt_cv_nm_interface="BSD nm"
   echo "int some_variable = 0;" > conftest.$ac_ext
-  (eval echo "\"\$as_me:4857: $ac_compile\"" >&5)
+  (eval echo "\"\$as_me:4864: $ac_compile\"" >&5)
   (eval "$ac_compile" 2>conftest.err)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4860: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
+  (eval echo "\"\$as_me:4867: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
   (eval "$NM \"conftest.$ac_objext\"" 2>conftest.err > conftest.out)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4863: output\"" >&5)
+  (eval echo "\"\$as_me:4870: output\"" >&5)
   cat conftest.out >&5
   if $GREP 'External.*some_variable' conftest.out > /dev/null; then
     lt_cv_nm_interface="MS dumpbin"
@@ -6065,7 +6072,7 @@ ia64-*-hpux*)
   ;;
 *-*-irix6*)
   # Find out which ABI we are using.
-  echo '#line 6068 "configure"' > conftest.$ac_ext
+  echo '#line 6075 "configure"' > conftest.$ac_ext
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
@@ -7594,11 +7601,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7597: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7604: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7601: \$? = $ac_status" >&5
+   echo "$as_me:7608: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -7933,11 +7940,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7936: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7943: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7940: \$? = $ac_status" >&5
+   echo "$as_me:7947: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8038,11 +8045,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8041: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8048: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8045: \$? = $ac_status" >&5
+   echo "$as_me:8052: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -8093,11 +8100,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8096: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8103: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8100: \$? = $ac_status" >&5
+   echo "$as_me:8107: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -10463,7 +10470,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10466 "configure"
+#line 10473 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -10559,7 +10566,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10562 "configure"
+#line 10569 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -10989,6 +10996,14 @@ $as_echo "yes" >&6; }
 else
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
+fi
+
+# Enable a wrapper to turn acvp_app into a small library (Only for static offline builds)
+# Check whether --enable-wrapper-library was given.
+if test "${enable_wrapper_library+set}" = set; then :
+  enableval=$enable_wrapper_library; wraplib="$enableval"
+else
+  wrap_lib=false
 fi
 
 
@@ -11473,6 +11488,14 @@ else
   USE_LDL_CHECK_FALSE=
 fi
 
+ if test "x$wrap_lib" != "xfalse"; then
+  BUILD_APP_AS_LIB_TRUE=
+  BUILD_APP_AS_LIB_FALSE='#'
+else
+  BUILD_APP_AS_LIB_TRUE='#'
+  BUILD_APP_AS_LIB_FALSE=
+fi
+
 
 ##
 # SafeC Stub
@@ -11683,6 +11706,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${USE_LDL_CHECK_TRUE}" && test -z "${USE_LDL_CHECK_FALSE}"; then
   as_fn_error $? "conditional \"USE_LDL_CHECK\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${BUILD_APP_AS_LIB_TRUE}" && test -z "${BUILD_APP_AS_LIB_FALSE}"; then
+  as_fn_error $? "conditional \"BUILD_APP_AS_LIB\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,12 @@ else
     AC_MSG_RESULT(no)
 fi
 
+# Enable a wrapper to turn acvp_app into a small library (Only for static offline builds)
+AC_ARG_ENABLE([wrapper-library],
+[AS_HELP_STRING([--enable-wrapper-library],
+[Designed for use with offline builds, turns acvp_app into a single API library for processing offline tests])],
+[wraplib="$enableval"],
+[wrap_lib=false])
 
 ########################################################################################
 # End reading arguments. Begin testing presence of libs and setting certain make vars. #
@@ -314,6 +320,7 @@ AS_IF([test "x$with_criterion" != xno],
 AM_CONDITIONAL([UNIT_TEST_SUPPORTED], [test "x$with_criteriondir" != "xno"])
 
 AM_CONDITIONAL([USE_LDL_CHECK], [test "x$check_ldl" != "xfalse" && test "x$enable_offline" != "xfalse"])
+AM_CONDITIONAL([BUILD_APP_AS_LIB], [test "x$wrap_lib" != "xfalse"])
 
 ##
 # SafeC Stub


### PR DESCRIPTION
Using configure option --enable-wrapper-library, builds acvp_app as libacvp_app. This can then be used as a single API library (acvp_app_run_vector_test_file) to easily link into more proprietary build systems (such as xcode) without having to constantly maintain an app codebase for the sole purpose of running a test file.

This is meant to be used with --enable-offline. I will disable allowing it to be used with online builds (it builds fine, but is pointless) in the next PR with some other things. 