### PR TITLE
Fixes and improvements to kas-kdf

### DIFF
--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -80,7 +80,7 @@ typedef struct app_config {
 
 int ingest_cli(APP_CONFIG *cfg, int argc, char **argv);
 int app_setup_two_factor_auth(ACVP_CTX *ctx);
-unsigned int convert_uint_to_big_endian(unsigned int i);
+unsigned int swap_uint_endian(unsigned int i);
 int check_is_little_endian(void);
 
 void app_aes_cleanup(void);

--- a/app/app_utils.c
+++ b/app/app_utils.c
@@ -231,7 +231,7 @@ int app_setup_two_factor_auth(ACVP_CTX *ctx) {
     return 0;
 }
 
-unsigned int convert_uint_to_big_endian(unsigned int i) {
+unsigned int swap_uint_endian(unsigned int i) {
     int a = 0, b = 0, c = 0, d = 0;
     a = (i >> 24) & 0x000000ff;
     b = (i >> 8) & 0x0000ff00;


### PR DESCRIPTION
Fixed an issue on big-endian platforms for kas-kdf. Every other value is expected to be big endian, except the counter for hkdf, which is supposed to be little endian. The check was never there for endianness, so it worked fine on little endian platforms.

added loop breaks for when the total concatenated output is greater than the length of output for the test case. this increases the processing speed for onestep KDF by several multitudes.

Renamed function to indicate its used to swap endianness instead of just convert to little endian.