### PR TITLE
Substantial readme and CLI parsing updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,21 @@ purposes as long as you fulfill its conditions. See the LICENSE
 file for details.
 
 ### Recent Changes
-The client library is compatible with the ACVP spec version 1.0, see https://github.com/usnistgov/ACVP however not all algorithms and options are supported. See the support list in the Supported Algorithms section below.
+The client library is compatible with the ACVP spec version 1.0, see https://github.com/usnistgov/ACVP
+however not all algorithms and options are supported. See the support list in the Supported Algorithms
+section below.
 
-Metadata processing has been simplified and no longer requires id fields. Please review the new metadata directory sample json files to see the new format. Older formats should continue to work, but will have some unused keywords and fields.
+Support for new algorithms and features is being added fairly regularly. Recent features also include the
+ability to cancel test sessions and more configure options to help various different build configurations
+and platforms.
 
-To track any and all changes please review recent commits for more detail.
 
 ## Overview
 
 Libacvp is a client-side ACVP library implementation, and also includes
-an example application which utilizes the library. 
+an example application (acvp_app) which utilizes the library.
 
-libacvp will login and then register with the ACVP server (advertising capabilities)
+libacvp will login and then register with the ACVP server (advertising capabilities).
 The server will respond with a list of vector set identifiers that need to be processed.
 libacvp will download each vector set, process the vectors, and send the results back to the server.
 This is performed in real-time by default. The user can also use "offline" mode for non-realtime
@@ -95,13 +98,14 @@ overwriting the default OpenSSL that comes with your distro.
 It is highly recommended to use versions of OpenSSL 1.1.1 or greater when possible, 
 as all previous versions have reached end of life status. 
 
-The next problem is the default libcurl on the Linux distro may be linked against
+A potential source of issues is the default libcurl on the Linux distro, which may be linked against
 the previously mentioned default OpenSSL. This could result in linker failures when trying to use
 the system default libcurl with the new OpenSSL install (due to missing symbols).
 Therefore, you SHOULD download the Curl source, compile it against the "new" OpenSSL
 header files, and link libcurl against the "new" OpenSSL. 
 libacvp uses compile time macro logic to address differences in the APIs of different OpenSSL
-versions.
+versions; therefore, it is important that you ensure libacvp is linking to the correct openSSL versions
+at run time as well.
 
 Libacvp is designed to work with curl version 7.61.0 or newer. Some operating systems may ship with
 older versions of Curl which are missing certain features that libacvp depends on. In this case you
@@ -126,7 +130,7 @@ make install
 #### To build for non-runtime testing
 
 ```
-./configure --with-ssl-dir=<path to ssl dir> --with-libcurl-dir=<path to curl dir> --with-fom_dir=<path to where FOM is installed>
+./configure --with-ssl-dir=<path to ssl dir> --with-fom_dir=<path to where FOM is installed> --with-libcurl-dir=<path to curl dir>
 make clean
 make
 make install
@@ -146,6 +150,18 @@ on libacvp having already been built. The libacvp directory can be provided usin
 Otherwise, it will look in the default build directory in the root folder for libacvp.
 
 --disable-lib
+
+#### Other build options
+More info about all available configure options can be found by using ./configure --help. Some important
+ones include:
+--enable-offline : Will link to all dependencies statically and remove the libcurl dependency. See "How
+ to test offline" for more details.
+--disable-kdf : Will disable kdf registration and processing in the application, in cases where the given
+ crypto implementation does not support it (E.g. OpenSSL FOM 2.X.X)
+--disable-lib-check : This will disable autoconf's attempts to automatically detect prerequisite libraries
+ before building libacvp. This may be useful in some edge cases where the libraries exist but autoconf
+ cannot detect them; however, it will give more cryptic error messages in the make stage if there are issues
+
 
 #### Cross Compiling
 Requires options --build and --host.
@@ -240,7 +256,9 @@ libacvp you may configure and build a special app used only for Step 2. This
 can be done by using --enable-offline and --enable-static when running 
 ./configure and do not use --with-libcurl-dir or --with-libmurl-dir which
 will  minimize the library dependencies. Note that openssl with FOM must also
-be built as static.
+be built as static. For this case, OpenSSL MUST be built with the "no-dso" option,
+OR the configure option `--enable-offline-ldl-check` must be used to resolve the libdl
+dependency. Some specific versions of SSL may not be able to remove the libdl dependency.
 
 For example:
 ```
@@ -277,6 +295,36 @@ it was configured and built with. libacvp/acvp_app depend on library versions in
 or disabling certain features at build time, so please make sure libacvp and acvp_app are 
 built and run with the same versions of each library.
 
+`Can I redownload vector sets from a previously created session?`
+Yes. running acvp_app with the --resume_session AND --vector_req options will redownload
+those vector sets to the given file without processing or uploading anything. See the app
+help section for more details about these commands.
+
+`I have been getting retry messages for X amount of time. Is this normal?`
+Yes; the server actively sends retry messages when it is still in the process of generating
+tests or waiting to generate tests. This period of time can vary wildly if the server is under
+intense load, anywhere from a few seconds to a few days. If there is an issue and the connection
+is lost or the server experiences an error, the library output will indicate it.
+
+`I recieved a vector set from somewhere other than libacvp, such as a lab. How can I process it?`
+Libacvp expects vector set json files to have a specific formatting. It is possible to manually
+modify the JSON file to make it work though we do not officially support or endorse this process.
+Moving your vector set into a json array, and putting this as the json object before the vector set
+should allow libacvp to process it using the offline testing process described above; you would
+also need to remove these entries from the output file.
+```
+{
+    "jwt": "NA",
+    "url": "NA",
+    "isSample": false,
+    "vectorSetUrls": [
+        "NA"
+    ]
+}
+```
+Note that this file will not be able to be submitted using libacvp unless you manually input all
+of the correct information in the above object; we do not recommend this and you should instead
+try to submit via wherever you originally got the vector set from.
 
 ## Credits
 This package was initially written by John Foley of Cisco Systems.
@@ -285,7 +333,7 @@ This package was initially written by John Foley of Cisco Systems.
 
 |   Algorithm Type   |    Library Support    |   Client App Support    |
 | :---------------:  | :-------------------: | :---------------------: |
-| **Block Cipher Modes** |                       |                         |   
+| **Block Cipher Modes** |                   |                         |
 | **AES-CBC** |   Y  |  Y |
 | **AES-CFB1** |  Y  |  Y  |
 | **AES-CFB8** |  Y  |  Y  |
@@ -421,8 +469,8 @@ This package was initially written by John Foley of Cisco Systems.
 | **TPM** |  N  |  N  |
 | **ANSX9.63** |  Y  |  N  |
 | **ANSX9.42** |  N  |  N  |
-| **PBKDF** |  N  |  N  |
-| **Safe Primes** | |
-| **SafePrimes KeyGen** |  N  |  N  |
-| **SafePrimes KeyVer** |  N  |  N  |
+| **PBKDF** |  Y  |  N  |
+| **Safe Primes** | | |
+| **SafePrimes KeyGen** |  Y  |  Y  |
+| **SafePrimes KeyVer** |  Y  |  Y  |
 

--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -21,6 +21,7 @@
 #define ANSI_COLOR_RED "\x1b[31m"
 #define ANSI_COLOR_YELLOW "\x1b[33m"
 #define ANSI_COLOR_RESET "\x1b[0m"
+#define ACVP_APP_HELP_MSG "Use acvp_app --help for more information."
 
 static void print_usage(int code) {
     if (code == -1) {
@@ -32,6 +33,7 @@ static void print_usage(int code) {
     }
     printf("To output version of library and of ACVP spec:\n");
     printf("      --version\n");
+    printf("      -v\n");
     printf("Logging level decides the amount of information output by the library. Logging level\n");
     printf("can be controlled using:\n");
     printf("      --none\n");
@@ -104,13 +106,18 @@ static void print_usage(int code) {
     printf("\n");
     printf("To register and save the vectors to file:\n");
     printf("      --vector_req <file>\n");
+    printf("      -r <file>\n");
     printf("\n");
     printf("To process saved vectors and write results/responses to file:\n");
     printf("      --vector_req <file>\n");
     printf("      --vector_rsp <file>\n");
+    printf("      OR\n");
+    printf("      -r <file>\n");
+    printf("      -p <file>\n");
     printf("\n");
     printf("To upload vector responses from file:\n");
     printf("      --vector_upload <file>\n");
+    printf("      -u <file>\n");
     printf("\n");
     printf("To process kat vectors from a JSON file use:\n");
     printf("      --kat <file>\n");
@@ -149,6 +156,7 @@ static void print_usage(int code) {
     printf("\n");
     printf("Some other options may support outputting to log OR saving to a file. To save to a file:\n");
     printf("      --save_to <file>\n");
+    printf("      -s <file>\n");
     printf("\n");
     printf("In addition some options are passed to acvp_app using\n");
     printf("environment variables.  The following variables can be set:\n\n");
@@ -171,8 +179,60 @@ static void print_usage(int code) {
     printf("        ACV_OE_ARCHITECTURE\n");
     printf("        ACV_OE_PROCESSOR\n");
     printf("        ACV_OE_COMPILER\n\n");
-
 }
+
+static ko_longopt_t longopts[] = {
+    { "version", ko_no_argument, 301 },
+    { "help", ko_optional_argument, 302 },
+    { "info", ko_no_argument, 303 },
+    { "status", ko_no_argument, 304 },
+    { "warn", ko_no_argument, 305 },
+    { "error", ko_no_argument, 306 },
+    { "verbose", ko_no_argument, 307 },
+    { "none", ko_no_argument, 308 },
+    { "sample", ko_no_argument, 309 },
+    { "aes", ko_no_argument, 310 },
+    { "tdes", ko_no_argument, 311 },
+    { "hash", ko_no_argument, 312 },
+    { "cmac", ko_no_argument, 313 },
+    { "hmac", ko_no_argument, 314 },
+#ifdef OPENSSL_KDF_SUPPORT
+    { "kdf", ko_no_argument, 315 },
+#endif
+#ifndef OPENSSL_NO_DSA
+    { "dsa", ko_no_argument, 316 },
+#endif
+    { "rsa", ko_no_argument, 317 },
+    { "drbg", ko_no_argument, 318 },
+    { "ecdsa", ko_no_argument, 319 },
+    { "kas_ecc", ko_no_argument, 320 },
+#ifndef OPENSSL_NO_DSA
+    { "kas_ffc", ko_no_argument, 321 },
+    { "safe_primes", ko_no_argument, 322 },
+#endif
+    { "kas_ifc", ko_no_argument, 323 },
+    { "kts_ifc", ko_no_argument, 324 },
+    { "kas_kdf", ko_no_argument, 325 },
+    { "all_algs", ko_no_argument, 350 },
+    { "manual_registration", ko_required_argument, 400 },
+    { "kat", ko_required_argument, 401 },
+    { "fips_validation", ko_required_argument, 402 },
+    { "vector_req", ko_required_argument, 403 },
+    { "vector_rsp", ko_required_argument, 404 },
+    { "vector_upload", ko_required_argument, 405 },
+    { "get", ko_required_argument, 406 },
+    { "post", ko_required_argument, 407 },
+    { "put", ko_required_argument, 408 },
+    { "get_results", ko_required_argument, 409},
+    { "certnum", ko_required_argument, 410 },
+    { "resume_session", ko_required_argument, 411 },
+    { "get_expected_results", ko_required_argument, 412 },
+    { "save_to", ko_required_argument, 413 },
+    { "delete", ko_required_argument, 414 },
+    { "cancel_session", ko_required_argument, 415 },
+    { NULL, 0, 0 }
+};
+
 
 static void default_config(APP_CONFIG *cfg) {
     cfg->level = ACVP_LOG_LVL_STATUS;
@@ -202,82 +262,52 @@ static void enable_all_algorithms(APP_CONFIG *cfg) {
 #endif
 }
 
+static const char* lookup_arg_name(int c) {
+    int arrlen = sizeof(longopts) / sizeof(ko_longopt_t);
+    for (int i = 0; i < arrlen; i++) {
+        if (longopts[i].val == c) {
+            return longopts[i].name;
+        }
+    }
+    return NULL;
+}
+
+//return 0 if fails check, 1 if passes
+static int check_option_length(const char *opt, int c, int maxAllowed) {
+    if ((int)strnlen_s(opt, maxAllowed + 1) > maxAllowed) {
+        const char *argName = lookup_arg_name(c);
+        printf(ANSI_COLOR_RED "Command error... "ANSI_COLOR_RESET
+                "\nThe argument given for option %s is too long."
+                "\nMax length allowed: %d"
+                "\n%s\n", argName, maxAllowed, ACVP_APP_HELP_MSG);
+        return 0;
+    }
+    return 1;
+}
+
 int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
     ketopt_t opt = KETOPT_INIT;
-    int c = 0;
+    int c = 0, diff = 0;
 
     cfg->empty_alg = 1;
-
-    static ko_longopt_t longopts[] = {
-        { "version", ko_no_argument, 301 },
-        { "help", ko_optional_argument, 302 },
-        { "info", ko_no_argument, 303 },
-        { "status", ko_no_argument, 304 },
-        { "warn", ko_no_argument, 305 },
-        { "error", ko_no_argument, 306 },
-        { "verbose", ko_no_argument, 307 },
-        { "none", ko_no_argument, 308 },
-        { "sample", ko_no_argument, 309 },
-        { "aes", ko_no_argument, 310 },
-        { "tdes", ko_no_argument, 311 },
-        { "hash", ko_no_argument, 312 },
-        { "cmac", ko_no_argument, 313 },
-        { "hmac", ko_no_argument, 314 },
-#ifdef OPENSSL_KDF_SUPPORT
-        { "kdf", ko_no_argument, 315 },
-#endif
-#ifndef OPENSSL_NO_DSA
-        { "dsa", ko_no_argument, 316 },
-#endif
-        { "rsa", ko_no_argument, 317 },
-        { "drbg", ko_no_argument, 318 },
-        { "ecdsa", ko_no_argument, 319 },
-        { "kas_ecc", ko_no_argument, 320 },
-#ifndef OPENSSL_NO_DSA
-        { "kas_ffc", ko_no_argument, 321 },
-        { "safe_primes", ko_no_argument, 322 },
-#endif
-        { "kas_ifc", ko_no_argument, 323 },
-        { "kts_ifc", ko_no_argument, 324 },
-        { "kas_kdf", ko_no_argument, 325 },
-        { "all_algs", ko_no_argument, 350 },
-        { "manual_registration", ko_required_argument, 400 },
-        { "kat", ko_required_argument, 401 },
-        { "fips_validation", ko_required_argument, 402 },
-        { "vector_req", ko_required_argument, 403 },
-        { "vector_rsp", ko_required_argument, 404 },
-        { "vector_upload", ko_required_argument, 405 },
-        { "get", ko_required_argument, 406 },
-        { "post", ko_required_argument, 407 },
-        { "put", ko_required_argument, 408 },
-        { "get_results", ko_required_argument, 409},
-        { "certnum", ko_required_argument, 410 },
-        { "resume_session", ko_required_argument, 411 },
-        { "get_expected_results", ko_required_argument, 412 },
-        { "save_to", ko_required_argument, 413 },
-        { "delete", ko_required_argument, 414 },
-        { "cancel_session", ko_required_argument, 415 },
-        { NULL, 0, 0 }
-    };
 
     /* Set the default configuration values */
     default_config(cfg);
 
-    while ((c = ketopt(&opt, argc, argv, 1, "vh", longopts)) >= 0) {
-        if (c == 'v') {
+    while ((c = ketopt(&opt, argc, argv, 1, "vhs:u:r:p:", longopts)) >= 0) {
+        diff = 0;
+
+        switch (c) {
+        case 'v':
             printf("\nACVP library version(protocol version): %s(%s)\n", acvp_version(), acvp_protocol_version());
             return 1;
-        }
-        if (c == 'h') {
+        case 'h':
             print_usage(0);
             return 1;
-        }
-        if (c == 301) {
+        case 301:
             printf("\nACVP library version(protocol version): %s(%s)\n", acvp_version(), acvp_protocol_version());
             return 1;
-        }
-        if (c == 302) {
-            int diff = -1;
+        case 302:
             strncmp_s(opt.arg, JSON_FILENAME_LENGTH + 1, "verbose", 7, &diff);
             if (!diff) {
                 print_usage(ACVP_LOG_LVL_VERBOSE);
@@ -285,425 +315,267 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
                 print_usage(0);
             }
             return 1;
-        }
-        if (c == 303) {
+        case 303:
             cfg->level = ACVP_LOG_LVL_INFO;
-            continue;
-        }
-        if (c == 304) {
+            break;
+        case 304:
             cfg->level = ACVP_LOG_LVL_STATUS;
-            continue;
-        }
-        if (c == 305) {
+            break;
+        case 305:
             cfg->level = ACVP_LOG_LVL_WARN;
-            continue;
-        }
-        if (c == 306) {
+            break;
+        case 306:
             cfg->level = ACVP_LOG_LVL_ERR;
-            continue;
-        }
-        if (c == 307) {
+            break;
+        case 307:
             cfg->level = ACVP_LOG_LVL_VERBOSE;
-            continue;
-        }
-        if (c == 308) {
+            break;
+        case 308:
             cfg->level = ACVP_LOG_LVL_NONE;
-            continue;
-        }
-        if (c == 309) {
+            break;
+        case 309:
             cfg->sample = 1;
-            continue;
-        }
-        if (c == 310) {
+            break;
+        case 310:
             cfg->aes = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 311) {
+            break;
+        case 311:
             cfg->tdes = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 312) {
+            break;
+        case 312:
             cfg->hash = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 313) {
+            break;
+        case 313:
             cfg->cmac = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 314) {
+            break;
+        case 314:
             cfg->hmac = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
+            break;
 #ifdef OPENSSL_KDF_SUPPORT
-        if (c == 315) {
+        case 315:
             cfg->kdf = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
+            break;
 #endif
 #ifndef OPENSSL_NO_DSA
-        if (c == 316) {
+        case 316:
             cfg->dsa = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
+            break;
 #endif
-        if (c == 317) {
+        case 317:
             cfg->rsa = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 318) {
+            break;
+        case 318:
             cfg->drbg = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 319) {
+            break;
+        case 319:
             cfg->ecdsa = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 320) {
+            break;
+        case 320:
             cfg->kas_ecc = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
+            break;
 #ifndef OPENSSL_NO_DSA
-        if (c == 321) {
+        case 321:
             cfg->kas_ffc = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 322) {
+            break;
+        case 322:
             cfg->safe_primes = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
+            break;
 #endif
-        if (c == 323) {
+        case 323:
             cfg->kas_ifc = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 324) {
+            break;
+        case 324:
             cfg->kts_ifc = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 325) {
+            break;
+        case 325:
             cfg->kas_kdf = 1;
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 350) {
+            break;
+        case 350:
             enable_all_algorithms(cfg);
             cfg->empty_alg = 0;
-            continue;
-        }
-        if (c == 400) {
-            int filename_len = 0;
+            break;
+
+        case 400:
             cfg->manual_reg = 1;
-
-            filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (filename_len > JSON_FILENAME_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                       "\nThe <file> \"%s\", has a name that is too long."
-                       "\nMax allowed <file> name length is (%d).\n",
-                       "--manual_registration", opt.arg, JSON_FILENAME_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->reg_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
-        if (c == 401) {
-            int filename_len = 0;
+            break;
+
+        case 401:
             cfg->kat = 1;
-
-            filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (filename_len > JSON_FILENAME_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                       "\nThe <file> \"%s\", has a name that is too long."
-                       "\nMax allowed <file> name length is (%d).\n",
-                       "--kat", opt.arg, JSON_FILENAME_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->kat_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
-        if (c == 402) {
-            int filename_len = 0;
+            break;
+
+        case 402:
             cfg->fips_validation = 1;
-
-            filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (filename_len > JSON_FILENAME_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                       "\nThe <file> \"%s\", has a name that is too long."
-                       "\nMax allowed <file> name length is (%d).\n",
-                       "--fips_validation", opt.arg, JSON_FILENAME_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->validation_metadata_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
+            break;
 
-        if (c == 403) {
-            int filename_len = 0;
+        case 'r':
+        case 403:
             cfg->vector_req = 1;
-
-            filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (filename_len > JSON_FILENAME_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                       "\nThe <file> \"%s\", has a name that is too long."
-                       "\nMax allowed <file> name length is (%d).\n",
-                       "--vector_req", opt.arg, JSON_FILENAME_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->vector_req_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
+            break;
 
-        if (c == 404) {
-            int rsp_filename_len = 0;
+        case 'p':
+        case 404:
             cfg->vector_rsp = 1;
-
-            rsp_filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (rsp_filename_len > JSON_FILENAME_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                       "\nThe <file> \"%s\", has a name that is too long."
-                       "\nMax allowed <file> name length is (%d).\n",
-                       "--vector_rsp", opt.arg, JSON_FILENAME_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
 
             strcpy_s(cfg->vector_rsp_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
+            break;
 
-        if (c == 405) {
-            int upload_filename_len = 0;
+        case 'u':
+        case 405:
             cfg->vector_upload = 1;
-
-            upload_filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (upload_filename_len > JSON_FILENAME_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                       "\nThe <file> \"%s\", has a name that is too long."
-                       "\nMax allowed <file> name length is (%d).\n",
-                       "--vector_upload", opt.arg, JSON_FILENAME_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->vector_upload_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
+            break;
 
-        if (c == 406) {
-            int get_string_len = 0;
+        case 406:
             cfg->get = 1;
-
-            get_string_len = strnlen_s(opt.arg, JSON_REQUEST_LENGTH + 1);
-            if (get_string_len > JSON_REQUEST_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                       "\nThe <string> \"%s\", is too long."
-                       "\nMax allowed <string> length is (%d).\n",
-                       "--get", opt.arg, JSON_REQUEST_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_REQUEST_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->get_string, JSON_REQUEST_LENGTH + 1, opt.arg);
-            continue;
-        }
+            break;
 
-        if (c == 407) {
-            int post_filename_len = 0;
+        case 407:
             cfg->post = 1;
-
-            post_filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (post_filename_len > JSON_REQUEST_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                       "\nThe <file> \"%s\", has a name that is too long."
-                       "\nMax allowed <file> name length is (%d).\n",
-                       "--post", opt.arg, JSON_FILENAME_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->post_filename, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
+            break;
 
-        if (c == 408) {
-            int put_filename_len = 0;
+        case 408:
             cfg->put = 1;
-
-            put_filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (put_filename_len > JSON_REQUEST_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                       "\nThe <file> \"%s\", has a name that is too long."
-                       "\nMax allowed <file> name length is (%d).\n",
-                       "--put", opt.arg, JSON_FILENAME_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->put_filename, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
+            break;
 
-        if (c == 409) {
-            int result_filename_len = 0;
+        case 409:
             cfg->get_results = 1;
-
-            result_filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (result_filename_len > JSON_REQUEST_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                    "\nThe <file> \"%s\", has a name that is too long."
-                    "\nMax allowed <file> name length is (%d).\n",
-                    "--get_results", opt.arg, JSON_FILENAME_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->session_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
+            break;
 
-        if (c == 410) {
-            int certnum_len = 0;
-            certnum_len = strnlen_s(opt.arg, JSON_STRING_LENGTH + 1);
-            if (certnum_len > JSON_STRING_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                       "\nThe string used is too long."
-                       "\nMax allowed string length is %d.\n",
-                       "--certnum", JSON_STRING_LENGTH);
+        case 410:
+            if (!check_option_length(opt.arg, c, JSON_STRING_LENGTH)) {
                 return 1;
             }
             strcpy_s(value, JSON_STRING_LENGTH, opt.arg);
-            continue;
-        }
-        if (c == 411) {
-            int resume_filename_len = 0;
+            break;
+
+        case 411:
             cfg->resume_session = 1;
-
-            resume_filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (resume_filename_len > JSON_REQUEST_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                    "\nThe <file> \"%s\", has a name that is too long."
-                    "\nMax allowed <file> name length is (%d).\n",
-                    "--resume_session", opt.arg, JSON_FILENAME_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->session_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
-        if (c == 412) {
-            int session_filename_len = 0;
+            break;
+
+        case 412:
             cfg->get_expected = 1;
-
-            session_filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (session_filename_len > JSON_REQUEST_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                    "\nThe <file> \"%s\", has a name that is too long."
-                    "\nMax allowed <file> name length is (%d).\n",
-                    "--get_expected_results", opt.arg, JSON_FILENAME_LENGTH);
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->session_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
-        if (c == 413) {
-            int save_filename_len = 0;
-            cfg->save_to = 1;
+            break;
 
-            save_filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (save_filename_len > JSON_REQUEST_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                    "\nThe <file> \"%s\", has a name that is too long."
-                    "\nMax allowed <file> name length is (%d).\n",
-                    "--save_to", opt.arg, JSON_FILENAME_LENGTH);
+        case 's':
+        case 413:
+            cfg->save_to = 1;
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
             strcpy_s(cfg->save_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
-        if (c == 414) {
-            int delete_request_url_len = 0;
-            cfg->delete = 1;
+            break;
 
-            delete_request_url_len = strnlen_s(opt.arg, JSON_REQUEST_LENGTH + 1);
-            if (delete_request_url_len > JSON_REQUEST_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                    "\nThe <file> \"%s\", has a name that is too long."
-                    "\nMax allowed <file> name length is (%d).\n",
-                    "--save_to", opt.arg, JSON_REQUEST_LENGTH);
+        case 414:
+            cfg->delete = 1;
+            if (!check_option_length(opt.arg, c, JSON_REQUEST_LENGTH)) {
                 return 1;
             }
             strcpy_s(cfg->delete_url, JSON_REQUEST_LENGTH + 1, opt.arg);
-            continue;
-        }
-        if (c == 415) {
-            int session_filename_len = 0;
-            cfg->cancel_session = 1;
+            break;
 
-            session_filename_len = strnlen_s(opt.arg, JSON_FILENAME_LENGTH + 1);
-            if (session_filename_len > JSON_REQUEST_LENGTH) {
-                print_usage(-1);
-                printf(ANSI_COLOR_RED "Command error... [%s]"ANSI_COLOR_RESET
-                    "\nThe <file> \"%s\", has a name that is too long."
-                    "\nMax allowed <file> name length is (%d).\n",
-                    "--get_expected_results", opt.arg, JSON_FILENAME_LENGTH);
+        case 415:
+            cfg->cancel_session = 1;
+            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
                 return 1;
             }
-
             strcpy_s(cfg->session_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            continue;
-        }
-        
-        if (c == '?') {
-            print_usage(-1);
-            printf(ANSI_COLOR_RED "unknown option: %s\n"ANSI_COLOR_RESET, *(argv + opt.ind - 1));
+            break;
+
+        case '?':
+            printf(ANSI_COLOR_RED "unknown option: %s\n"ANSI_COLOR_RESET, *(argv + opt.ind - !(opt.pos > 0)));
+            printf("%s\n", ACVP_APP_HELP_MSG);
             return 1;
-        }
-        if (c == ':') {
-            print_usage(-1);
+
+        case ':':
             printf(ANSI_COLOR_RED "option missing arg: %s\n"ANSI_COLOR_RESET, *(argv + opt.ind - 1));
+            printf("%s\n", ACVP_APP_HELP_MSG);
             return 1;
+
+        default:
+            printf("An unknown error occurred while parsing arguments.\n");
+            break;
         }
     }
 
-    if (cfg->save_to && !cfg->get_expected && !cfg->get) {
-        printf("Warning: --save-to only works with --get and --get_expected. Option will be ignored.\n");
+    //If there are still arguments that were not permuted, they are invalid
+    if (opt.ind < argc) {
+        for (c = opt.ind; c < argc; c++) {
+            printf(ANSI_COLOR_RED "unknown option: %s\n" ANSI_COLOR_RESET, argv[c]);
+        }
+        printf("%s\n", ACVP_APP_HELP_MSG);
+        return 1;
     }
 
     //Many args do not need an alg specified. Todo: make cleaner
     if (cfg->empty_alg && !cfg->post && !cfg->get && !cfg->put && !cfg->get_results
             && !cfg->get_expected && !cfg->manual_reg && !cfg->vector_upload
-            && !cfg->delete && !cfg->cancel_session)  {
+            && !cfg->delete && !cfg->cancel_session && !(cfg->resume_session && 
+            cfg->vector_req)) {
         /* The user needs to select at least 1 algorithm */
-        print_usage(-1);
         printf(ANSI_COLOR_RED "Requires at least 1 Algorithm Test Suite\n"ANSI_COLOR_RESET);
+        printf("%s\n", ACVP_APP_HELP_MSG);
         return 1;
     }
 

--- a/app/ketopt.h
+++ b/app/ketopt.h
@@ -13,7 +13,7 @@
 #define ko_optional_argument 2
 
 #define OPTION_NAME_MAX 128
-#define OSTR_MAX 2 /* Change according to the ostr parameter in app_cli.c */
+#define OSTR_MAX 9 /* Change according to the ostr parameter in app_cli.c */
 
 typedef struct {
 	int ind;   /* equivalent to optind */
@@ -63,14 +63,14 @@ static void ketopt_permute(char *argv[], int j, int n) /* move argv[j] over n el
  */
 static int ketopt(ketopt_t *s, int argc, char *argv[], int permute, const char *ostr, const ko_longopt_t *longopts)
 {
-        char ostr2[OSTR_MAX+1] = "vh";
+    char ostr2[OSTR_MAX+1] = "vhs:u:r:p:";
 	int opt = -1, i0, j;
-        int odiff = 0;
+    int odiff = 0;
 
-        strncmp_s(ostr, OSTR_MAX, ostr2, OSTR_MAX, &odiff);
-        if (odiff) {
-            return -1;
-        }
+    strncmp_s(ostr, OSTR_MAX, ostr2, OSTR_MAX, &odiff);
+    if (odiff) {
+        return -1;
+    }
 	if (permute) {
 		while (s->i < argc && (argv[s->i][0] != '-' || argv[s->i][1] == '\0'))
 			++s->i, ++s->n_args;
@@ -110,22 +110,20 @@ static int ketopt(ketopt_t *s, int argc, char *argv[], int permute, const char *
 				}
 			}
 		}
-	} else { /* a short option */
+	} else if (argv[s->i][0] == '-' && strnlen_s(argv[s->i], 3) == 2) { /* a short option */
 		char *p = NULL;
         char short_opt[2];
 		if (s->pos == 0) s->pos = 1;
 		opt = s->opt = argv[s->i][s->pos++];
         short_opt[0] = opt;
         short_opt[1] = '\0';
-        
+
         strstr_s(ostr2, OSTR_MAX, short_opt, 1, &p);
 		if (p == 0) {
 			opt = '?'; /* unknown option */
 		} else if (p[1] == ':') {
-			if (argv[s->i][s->pos] == 0) {
-				if (s->i < argc - 1) s->arg = argv[++s->i];
-				else opt = ':'; /* missing option argument */
-			} else s->arg = &argv[s->i][s->pos];
+			if (s->i < argc - 1) s->arg = argv[++s->i];
+			else opt = ':'; /* missing option argument */
 			s->pos = -1;
 		}
 	}


### PR DESCRIPTION
- Multiple changes to CLI arguments, without changing any current functionality:
   - Ketopt will no longer view extra characters in short options as parameters
   - any short options longer than 2 characters (-X) are considered invalid
   - Improved error output for tons of edge cases for CLI arguments
   - Added several new short options that function identically to their counterparts:
       - `-r` can be used in place of --vector_req
       - `-p` can be used in place of --vector_rsp
       - `-u` can be used in place of --vector_upload
       - `-s` can be used in place of --save-to

- Replaced if statements in CLI parsing code with switch case. Note that strict cflags do not complain as those warnings are specific to enumerators.
- Relocated much common code to separate functions in app_cli.c

- Many readme updates, including some FAQs and some common configure options
