### PR TITLE
Drastic overhaul for doc formatting in acvp.h

### DIFF
--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -5,8 +5,8 @@
 /*
  * Copyright (c) 2021, Cisco Systems, Inc.
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
+ * Licensed under the Apache License 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. You can obtain a copy
  * in the file LICENSE in the source distribution or at
  * https://github.com/cisco/libacvp/LICENSE
  */
@@ -29,9 +29,19 @@ extern "C"
 #define ACVP_DES_MCT_INNER      10000
 #define ACVP_DES_MCT_OUTER      400
 
-/*! @enum ACVP_LOG_LVL
+/**
+ * @enum ACVP_LOG_LVL
  * @brief This enum defines the different log levels for
- * the ACVP client library
+ *        the ACVP client library. Each level also contains
+ *        the logging for the level below it.
+ *        Error level logging will only create output in case of failures.
+ *        Warning level logging will create output for situations where the user may want to intervene,
+ *        but are not neccessarily issues and running will continue.
+ *        Status level logging is the default and will include high-level information about the progress
+ *        of the test session and status of processing.
+ *        Info level logging contains more info about network activity, metadata processing, and login.
+ *        Verbose level logging is extensive and contains info about test groups and cases being run,
+ *        more network activity, and other information. This is excessive for most users.
  */
 typedef enum acvp_log_lvl {
     ACVP_LOG_LVL_NONE = 0,
@@ -43,40 +53,44 @@ typedef enum acvp_log_lvl {
     ACVP_LOG_LVL_MAX = ACVP_LOG_LVL_VERBOSE,
 } ACVP_LOG_LVL;
 
-/*! @struct ACVP_CTX
- *  @brief This opaque structure is used to maintain the state of a test session
- *         with an ACVP server.  A single instance of this context
- *         represents a test session with the ACVP server.  This context
- *         is used by the application layer to perform the steps to
- *         conduct a test.  These steps are:
+/**
+ * @struct ACVP_CTX
+ * @brief This opaque structure is used to maintain the state of a session with an ACVP server.
+ *        A single instance of this context represents a session with the ACVP server. A session
+ *        can consist of a regular test session, or various types of requests (like requesting a
+ *        metadata listing.) Largely, This context is used by the application layer to perform the
+ *        steps to conduct a test session. These steps are:
  *
- *         1. Create the context
- *         2. Specify the server hostname
- *         3. Specify the crypto algorithms to test
- *         4. Register with the ACVP server
- *         5. Commence the test with the server
- *         6. Check the test results
- *         7. Free the context
+ *        1. Create the context
+ *        2. Specify the server hostname
+ *        3. Specify the crypto algorithms to test
+ *        4. Register with the ACVP server
+ *        5. Commence the test with the server
+ *        6. Check the test results
+ *        7. Free the context
  */
 typedef struct acvp_ctx_t ACVP_CTX;
 
-/*! @struct ACVP_RESULT
- *  @brief This enum is used to indicate error conditions to the application
- *     layer. Most libacvp function will return a value from this enum.
+/**
+ * @enum ACVP_RESULT
+ * @brief This enum is used to indicate error conditions to the application
+ *        layer. Most libacvp function will return a value from this enum.
  */
 typedef enum acvp_result ACVP_RESULT;
 
 /*
- * These are the available symmetric algorithms that libacvp supports.  The application
- * layer will need to register one or more of these based on the capabilities
- * of the crypto module being validated.
+ * These are the available algorithms that libacvp supports. The application layer will need to
+ * register one or more of these based on the capabilities of the crypto module being validated.
+ * Libacvp may not support every desired algorithm; the list of all algorithms supported by the
+ * protocol itself can be found in the ACVP specification.
  *
  * **************** ALERT *****************
  * This enum must stay aligned with alg_tbl[] in acvp.c
  */
-/*! @struct ACVP_CIPHER
- *  @brief This enum lists the various algorithms supported by the ACVP
- *  library
+/**
+ * @enum ACVP_CIPHER
+ * @brief This enum lists the various algorithms supported by the ACVP
+ *        library
  */
 typedef enum acvp_cipher {
     ACVP_CIPHER_START = 0,
@@ -181,10 +195,10 @@ typedef enum acvp_cipher {
 } ACVP_CIPHER;
 
 
-/*
+/**
  * The following are sub-type algorithms which can be used within
  * algorithm specific code to avoid having to include all the
- * above enums in the case statements. 
+ * above enums in the case statements.
  *
  * To get the sub-type enum call the algorithm specific functions
  * in acvp.c such as acvp_get_aes_alg(CIPHER).
@@ -213,6 +227,7 @@ typedef enum acvp_alg_type_aes {
     ACVP_SUB_AES_GMAC
 } ACVP_SUB_AES;
 
+/** @enum ACVP_SUB_TDES */
 typedef enum acvp_alg_type_tdes {
     ACVP_SUB_TDES_ECB = ACVP_TDES_ECB,
     ACVP_SUB_TDES_CBC,
@@ -229,11 +244,13 @@ typedef enum acvp_alg_type_tdes {
     ACVP_SUB_TDES_KW
 } ACVP_SUB_TDES;
 
+/** @enum ACVP_SUB_CMAC */
 typedef enum acvp_alg_type_cmac {
     ACVP_SUB_CMAC_AES = ACVP_CMAC_AES,
     ACVP_SUB_CMAC_TDES
 } ACVP_SUB_CMAC;
 
+/** @enum ACVP_SUB_HMAC */
 typedef enum acvp_alg_type_hmac {
     ACVP_SUB_HMAC_SHA1 = ACVP_HMAC_SHA1,
     ACVP_SUB_HMAC_SHA2_224,
@@ -248,6 +265,7 @@ typedef enum acvp_alg_type_hmac {
     ACVP_SUB_HMAC_SHA3_512
 } ACVP_SUB_HMAC;
 
+/** @enum ACVP_SUB_HASH */
 typedef enum acvp_alg_type_hash {
     ACVP_SUB_HASH_SHA1 = ACVP_HASH_SHA1,
     ACVP_SUB_HASH_SHA2_224,
@@ -264,6 +282,7 @@ typedef enum acvp_alg_type_hash {
     ACVP_SUB_HASH_SHAKE_256
 } ACVP_SUB_HASH;
 
+/** @enum ACVP_SUB_DSA */
 typedef enum acvp_alg_type_dsa {
     ACVP_SUB_DSA_KEYGEN = ACVP_DSA_KEYGEN,
     ACVP_SUB_DSA_PQGGEN,
@@ -272,6 +291,7 @@ typedef enum acvp_alg_type_dsa {
     ACVP_SUB_DSA_SIGVER,
 } ACVP_SUB_DSA;
 
+/** @enum ACVP_SUB_RSA */
 typedef enum acvp_alg_type_rsa {
     ACVP_SUB_RSA_KEYGEN = ACVP_RSA_KEYGEN,
     ACVP_SUB_RSA_SIGGEN,
@@ -280,6 +300,7 @@ typedef enum acvp_alg_type_rsa {
     ACVP_SUB_RSA_SIGPRIM
 } ACVP_SUB_RSA;
 
+/** @enum ACVP_SUB_ECDSA */
 typedef enum acvp_alg_type_ecdsa {
     ACVP_SUB_ECDSA_KEYGEN = ACVP_ECDSA_KEYGEN,
     ACVP_SUB_ECDSA_KEYVER,
@@ -287,12 +308,14 @@ typedef enum acvp_alg_type_ecdsa {
     ACVP_SUB_ECDSA_SIGVER
 } ACVP_SUB_ECDSA;
 
+/** @enum ACVP_SUB_DRBG */
 typedef enum acvp_alg_type_drbg {
     ACVP_SUB_DRBG_HASH = ACVP_HASHDRBG,
     ACVP_SUB_DRBG_HMAC,
     ACVP_SUB_DRBG_CTR
 } ACVP_SUB_DRBG;
 
+/** @enum ACVP_SUB_KAS */
 typedef enum acvp_alg_type_kas {
     ACVP_SUB_KAS_ECC_CDH = ACVP_KAS_ECC_CDH,
     ACVP_SUB_KAS_ECC_COMP,
@@ -309,6 +332,7 @@ typedef enum acvp_alg_type_kas {
     ACVP_SUB_SAFE_PRIMES_KEYVER
 } ACVP_SUB_KAS;
 
+/** @enum ACVP_SUB_KDF */
 typedef enum acvp_alg_type_kdf {
     ACVP_SUB_KDF_TLS = ACVP_KDF135_TLS,
     ACVP_SUB_KDF_SNMP,
@@ -325,11 +349,12 @@ typedef enum acvp_alg_type_kdf {
 
 #define CIPHER_TO_ALG(alg2) (alg_tbl[cipher].alg.alg2)
 
-/*! @struct ACVP_PREREQ_ALG
- *  @brief This enum lists the prerequisities that are available
- *  to the library during registration. Whereas an ACVP_CIPHER may
- *  specify a certain mode or key size, the prereqs are more
- *  generic.
+/**
+ * @enum ACVP_PREREQ_ALG
+ * @brief This enum lists the prerequisities that are available
+ *        to the library during registration. Whereas an ACVP_CIPHER may
+ *        specify a certain mode or key size, the prereqs are more
+ *        generic.
  */
 typedef enum acvp_prereq_mode_t {
     ACVP_PREREQ_AES = 1,
@@ -347,9 +372,10 @@ typedef enum acvp_prereq_mode_t {
     ACVP_PREREQ_TDES
 } ACVP_PREREQ_ALG;
 
-/*! @struct ACVP_CONFORMANCE
- *  @brief this enum lists different conformances that can be claimed
- *  in libacvp. These are largely algorithm specific.
+/**
+ * @enum ACVP_CONFORMANCE
+ * @brief this enum lists different conformances that can be claimed
+ *        in libacvp. These are largely algorithm specific.
  */
 typedef enum acvp_conformance_t {
     ACVP_CONFORMANCE_DEFAULT = 0,
@@ -357,10 +383,9 @@ typedef enum acvp_conformance_t {
     ACVP_CONFORMANCE_MAX
 } ACVP_CONFORMANCE;
 
-/*!
+/**
  * @enum ACVP_HASH_ALG
- * @brief Represents the general hash algorithms.
- *        Can be used as bit flags.
+ * @brief Represents the general hash algorithms. Can be used as bit flags.
  */
 typedef enum acvp_hash_alg {
     ACVP_NO_SHA = 0,
@@ -378,13 +403,21 @@ typedef enum acvp_hash_alg {
     ACVP_HASH_ALG_MAX = 2048
 } ACVP_HASH_ALG;
 
-/*! @enum ACVP_TEST_DISPOSITION */
+/**
+ * @enum ACVP_TEST_DISPOSITION
+ * @brief These values are used to indicate the pass/fail status of a test session
+ */
 typedef enum acvp_test_disposition {
     ACVP_TEST_DISPOSITION_FAIL = 0,
     ACVP_TEST_DISPOSITION_PASS = 1
 } ACVP_TEST_DISPOSITION;
 
-/*! @struct ACVP_KDF135_SSH_METHOD */
+/*
+ * The following enumerators are used to track the capabiltiies that the application
+ * registers with the library and are used in data fields for some test cases.
+ */
+
+/** @enum ACVP_KDF135_SSH_METHOD */
 typedef enum acvp_kdf135_ssh_method {
     ACVP_SSH_METH_TDES_CBC = 1,
     ACVP_SSH_METH_AES_128_CBC,
@@ -393,7 +426,7 @@ typedef enum acvp_kdf135_ssh_method {
     ACVP_SSH_METH_MAX
 } ACVP_KDF135_SSH_METHOD;
 
-/*! @struct ACVP_KDF135_IKEV1_AUTH_METHOD */
+/** @enum ACVP_KDF135_IKEV1_AUTH_METHOD */
 typedef enum acvp_kdf135_ikev1_auth_method {
     ACVP_KDF135_IKEV1_AMETH_DSA = 1,
     ACVP_KDF135_IKEV1_AMETH_PSK,
@@ -401,7 +434,7 @@ typedef enum acvp_kdf135_ikev1_auth_method {
     ACVP_KDF135_IKEV1_AMETH_MAX
 } ACVP_KDF135_IKEV1_AUTH_METHOD;
 
-/*! @struct ACVP_KDF135_SRTP_PARAM */
+/** @enum ACVP_KDF135_SRTP_PARAM */
 typedef enum acvp_kdf135_srtp_param {
     ACVP_SRTP_AES_KEYLEN = 1,
     ACVP_SRTP_SUPPORT_ZERO_KDR,
@@ -411,14 +444,14 @@ typedef enum acvp_kdf135_srtp_param {
 #define ACVP_KDF108_KEYOUT_MAX 64     /**< SHA2-512 */
 #define ACVP_KDF108_FIXED_DATA_MAX 64 /**< SHA2-512 */
 
-/*! @struct ACVP_KDF108_MODE */
+/** @enum ACVP_KDF108_MODE */
 typedef enum acvp_kdf108_mode {
     ACVP_KDF108_MODE_COUNTER = 1,
     ACVP_KDF108_MODE_FEEDBACK,
     ACVP_KDF108_MODE_DPI
 } ACVP_KDF108_MODE;
 
-/*! @struct ACVP_KDF108_MAC_MODE_VAL */
+/** @enum ACVP_KDF108_MAC_MODE_VAL */
 typedef enum acvp_kdf108_mac_mode_val {
     ACVP_KDF108_MAC_MODE_MIN,
     ACVP_KDF108_MAC_MODE_CMAC_AES128,
@@ -433,7 +466,7 @@ typedef enum acvp_kdf108_mac_mode_val {
     ACVP_KDF108_MAC_MODE_MAX
 } ACVP_KDF108_MAC_MODE_VAL;
 
-/*! @struct ACVP_KDF108_FIXED_DATA_ORDER_VAL */
+/** @enum ACVP_KDF108_FIXED_DATA_ORDER_VAL */
 typedef enum acvp_kdf108_fixed_data_order_val {
     ACVP_KDF108_FIXED_DATA_ORDER_MIN,
     ACVP_KDF108_FIXED_DATA_ORDER_NONE,
@@ -444,7 +477,7 @@ typedef enum acvp_kdf108_fixed_data_order_val {
     ACVP_KDF108_FIXED_DATA_ORDER_MAX
 } ACVP_KDF108_FIXED_DATA_ORDER_VAL;
 
-/* @struct ACVP_HMAC_ALG_VAL */
+/* @enum ACVP_HMAC_ALG_VAL */
 typedef enum acvp_hmac_alg_val {
     ACVP_HMAC_ALG_MIN,
     ACVP_HMAC_ALG_SHA1,
@@ -461,7 +494,7 @@ typedef enum acvp_hmac_alg_val {
     ACVP_HMAC_ALG_MAX
 } ACVP_HMAC_ALG_VAL;
 
-/*! @struct ACVP_SYM_CIPH_KO */
+/** @enum ACVP_SYM_CIPH_KO */
 typedef enum acvp_sym_cipher_keying_option {
     ACVP_SYM_CIPH_KO_NA = 1,
     ACVP_SYM_CIPH_KO_THREE,
@@ -470,10 +503,9 @@ typedef enum acvp_sym_cipher_keying_option {
     ACVP_SYM_CIPH_KO_MAX
 } ACVP_SYM_CIPH_KO;
 
-/*!
- * @struct ACVP_SYM_CIPH_IVGEN_SRC
- * @brief The IV generation source for AEAD ciphers.
- * This can be internal, external, or not applicable.
+/**
+ * @enum ACVP_SYM_CIPH_IVGEN_SRC
+ * @brief The IV generation source for AEAD ciphers. This can be internal, external, or not applicable.
  */
 typedef enum acvp_sym_cipher_ivgen_source {
     ACVP_SYM_CIPH_IVGEN_SRC_INT = 1,
@@ -483,10 +515,9 @@ typedef enum acvp_sym_cipher_ivgen_source {
 } ACVP_SYM_CIPH_IVGEN_SRC;
 
 
-/*!
- * @struct ACVP_SYM_CIPH_SALT_SRC
- * @brief The IV generation source for AES_XPN
- * This can be internal, external, or not applicable.
+/**
+ * @enum ACVP_SYM_CIPH_SALT_SRC
+ * @brief The IV generation source for AES_XPN. This can be internal, external, or not applicable.
  */
 typedef enum acvp_sym_cipher_salt_source {
     ACVP_SYM_CIPH_SALT_SRC_INT = 1,
@@ -495,10 +526,9 @@ typedef enum acvp_sym_cipher_salt_source {
     ACVP_SYM_CIPH_SALT_SRC_MAX
 } ACVP_SYM_CIPH_SALT_SRC;
 
-/*!
- * @struct ACVP_SYM_CIPH_IVGEN_MODE
- * @brief The IV generation mode.  It can comply with 8.2.1,
- * 8.2.2, or may not be applicable for some ciphers.
+/**
+ * @enum ACVP_SYM_CIPH_IVGEN_MODE
+ * @brief The IV generation mode. It can comply with 8.2.1, 8.2.2, or may not be applicable for some ciphers.
  */
 typedef enum acvp_sym_cipher_ivgen_mode {
     ACVP_SYM_CIPH_IVGEN_MODE_821 = 1,
@@ -508,11 +538,10 @@ typedef enum acvp_sym_cipher_ivgen_mode {
 } ACVP_SYM_CIPH_IVGEN_MODE;
 
 
-/*!
- * @struct ACVP_SYM_CIPH_DIR
- * @brief These are the algorithm direction suppported by libacvp.
- * These are used in conjunction with ACVP_SYM_CIPH when registering the
- * crypto module capabilities with libacvp.
+/**
+ * @enum ACVP_SYM_CIPH_DIR
+ * @brief These are the algorithm direction suppported by libacvp. These are used in conjunction
+ *        with ACVP_SYM_CIPH when registering the crypto module capabilities with libacvp.
  */
 typedef enum acvp_sym_cipher_direction {
     ACVP_SYM_CIPH_DIR_ENCRYPT = 1,
@@ -521,13 +550,13 @@ typedef enum acvp_sym_cipher_direction {
     ACVP_SYM_CIPH_DIR_MAX
 } ACVP_SYM_CIPH_DIR;
 
-/*! @struct ACVP_KDF135_TLS_METHOD */
+/** @enum ACVP_KDF135_TLS_METHOD */
 typedef enum acvp_kdf135_tls_method {
     ACVP_KDF135_TLS10_TLS11 = 1,
     ACVP_KDF135_TLS12
 } ACVP_KDF135_TLS_METHOD;
 
-/*! @struct ACVP_KDF135_SNMP_PARAM */
+/** @enum ACVP_KDF135_SNMP_PARAM */
 typedef enum acvp_kdf135_snmp_param {
     ACVP_KDF135_SNMP_PASS_LEN,
     ACVP_KDF135_SNMP_ENGID
@@ -545,6 +574,8 @@ typedef enum acvp_kdf135_snmp_param {
 #define ACVP_STR_SHA3_384       "SHA3-384"
 #define ACVP_STR_SHA3_512       "SHA3-512"
 #define ACVP_STR_SHA_MAX        12
+
+/** @enum ACVP_HASH_PARM */
 typedef enum acvp_hash_param {
     ACVP_HASH_IN_BIT = 1,
     ACVP_HASH_IN_EMPTY,
@@ -557,7 +588,7 @@ typedef enum acvp_hash_param {
  * * **************** ALERT *****************
  * This enum must stay aligned with drbg_mode_tbl[] in acvp.c
  */
-/*! @struct ACVP_DRBG_MODE */
+/** @enum ACVP_DRBG_MODE */
 typedef enum acvp_drbg_mode {
     ACVP_DRBG_SHA_1 = 1,
     ACVP_DRBG_SHA_224,
@@ -572,7 +603,7 @@ typedef enum acvp_drbg_mode {
     ACVP_DRBG_AES_256
 } ACVP_DRBG_MODE;
 
-/*! @struct ACVP_DRBG_PARM */
+/** @enum ACVP_DRBG_PARM */
 typedef enum acvp_drbg_param {
     ACVP_DRBG_DER_FUNC_ENABLED = 0,
     ACVP_DRBG_PRED_RESIST_ENABLED,
@@ -585,7 +616,7 @@ typedef enum acvp_drbg_param {
     ACVP_DRBG_PRE_REQ_VALS
 } ACVP_DRBG_PARM;
 
-/*! @struct ACVP_RSA_PARM */
+/** @enum ACVP_RSA_PARM */
 typedef enum acvp_rsa_param {
     ACVP_RSA_PARM_PUB_EXP_MODE = 1,
     ACVP_RSA_PARM_FIXED_PUB_EXP_VAL,
@@ -594,24 +625,26 @@ typedef enum acvp_rsa_param {
     ACVP_RSA_PARM_INFO_GEN_BY_SERVER,
 } ACVP_RSA_PARM;
 
-/*! @struct ACVP_RSA_PRIME_PARAM */
+/** @enum ACVP_RSA_PRIME_PARAM */
 typedef enum acvp_rsa_prime_param {
     ACVP_RSA_PRIME_HASH_ALG = 1,
     ACVP_RSA_PRIME_TEST,
 } ACVP_RSA_PRIME_PARAM;
 
-/*! @struct ACVP_ECDSA_PARM */
+/** @enum ACVP_ECDSA_PARM */
 typedef enum acvp_ecdsa_param {
     ACVP_ECDSA_CURVE,
     ACVP_ECDSA_SECRET_GEN,
     ACVP_ECDSA_HASH_ALG
 } ACVP_ECDSA_PARM;
 
+/** @enum ACVP_ECDSA_SECRET_GEN_MODE */
 typedef enum acvp_ecdsa_secret_gen_mode {
     ACVP_ECDSA_SECRET_GEN_EXTRA_BITS = 1,
     ACVP_ECDSA_SECRET_GEN_TEST_CAND
 } ACVP_ECDSA_SECRET_GEN_MODE;
 
+/** @enum ACVP_EC_CURVE */
 typedef enum acvp_ec_curve {
     ACVP_EC_CURVE_START = 0,
     ACVP_EC_CURVE_P192,
@@ -632,6 +665,7 @@ typedef enum acvp_ec_curve {
     ACVP_EC_CURVE_END
 } ACVP_EC_CURVE;
 
+/** @enum ACVP_KDF135_IKEV2_PARM */
 typedef enum acvp_kdf135_ikev2_param {
     ACVP_KDF_HASH_ALG,
     ACVP_INIT_NONCE_LEN,
@@ -640,6 +674,7 @@ typedef enum acvp_kdf135_ikev2_param {
     ACVP_KEY_MATERIAL_LEN
 } ACVP_KDF135_IKEV2_PARM;
 
+/** @enum ACVP_KDF135_IKEV1_PARM */
 typedef enum acvp_kdf135_ikev1_param {
     ACVP_KDF_IKEv1_HASH_ALG,
     ACVP_KDF_IKEv1_AUTH_METHOD,
@@ -649,6 +684,7 @@ typedef enum acvp_kdf135_ikev1_param {
     ACVP_KDF_IKEv1_PSK_LEN
 } ACVP_KDF135_IKEV1_PARM;
 
+/** @enum ACVP_KDF135_X963_PARM */
 typedef enum acvp_kdf135_x963_param {
     ACVP_KDF_X963_HASH_ALG,
     ACVP_KDF_X963_KEY_DATA_LEN,
@@ -656,6 +692,7 @@ typedef enum acvp_kdf135_x963_param {
     ACVP_KDF_X963_SHARED_INFO_LEN
 } ACVP_KDF135_X963_PARM;
 
+/** @enum ACVP_KDF108_PARM */
 typedef enum acvp_kdf108_param {
     ACVP_KDF108_PARAM_MIN,
     ACVP_KDF108_KDF_MODE,
@@ -668,6 +705,7 @@ typedef enum acvp_kdf108_param {
     ACVP_KDF108_PARAM_MAX
 } ACVP_KDF108_PARM;
 
+/** @enum ACVP_PBKDF_PARM */
 typedef enum acvp_pbkdf_param {
     ACVP_PBKDF_PARAM_MIN,
     ACVP_PBKDF_ITERATION_COUNT,
@@ -677,6 +715,7 @@ typedef enum acvp_pbkdf_param {
     ACVP_PBKDF_HMAC_ALG
 } ACVP_PBKDF_PARM;
 
+/** @enum ACVP_KDF_TLS13_RUN_MODE */
 typedef enum acvp_kdf_tls13_running_mode {
     ACVP_KDF_TLS13_RUN_MODE_MIN,
     ACVP_KDF_TLS13_RUN_MODE_PSK,
@@ -685,31 +724,32 @@ typedef enum acvp_kdf_tls13_running_mode {
     ACVP_KDF_TLS13_RUN_MODE_MAX
 } ACVP_KDF_TLS13_RUN_MODE;
 
+/** @enum ACVP_KDF_TLS13_PARM */
 typedef enum acvp_kdf_tls13_param {
     ACVP_KDF_TLS13_PARAM_MIN,
     ACVP_KDF_TLS13_HMAC_ALG,
     ACVP_KDF_TLS13_RUNNING_MODE
 } ACVP_KDF_TLS13_PARM;
 
-/*! @struct ACVP_RSA_KEY_FORMAT */
+/** @enum ACVP_RSA_KEY_FORMAT */
 typedef enum acvp_rsa_key_format {
     ACVP_RSA_KEY_FORMAT_STANDARD = 1, /**< Standard */
     ACVP_RSA_KEY_FORMAT_CRT           /**< Chinese Remainder Theorem */
 } ACVP_RSA_KEY_FORMAT;
 
-/*! @struct ACVP_RSA_PUB_EXP_MODE */
+/** @enum ACVP_RSA_PUB_EXP_MODE */
 typedef enum acvp_rsa_pub_exp_mode {
     ACVP_RSA_PUB_EXP_MODE_FIXED = 1,
     ACVP_RSA_PUB_EXP_MODE_RANDOM
 } ACVP_RSA_PUB_EXP_MODE;
 
-/*! @struct ACVP_RSA_PRIME_TEST_TYPE */
+/** @enum ACVP_RSA_PRIME_TEST_TYPE */
 typedef enum acvp_rsa_prime_test_type {
     ACVP_RSA_PRIME_TEST_TBLC2 = 1,
     ACVP_RSA_PRIME_TEST_TBLC3
 } ACVP_RSA_PRIME_TEST_TYPE;
 
-/*! @struct ACVP_RSA_KEYGEN_MODE */
+/** @enum ACVP_RSA_KEYGEN_MODE */
 typedef enum acvp_rsa_keygen_mode_t {
     ACVP_RSA_KEYGEN_B32 = 1,
     ACVP_RSA_KEYGEN_B33,
@@ -718,18 +758,29 @@ typedef enum acvp_rsa_keygen_mode_t {
     ACVP_RSA_KEYGEN_B36
 } ACVP_RSA_KEYGEN_MODE;
 
-/*! @struct ACVP_RSA_SIG_TYPE */
+/** @enum ACVP_RSA_SIG_TYPE */
 typedef enum acvp_rsa_sig_type {
     ACVP_RSA_SIG_TYPE_X931 = 1,
     ACVP_RSA_SIG_TYPE_PKCS1V15,
     ACVP_RSA_SIG_TYPE_PKCS1PSS
 } ACVP_RSA_SIG_TYPE;
 
+/** @enum ACVP_RSA_PRIM_KEYFORMAT */
 typedef enum acvp_rsa_prim_keyformat {
     ACVP_RSA_PRIM_KEYFORMAT_STANDARD = 1,
     ACVP_RSA_PRIM_KEYFORMAT_CRT
 } ACVP_RSA_PRIM_KEYFORMAT;
 
+/**
+ * @struct ACVP_RSA_PRIM_TC
+ * @brief This struct holds data that represents a single test case for a RSA primitive cipher.
+ *        This data is passed between libacvp and the crypto module. libacvp will parse the test
+ *        case parameters from the JSON encoded test vector, fill in this structure, and pass the
+ *        struct to the crypto module via the handler that was registered with libacvp. The crypto
+ *        module will then need to perform the crypto operation and fill in the remaining tems in
+ *        the struct for the given test case. The struct is then passed back to libacvp, where it
+ *        is then used to build the JSON encoded vector response.
+ */
 typedef struct acvp_rsa_prim_tc_t {
     unsigned int tc_id;    /* Test case id */
     unsigned char *cipher;
@@ -756,7 +807,7 @@ typedef struct acvp_rsa_prim_tc_t {
 } ACVP_RSA_PRIM_TC;
 
 
-/*! @struct ACVP_SYM_CIPHER_PARM */
+/** @enum ACVP_SYM_CIPHER_PARM */
 typedef enum acvp_sym_cipher_parameter {
     ACVP_SYM_CIPH_KEYLEN = 1,
     ACVP_SYM_CIPH_TAGLEN,
@@ -777,21 +828,21 @@ typedef enum acvp_sym_cipher_parameter {
 } ACVP_SYM_CIPH_PARM;
 
 
-/*! @struct ACVP_SYM_CIPHER_DOMAIN_PARM */
+/** @enum ACVP_SYM_CIPHER_DOMAIN_PARM */
 typedef enum acvp_sym_cipher_domain_parameter {
     ACVP_SYM_CIPH_DOMAIN_IVLEN = 1,
     ACVP_SYM_CIPH_DOMAIN_PTLEN,
     ACVP_SYM_CIPH_DOMAIN_AADLEN
 } ACVP_SYM_CIPH_DOMAIN_PARM;
 
-/*! @struct ACVP_SYM_CIPH_TWEAK_MODE */
+/** @enum ACVP_SYM_CIPH_TWEAK_MODE */
 typedef enum acvp_sym_xts_tweak_mode {
     ACVP_SYM_CIPH_TWEAK_HEX = 1,
     ACVP_SYM_CIPH_TWEAK_NUM,
     ACVP_SYM_CIPH_TWEAK_NONE
 } ACVP_SYM_CIPH_TWEAK_MODE;
 
-/*! @struct ACVP_SYM_KW_MODE */
+/** @enum ACVP_SYM_KW_MODE */
 typedef enum acvp_sym_kw_mode {
     ACVP_SYM_KW_NONE = 0,
     ACVP_SYM_KW_CIPHER,
@@ -799,7 +850,7 @@ typedef enum acvp_sym_kw_mode {
     ACVP_SYM_KW_MAX
 } ACVP_SYM_KW_MODE;
 
-/*! @struct ACVP_SYM_CIPH_TESTTYPE */
+/** @enum ACVP_SYM_CIPH_TESTTYPE */
 typedef enum acvp_sym_cipher_testtype {
     ACVP_SYM_TEST_TYPE_NONE = 0,
     ACVP_SYM_TEST_TYPE_AFT,
@@ -807,7 +858,7 @@ typedef enum acvp_sym_cipher_testtype {
     ACVP_SYM_TEST_TYPE_MCT
 } ACVP_SYM_CIPH_TESTTYPE;
 
-/*! @struct ACVP_HASH_TESTTYPE */
+/** @enum ACVP_HASH_TESTTYPE */
 typedef enum acvp_hash_testtype {
     ACVP_HASH_TEST_TYPE_NONE = 0,
     ACVP_HASH_TEST_TYPE_AFT,
@@ -815,32 +866,32 @@ typedef enum acvp_hash_testtype {
     ACVP_HASH_TEST_TYPE_VOT
 } ACVP_HASH_TESTTYPE;
 
-/*! @struct ACVP_CMAC_TESTTYPE */
+/** @enum ACVP_CMAC_TESTTYPE */
 typedef enum acvp_cmac_testtype {
     ACVP_CMAC_TEST_TYPE_NONE = 0,
     ACVP_CMAC_TEST_TYPE_AFT
 } ACVP_CMAC_TESTTYPE;
 
-/*! @struct ACVP_PBKDF_TESTTYPE */
+/** @enum ACVP_PBKDF_TESTTYPE */
 typedef enum acvp_pbkdf_testtype {
     ACVP_PBKDF_TEST_TYPE_NONE = 0,
     ACVP_PBKDF_TEST_TYPE_AFT
 } ACVP_PBKDF_TESTTYPE;
 
-/*! @struct ACVP_KDF_TLS13_TESTTYPE */
+/** @enum ACVP_KDF_TLS13_TESTTYPE */
 typedef enum acvp_kdf_tls13_testtype {
     ACVP_KDF_TLS13_TEST_TYPE_NONE = 0,
     ACVP_KDF_TLS13_TEST_TYPE_AFT
 } ACVP_KDF_TLS13_TESTTYPE;
 
-/*! @struct ACVP_HMAC_PARM */
+/** @enum ACVP_HMAC_PARM */
 typedef enum acvp_hmac_parameter {
     ACVP_HMAC_KEYLEN = 1,
     ACVP_HMAC_KEYBLOCK,
     ACVP_HMAC_MACLEN
 } ACVP_HMAC_PARM;
 
-/*! @struct ACVP_CMAC_PARM */
+/** @enum ACVP_CMAC_PARM */
 typedef enum acvp_cmac_parameter {
     ACVP_CMAC_MACLEN,
     ACVP_CMAC_MSGLEN,
@@ -850,6 +901,7 @@ typedef enum acvp_cmac_parameter {
     ACVP_CMAC_DIRECTION_VER
 } ACVP_CMAC_PARM;
 
+/** @enum ACVP_CMAC_KEY_ATTR */
 typedef enum acvp_cmac_keylen {
     ACVP_CMAC_KEYING_OPTION_1 = 1,
     ACVP_CMAC_KEYING_OPTION_2 = 2,
@@ -858,7 +910,7 @@ typedef enum acvp_cmac_keylen {
     ACVP_CMAC_KEYLEN_256 = 256
 } ACVP_CMAC_KEY_ATTR;
 
-/*! @enum ACVP_CMAC_TDES_KEYING_OPTION */
+/** @enum ACVP_CMAC_TDES_KEYING_OPTION */
 typedef enum acvp_cmac_tdes_keying_option {
     ACVP_CMAC_TDES_KEYING_OPTION_MIN = 0,
     ACVP_CMAC_TDES_KEYING_OPTION_1,
@@ -866,7 +918,7 @@ typedef enum acvp_cmac_tdes_keying_option {
     ACVP_CMAC_TDES_KEYING_OPTION_MAX
 } ACVP_CMAC_TDES_KEYING_OPTION;
 
-/*! @struct ACVP_CMAC_MSG_LEN_INDEX */
+/** @enum ACVP_CMAC_MSG_LEN_INDEX */
 typedef enum acvp_cmac_msg_len_index {
     CMAC_BLK_DIVISIBLE_1 = 0,
     CMAC_BLK_DIVISIBLE_2,
@@ -876,18 +928,15 @@ typedef enum acvp_cmac_msg_len_index {
     CMAC_MSG_LEN_NUM_ITEMS
 } ACVP_CMAC_MSG_LEN_INDEX;
 
-/*!
+/**
  * @struct ACVP_SYM_CIPHER_TC
- * @brief This struct holds data that represents a single test case for
- * a symmetric cipher, such as AES or DES.  This data is passed
- * between libacvp and the crypto module.  libacvp will parse the test
- * case parameters from the JSON encoded test vector, fill in this
- * structure, and pass the struct to the crypto module via the
- * handler that was registered with libacvp.  The crypto module will
- * then need to perform the crypto operation and fill in the remaining
- * items in the struct for the given test case.  The struct is then
- * passed back to libacvp, where it is then used to build the JSON
- * encoded vector response.
+ * @brief This struct holds data that represents a single test case for a symmetric cipher, such as
+ *        AES or DES. This data is passed between libacvp and the crypto module. libacvp will
+ *        parse the test case parameters from the JSON encoded test vector, fill in this structure,
+ *        and pass the struct to the crypto module via the handler that was registered with
+ *        libacvp. The crypto module will then need to perform the crypto operation and fill in
+ *        the remaining items in the struct for the given test case. The struct is then passed back
+ *        to libacvp, where it is then used to build the JSON encoded vector response.
  */
 typedef struct acvp_sym_cipher_tc_t {
     ACVP_CIPHER cipher;
@@ -909,7 +958,7 @@ typedef struct acvp_sym_cipher_tc_t {
     unsigned char *salt;         /* For use with AES-XPN */
     ACVP_SYM_KW_MODE kwcipher;
     ACVP_SYM_CIPH_TWEAK_MODE tw_mode;
-    unsigned int seq_num;     
+    unsigned int seq_num;
     unsigned int key_len;
     unsigned int pt_len;
     unsigned int data_len;
@@ -923,24 +972,10 @@ typedef struct acvp_sym_cipher_tc_t {
     unsigned int ovrflw_ctr;
 } ACVP_SYM_CIPHER_TC;
 
-/*!
- * @struct ACVP_ENTROPY_TC
- * @brief This struct holds data that represents a single test
- * case for entropy testing. This data is
- * passed between libacvp and the crypto module.
- */
-typedef struct acvp_entropy_tc_t {
-    ACVP_CIPHER cipher;
-    unsigned int tc_id;    /* Test case id */
-    unsigned int entropy_len;
-    unsigned char *entropy_data;
-} ACVP_ENTROPY_TC;
-
-/*!
+/**
  * @struct ACVP_HASH_TC
- * @brief This struct holds data that represents a single test case
- * for hash testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for hash testing. This data is
+ *        passed between libacvp and the crypto module.
  */
 typedef struct acvp_hash_tc_t {
     ACVP_CIPHER cipher;
@@ -968,11 +1003,10 @@ typedef struct acvp_hash_tc_t {
                               SUPPLIED BY USER */
 } ACVP_HASH_TC;
 
-/*!
+/**
  * @struct ACVP_KDF135_TLS_TC
- * @brief This struct holds data that represents a single test
- * case for kdf135 TLS testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for kdf135 TLS testing. This
+ *        data is passed between libacvp and the crypto module.
  */
 typedef struct acvp_kdf135_tls_tc_t {
     ACVP_CIPHER cipher;
@@ -996,11 +1030,10 @@ typedef struct acvp_kdf135_tls_tc_t {
     int c_rnd_len;
 } ACVP_KDF135_TLS_TC;
 
-/*!
+/**
  * @struct ACVP_KDF135_IKEV2_TC
- * This struct holds data that represents a single test case
- * for kdf135 IKEV2 testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for kdf135 IKEV2 testing. This
+ *        data is passed between libacvp and the crypto module.
  */
 typedef struct acvp_kdf135_ikev2_tc_t {
     ACVP_CIPHER cipher;
@@ -1028,11 +1061,10 @@ typedef struct acvp_kdf135_ikev2_tc_t {
     int key_out_len;
 } ACVP_KDF135_IKEV2_TC;
 
-/*!
+/**
  * @struct ACVP_KDF135_IKEV1_TC
- * @brief This struct holds data that represents a single test case
- * for kdf135 IKEV1 testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for kdf135 IKEV1 testing. This
+ *        data is passed between libacvp and the crypto module.
  */
 typedef struct acvp_kdf135_ikev1_tc_t {
     ACVP_CIPHER cipher;
@@ -1060,11 +1092,10 @@ typedef struct acvp_kdf135_ikev1_tc_t {
     int s_key_id_e_len;
 } ACVP_KDF135_IKEV1_TC;
 
-/*!
+/**
  * @struct ACVP_KDF135_SNMP_TC
- * @brief This struct holds data that represents a single test
- * case for kdf135 SNMP testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for kdf135 SNMP testing. This
+ *        data is passed between libacvp and the crypto module.
  */
 typedef struct acvp_kdf135_snmp_tc_t {
     ACVP_CIPHER cipher;
@@ -1077,11 +1108,10 @@ typedef struct acvp_kdf135_snmp_tc_t {
     unsigned int skey_len;
 } ACVP_KDF135_SNMP_TC;
 
-/*!
+/**
  * @struct ACVP_KDF135_X963_TC
- * @brief This struct holds data that represents a single test
- * case for kdf135 TPM testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for kdf135 TPM testing. This
+ *        data is passed between libacvp and the crypto module.
  */
 typedef struct acvp_kdf135_x963_tc_t {
     ACVP_CIPHER cipher;
@@ -1096,11 +1126,10 @@ typedef struct acvp_kdf135_x963_tc_t {
 } ACVP_KDF135_X963_TC;
 
 
-/*!
+/**
  * @struct ACVP_KDF108_TC
- * @brief This struct holds data that represents a single test
- * case for kdf108 testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for kdf108 testing. This
+ *        data is passed between libacvp and the crypto module.
  */
 typedef struct acvp_kdf108_tc_t {
     ACVP_CIPHER cipher;
@@ -1122,11 +1151,10 @@ typedef struct acvp_kdf108_tc_t {
     int deferred;
 } ACVP_KDF108_TC;
 
-/*!
+/**
  * @struct ACVP_KDF135_SRTP_TC
- * @brief This struct holds data that represents a single test
- * case for kdf135 SRTP testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for kdf135 SRTP testing. This
+ *        data is passed between libacvp and the crypto module.
  */
 typedef struct acvp_kdf135_srtp_tc_t {
     ACVP_CIPHER cipher;
@@ -1147,11 +1175,10 @@ typedef struct acvp_kdf135_srtp_tc_t {
     unsigned char *srtcp_ks;
 } ACVP_KDF135_SRTP_TC;
 
-/*!
+/**
  * @struct ACVP_KDF135_SSH_TC
- * @brief This struct holds data that represents a single test
- * case for kdf135 SSH testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for kdf135 SSH testing. This
+ *        data is passed between libacvp and the crypto module.
  */
 typedef struct acvp_kdf135_ssh_tc_t {
     ACVP_CIPHER cipher;
@@ -1180,11 +1207,10 @@ typedef struct acvp_kdf135_ssh_tc_t {
                                           ---User supplied--- */
 } ACVP_KDF135_SSH_TC;
 
-/*!
+/**
  * @struct ACVP_PBKDF_TC
- * @brief This struct holds data that represents a single test
- * case for pbkdf testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for pbkdf testing. This data is
+ *        passed between libacvp and the crypto module.
  */
 typedef struct acvp_pbkdf_tc_t {
     ACVP_CIPHER cipher;
@@ -1201,11 +1227,10 @@ typedef struct acvp_pbkdf_tc_t {
                                            ---User supplied--- */
 } ACVP_PBKDF_TC;
 
-/*!
+/**
  * @struct ACVP_KDF_TLS13_TC
- * @brief This struct holds data that represents a single test
- * case for TLS 1.3 KDF testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for TLS 1.3 KDF testing. This
+ *        data is passed between libacvp and the crypto module.
  */
 typedef struct acvp_kdf_tls13_tc_t {
     ACVP_CIPHER cipher;
@@ -1250,11 +1275,10 @@ typedef struct acvp_kdf_tls13_tc_t {
 
 } ACVP_KDF_TLS13_TC;
 
-/*!
+/**
  * @struct ACVP_HMAC_TC
- * @brief This struct holds data that represents a single
- * test case for HMAC testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for HMAC testing. This data is
+ *        passed between libacvp and the crypto module.
  */
 typedef struct acvp_hmac_tc_t {
     ACVP_CIPHER cipher;
@@ -1267,11 +1291,10 @@ typedef struct acvp_hmac_tc_t {
     unsigned char *key;
 } ACVP_HMAC_TC;
 
-/*!
+/**
  * @struct ACVP_CMAC_TC
- * @brief This struct holds data that represents a single
- * test case for CMAC testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for CMAC testing. This data is
+ *        passed between libacvp and the crypto module.
  */
 typedef struct acvp_cmac_tc_t {
     ACVP_CIPHER cipher;
@@ -1291,12 +1314,11 @@ typedef struct acvp_cmac_tc_t {
     unsigned char *key3;
 } ACVP_CMAC_TC;
 
-/*!
+/**
  * @struct ACVP_RSA_KEYGEN_TC
- * @brief This struct holds data that represents a single
- * test case for RSA keygen testing. The other modes of RSA
- * have their own respective structs. This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for RSA keygen testing. The
+ *        other modes of RSA have their own respective structs. This data is passed between
+ *        libacvp and the crypto module.
  */
 typedef struct acvp_rsa_keygen_tc_t {
     unsigned int tc_id;    /* Test case id */
@@ -1352,11 +1374,10 @@ typedef struct acvp_rsa_keygen_tc_t {
     int xp2_len;
 } ACVP_RSA_KEYGEN_TC;
 
-/*!
+/**
  * @struct ACVP_ECDSA_TC
- * @brief This struct holds data that represents a single
- * test case for ECDSA testing. This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for ECDSA testing. This data is
+ *        passed between libacvp and the crypto module.
  */
 typedef struct acvp_ecdsa_tc_t {
     unsigned int tc_id;    /* Test case id */
@@ -1385,12 +1406,11 @@ typedef struct acvp_ecdsa_tc_t {
     int msg_len;
 } ACVP_ECDSA_TC;
 
-/*!
+/**
  * @struct ACVP_RSA_SIG_TC
- * @brief This struct holds data that represents a single
- * test case for RSA signature testing. Both siggen and sigver
- * use this struct in their testing. This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for RSA signature testing. Both
+ *        siggen and sigver use this struct in their testing. This data is  passed between libacvp
+ *        and the crypto module.
  */
 typedef struct acvp_rsa_sig_tc_t {
     unsigned int tc_id; /* Test case id */
@@ -1414,7 +1434,7 @@ typedef struct acvp_rsa_sig_tc_t {
     ACVP_TEST_DISPOSITION ver_disposition; /**< Indicates pass/fail (only in "verify" direction)*/
 } ACVP_RSA_SIG_TC;
 
-/*! @struct ACVP_DSA_MODE */
+/** @enum ACVP_DSA_MODE */
 typedef enum acvp_dsa_mode {
     ACVP_DSA_MODE_KEYGEN = 1,
     ACVP_DSA_MODE_PQGGEN,
@@ -1423,7 +1443,7 @@ typedef enum acvp_dsa_mode {
     ACVP_DSA_MODE_SIGVER
 } ACVP_DSA_MODE;
 
-/*! @struct ACVP_DSA_PARM */
+/** @enum ACVP_DSA_PARM */
 typedef enum acvp_dsa_parm {
     ACVP_DSA_LN2048_224 = 1,
     ACVP_DSA_LN2048_256,
@@ -1432,7 +1452,7 @@ typedef enum acvp_dsa_parm {
     ACVP_DSA_GENG
 } ACVP_DSA_PARM;
 
-/*! @struct ACVP_DSA_GEN_PARM */
+/** @enum ACVP_DSA_GEN_PARM */
 typedef enum acvp_dsa_gen_parm {
     ACVP_DSA_PROVABLE = 1,
     ACVP_DSA_PROBABLE,
@@ -1440,13 +1460,11 @@ typedef enum acvp_dsa_gen_parm {
     ACVP_DSA_UNVERIFIABLE
 } ACVP_DSA_GEN_PARM;
 
-/*!
+/**
  * @struct ACVP_DSA_TC
- * @brief This struct holds data that represents a single test
- * case for DSA testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for DSA testing. This data is
+ *        passed between libacvp and the crypto module.
  */
-/*! @struct ACVP_DSA_TC */
 typedef struct acvp_dsa_tc_t {
     int tg_id;
     int tc_id;
@@ -1483,7 +1501,7 @@ typedef struct acvp_dsa_tc_t {
     unsigned char *msg;
 } ACVP_DSA_TC;
 
-/*! @struct ACVP_KAS_ECC_MODE */
+/** @enum ACVP_KAS_ECC_MODE */
 typedef enum acvp_kas_ecc_mode {
     ACVP_KAS_ECC_MODE_COMPONENT = 1,
     ACVP_KAS_ECC_MODE_CDH,
@@ -1492,7 +1510,7 @@ typedef enum acvp_kas_ecc_mode {
     ACVP_KAS_ECC_MAX_MODES
 } ACVP_KAS_ECC_MODE;
 
-/*! @struct ACVP_KAS_ECC_FUNC */
+/** @enum ACVP_KAS_ECC_FUNC */
 typedef enum acvp_kas_ecc_func {
     ACVP_KAS_ECC_FUNC_PARTIAL = 1,
     ACVP_KAS_ECC_FUNC_DPGEN,
@@ -1503,7 +1521,7 @@ typedef enum acvp_kas_ecc_func {
     ACVP_KAS_ECC_MAX_FUNCS
 } ACVP_KAS_ECC_FUNC;
 
-/*! @struct ACVP_KAS_ECC_PARAM */
+/** @enum ACVP_KAS_ECC_PARAM */
 typedef enum acvp_kas_ecc_param {
     ACVP_KAS_ECC_FUNCTION = 1,
     ACVP_KAS_ECC_CURVE,
@@ -1517,13 +1535,13 @@ typedef enum acvp_kas_ecc_param {
     ACVP_KAS_ECC_NONE
 } ACVP_KAS_ECC_PARAM;
 
-/*! @struct ACVP_KAS_ECC_ROLE */
+/** @enum ACVP_KAS_ECC_ROLE */
 typedef enum acvp_kas_ecc_roles {
     ACVP_KAS_ECC_ROLE_INITIATOR = 1,
     ACVP_KAS_ECC_ROLE_RESPONDER
 } ACVP_KAS_ECC_ROLES;
 
-/*! @struct ACVP_KAS_ECC_SET */
+/** @enum ACVP_KAS_ECC_SET */
 typedef enum acvp_kas_ecc_set {
     ACVP_KAS_ECC_NOKDFNOKC = 1,
     ACVP_KAS_ECC_KDFNOKC,
@@ -1531,7 +1549,7 @@ typedef enum acvp_kas_ecc_set {
     ACVP_KAS_ECC_PARMSET
 } ACVP_KAS_ECC_SET;
 
-/*! @struct ACVP_KAS_ECC_SCHEMES */
+/** @enum ACVP_KAS_ECC_SCHEMES */
 typedef enum acvp_kas_ecc_schemes {
     ACVP_KAS_ECC_EPHEMERAL_UNIFIED = 1,
     ACVP_KAS_ECC_FULL_MQV,
@@ -1543,19 +1561,17 @@ typedef enum acvp_kas_ecc_schemes {
     ACVP_KAS_ECC_SCHEMES_MAX
 } ACVP_KAS_ECC_SCHEMES;
 
-/*! @struct ACVP_KAS_ECC_TEST_TYPE */
+/** @enum ACVP_KAS_ECC_TEST_TYPE */
 typedef enum acvp_kas_ecc_test_type {
     ACVP_KAS_ECC_TT_AFT = 1,
     ACVP_KAS_ECC_TT_VAL
 } ACVP_KAS_ECC_TEST_TYPE;
 
-/*!
+/**
  * @struct ACVP_KAS_ECC_TC
- * @brief This struct holds data that represents a single test
- * case for KAS-ECC testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for KAS-ECC testing. This data
+ *        is passed between libacvp and the crypto module.
  */
-/*! @struct ACVP_KAS_ECC_TC */
 typedef struct acvp_kas_ecc_tc_t {
     ACVP_CIPHER cipher;
     ACVP_KAS_ECC_FUNC func;
@@ -1579,7 +1595,7 @@ typedef struct acvp_kas_ecc_tc_t {
     int chashlen;
 } ACVP_KAS_ECC_TC;
 
-/*! @struct ACVP_KAS_FFC_MODE */
+/** @enum ACVP_KAS_FFC_MODE */
 typedef enum acvp_kas_ffc_mode {
     ACVP_KAS_FFC_MODE_COMPONENT = 1,
     ACVP_KAS_FFC_MODE_NOCOMP,
@@ -1587,7 +1603,7 @@ typedef enum acvp_kas_ffc_mode {
     ACVP_KAS_FFC_MAX_MODES
 } ACVP_KAS_FFC_MODE;
 
-/*! @struct ACVP_KAS_FFC_SCHEMES */
+/** @enum ACVP_KAS_FFC_SCHEMES */
 typedef enum acvp_kas_ffc_schemes {
     ACVP_KAS_FFC_DH_EPHEMERAL = 1,
     ACVP_KAS_FFC_DH_HYBRID1,
@@ -1599,7 +1615,7 @@ typedef enum acvp_kas_ffc_schemes {
     ACVP_KAS_FFC_MAX_SCHEMES
 } ACVP_KAS_FFC_SCHEMES;
 
-/*! @struct ACVP_KAS_FFC_FUNC */
+/** @enum ACVP_KAS_FFC_FUNC */
 typedef enum acvp_kas_ffc_func {
     ACVP_KAS_FFC_FUNC_DPGEN = 1,
     ACVP_KAS_FFC_FUNC_DPVAL,
@@ -1609,7 +1625,7 @@ typedef enum acvp_kas_ffc_func {
     ACVP_KAS_FFC_MAX_FUNCS
 } ACVP_KAS_FFC_FUNC;
 
-/*! @struct ACVP_KAS_FFC_PARAM */
+/** @enum ACVP_KAS_FFC_PARAM */
 typedef enum acvp_kas_ffc_param {
     ACVP_KAS_FFC_FUNCTION = 1,
     ACVP_KAS_FFC_CURVE,
@@ -1631,13 +1647,13 @@ typedef enum acvp_kas_ffc_param {
     ACVP_KAS_FFC_FFDHE8192
 } ACVP_KAS_FFC_PARAM;
 
-/*! @struct ACVP_KAS_FFC_ROLE */
+/** @enum ACVP_KAS_FFC_ROLE */
 typedef enum acvp_kas_ffc_roles {
     ACVP_KAS_FFC_ROLE_INITIATOR = 1,
     ACVP_KAS_FFC_ROLE_RESPONDER
 } ACVP_KAS_FFC_ROLES;
 
-/*! @struct ACVP_KAS_FFC_SET */
+/** @enum ACVP_KAS_FFC_SET */
 typedef enum acvp_kas_ffc_set {
     ACVP_KAS_FFC_NOKDFNOKC = 1,
     ACVP_KAS_FFC_KDFNOKC,
@@ -1645,19 +1661,17 @@ typedef enum acvp_kas_ffc_set {
     ACVP_KAS_FFC_PARMSET
 } ACVP_KAS_FFC_SET;
 
-/*! @struct ACVP_KAS_FFC_TEST_TYPE */
+/** @enum ACVP_KAS_FFC_TEST_TYPE */
 typedef enum acvp_kas_ffc_test_type {
     ACVP_KAS_FFC_TT_AFT = 1,
     ACVP_KAS_FFC_TT_VAL
 } ACVP_KAS_FFC_TEST_TYPE;
 
-/*!
+/**
  * @struct ACVP_KAS_FFC_TC
- * @brief This struct holds data that represents a single test
- * case for KAS-FFC testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for KAS-FFC testing. This data
+ *        is passed between libacvp and the crypto module.
  */
-/*! @struct ACVP_KAS_FFC_TC */
 #define DGM_STR_MAX 9
 
 typedef struct acvp_kas_ffc_tc_t {
@@ -1688,12 +1702,12 @@ typedef struct acvp_kas_ffc_tc_t {
     int piutlen;
 } ACVP_KAS_FFC_TC;
 
-/*! @struct ACVP_SAFE_PRIMES_PARAM */
+/** @enum ACVP_SAFE_PRIMES_PARAM */
 typedef enum acvp_safe_primes_param {
     ACVP_SAFE_PRIMES_GENMETH = 1,
 } ACVP_SAFE_PRIMES_PARAM;
 
-/*! @struct ACVP_SAFE_PRIMES_MODE */
+/** @enum ACVP_SAFE_PRIMES_MODE */
 typedef enum acvp_safe_primes_mode {
     ACVP_SAFE_PRIMES_MODP2048 = 1,
     ACVP_SAFE_PRIMES_MODP3072,
@@ -1707,19 +1721,17 @@ typedef enum acvp_safe_primes_mode {
     ACVP_SAFE_PRIMES_FFDHE8192
 } ACVP_SAFE_PRIMES_MODE;
 
-/*! @struct ACVP_SAFE_PRIMES_TEST_TYPE */
+/** @enum ACVP_SAFE_PRIMES_TEST_TYPE */
 typedef enum acvp_safe_primes_test_type {
     ACVP_SAFE_PRIMES_TT_AFT = 1,
     ACVP_SAFE_PRIMES_TT_VAL
 } ACVP_SAFE_PRIMES_TEST_TYPE;
 
-/*!
+/**
  * @struct ACVP_SAFE_PRIMES_TC
- * @brief This struct holds data that represents a single test
- * case for SAFE PRIMES testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for safe primes testing. This
+ *        data is passed between libacvp and the crypto module.
  */
-/*! @struct ACVP_SAFE_PRIMES_TC */
 typedef struct acvp_safe_primes_tc_t {
     int tg_id;
     int tc_id;
@@ -1733,7 +1745,7 @@ typedef struct acvp_safe_primes_tc_t {
     ACVP_SAFE_PRIMES_MODE dgm;
 } ACVP_SAFE_PRIMES_TC;
 
-
+/** @enum ACVP_KAS_IFC_PARAM */
 typedef enum acvp_kas_ifc_param {
     ACVP_KAS_IFC_KEYGEN_METHOD = 1,
     ACVP_KAS_IFC_MODULO,
@@ -1743,6 +1755,7 @@ typedef enum acvp_kas_ifc_param {
     ACVP_KAS_IFC_FIXEDPUBEXP
 } ACVP_KAS_IFC_PARAM;
 
+/** @enum ACVP_KAS_IFC_KEYGEN */
 typedef enum acvp_kas_ifc_keygen {
     ACVP_KAS_IFC_RSAKPG1_BASIC = 1,
     ACVP_KAS_IFC_RSAKPG1_PRIME_FACTOR,
@@ -1752,25 +1765,23 @@ typedef enum acvp_kas_ifc_keygen {
     ACVP_KAS_IFC_RSAKPG2_CRT
 } ACVP_KAS_IFC_KEYGEN;
 
-/*! @struct ACVP_KAS_IFC_ROLE */
+/** @enum ACVP_KAS_IFC_ROLE */
 typedef enum acvp_kas_ifc_roles {
     ACVP_KAS_IFC_INITIATOR = 1,
     ACVP_KAS_IFC_RESPONDER
 } ACVP_KAS_IFC_ROLES;
 
-/*! @struct ACVP_KAS_IFC_TEST_TYPE */
+/** @enum ACVP_KAS_IFC_TEST_TYPE */
 typedef enum acvp_kas_ifc_test_type {
     ACVP_KAS_IFC_TT_AFT = 1,
     ACVP_KAS_IFC_TT_VAL
 } ACVP_KAS_IFC_TEST_TYPE;
 
-/*!
+/**
  * @struct ACVP_KAS_IFC_TC
- * @brief This struct holds data that represents a single test
- * case for KAS-IFC testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for KAS-IFC testing. This data
+ *        is passed between libacvp and the crypto module.
  */
-/*! @struct ACVP_KAS_IFC_TC */
 typedef struct acvp_kas_ifc_tc_t {
     ACVP_CIPHER cipher;
     ACVP_KAS_IFC_TEST_TYPE test_type;
@@ -1802,12 +1813,14 @@ typedef struct acvp_kas_ifc_tc_t {
     unsigned int modulo;
 } ACVP_KAS_IFC_TC;
 
+/** @enum ACVP_KAS_KDF_ENCODING */
 typedef enum acvp_kas_kdf_encoding {
     ACVP_KAS_KDF_ENCODING_NONE = 0,
     ACVP_KAS_KDF_ENCODING_CONCAT,
     ACVP_KAS_KDF_ENCODING_MAX
 } ACVP_KAS_KDF_ENCODING;
 
+/** @enum ACVP_KAS_KDF_PATTERN_CANDIDATE */
 typedef enum acvp_kas_kdf_pattern_candidate {
     ACVP_KAS_KDF_PATTERN_NONE = 0,
     ACVP_KAS_KDF_PATTERN_LITERAL,
@@ -1820,6 +1833,7 @@ typedef enum acvp_kas_kdf_pattern_candidate {
     ACVP_KAS_KDF_PATTERN_MAX
 } ACVP_KAS_KDF_PATTERN_CANDIDATE;
 
+/** @enum ACVP_KAS_KDF_SALT_METHOD */
 typedef enum acvp_kas_kdf_mac_salt_method {
     ACVP_KAS_KDF_MAC_SALT_METHOD_NONE = 0,
     ACVP_KAS_KDF_MAC_SALT_METHOD_DEFAULT,
@@ -1827,6 +1841,7 @@ typedef enum acvp_kas_kdf_mac_salt_method {
     ACVP_KAS_KDF_MAC_SALT_METHOD_MAX
 } ACVP_KAS_KDF_MAC_SALT_METHOD;
 
+/** @enum ACVP_KAS_KDF_TEST_TYPE */
 typedef enum acvp_kas_kdf_test_type {
     ACVP_KAS_KDF_TT_NONE = 0,
     ACVP_KAS_KDF_TT_AFT,
@@ -1834,6 +1849,7 @@ typedef enum acvp_kas_kdf_test_type {
     ACVP_KAS_KDF_TT_MAX
 } ACVP_KAS_KDF_TEST_TYPE;
 
+/** @enum ACVP_KAS_KDF_PARM */
 typedef enum acvp_kas_kdf_param {
     ACVP_KAS_KDF_PATTERN = 1,
     ACVP_KAS_KDF_ENCODING_TYPE,
@@ -1844,6 +1860,11 @@ typedef enum acvp_kas_kdf_param {
     ACVP_KAS_KDF_ONESTEP_AUX_FUNCTION
 } ACVP_KAS_KDF_PARM;
 
+/**
+ * @struct ACVP_KAS_KDF_ONESTEP_TC
+ * @brief This struct holds data that represents a single test case for KAS KDF onestep testing.
+ *        This data is passed between libacvp and the crypto module.
+ */
 typedef struct acvp_kas_kdf_onestep_tc_t {
     ACVP_CIPHER cipher;
     ACVP_KAS_KDF_TEST_TYPE type;
@@ -1878,6 +1899,11 @@ typedef struct acvp_kas_kdf_onestep_tc_t {
     unsigned char *outputDkm;
 } ACVP_KAS_KDF_ONESTEP_TC;
 
+/**
+ * @struct ACVP_KAS_HKDF_TC
+ * @brief This struct holds data that represents a single test case for KAS HKDF testing. This data
+ *        is passed between libacvp and the crypto module.
+ */
 typedef struct acvp_kas_hkdf_tc_t {
     ACVP_CIPHER cipher;
     ACVP_KAS_KDF_TEST_TYPE type;
@@ -1912,6 +1938,7 @@ typedef struct acvp_kas_hkdf_tc_t {
     unsigned char *outputDkm;
 } ACVP_KAS_HKDF_TC;
 
+/** @enum ACVP_KTS_IFC_PARAM */
 typedef enum acvp_kts_ifc_param {
     ACVP_KTS_IFC_KEYGEN_METHOD = 1,
     ACVP_KTS_IFC_SCHEME,
@@ -1923,6 +1950,7 @@ typedef enum acvp_kts_ifc_param {
     ACVP_KTS_IFC_FIXEDPUBEXP
 } ACVP_KTS_IFC_PARAM;
 
+/** @enum ACVP_KTS_IFC_KEYGEN */
 typedef enum acvp_kts_ifc_keygen {
     ACVP_KTS_IFC_RSAKPG1_BASIC = 1,
     ACVP_KTS_IFC_RSAKPG1_PRIME_FACTOR,
@@ -1932,12 +1960,13 @@ typedef enum acvp_kts_ifc_keygen {
     ACVP_KTS_IFC_RSAKPG2_CRT
 } ACVP_KTS_IFC_KEYGEN;
 
-/*! @struct ACVP_KTS_IFC_ROLE */
+/** @enum ACVP_KTS_IFC_ROLE */
 typedef enum acvp_kts_ifc_roles {
     ACVP_KTS_IFC_INITIATOR = 1,
     ACVP_KTS_IFC_RESPONDER
 } ACVP_KTS_IFC_ROLES;
 
+/** @enum ACVP_KTS_IFC_SCHEME_PARAM */
 typedef enum acvp_kts_ifc_scheme_param {
     ACVP_KTS_IFC_NULL_ASSOC_DATA = 1,
     ACVP_KTS_IFC_AD_PATTERN,
@@ -1948,7 +1977,7 @@ typedef enum acvp_kts_ifc_scheme_param {
     ACVP_KTS_IFC_MAC_METHODS
 } ACVP_KTS_IFC_SCHEME_PARAM;
 
-/*! @struct ACVP_KTS_IFC_SCHEMES */
+/** @enum ACVP_KTS_IFC_SCHEMES */
 typedef enum acvp_kts_ifc_scheme_type {
     ACVP_KTS_IFC_KAS1_BASIC = 1,
     ACVP_KTS_IFC_KAS1_PARTYV,
@@ -1959,7 +1988,7 @@ typedef enum acvp_kts_ifc_scheme_type {
 } ACVP_KTS_IFC_SCHEME_TYPE;
 
 #define ACVP_KAS_IFC_CONCAT 2
-/*! @struct ACVP_KTS_IFC_TEST_TYPE */
+/** @enum ACVP_KTS_IFC_TEST_TYPE */
 typedef enum acvp_kts_ifc_test_type {
     ACVP_KTS_IFC_TT_AFT = 1,
     ACVP_KTS_IFC_TT_VAL
@@ -1967,13 +1996,11 @@ typedef enum acvp_kts_ifc_test_type {
 
 
 
-/*!
+/**
  * @struct ACVP_KTS_IFC_TC
- * @brief This struct holds data that represents a single test
- * case for KAS-IFC testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief This struct holds data that represents a single test case for KTS-IFC testing. This data
+ *        is passed between libacvp and the crypto module.
  */
-/*! @struct ACVP_KTS_IFC_TC */
 typedef struct acvp_kts_ifc_tc_t {
     ACVP_CIPHER cipher;
     ACVP_KTS_IFC_TEST_TYPE test_type;
@@ -1999,11 +2026,10 @@ typedef struct acvp_kts_ifc_tc_t {
     int modulo;
 } ACVP_KTS_IFC_TC;
 
-/*!
+/**
  * @struct ACVP_DRBG_TC
- * @brief This struct holds data that represents a single test case
- * for DRBG testing.  This data is
- * passed between libacvp and the crypto module.
+ * @brief  This struct holds data that represents a single test case for DRBG testing. This data is
+ *         passed between libacvp and the crypto module.
  */
 typedef struct acvp_drbg_tc_t {
     ACVP_CIPHER cipher;
@@ -2033,19 +2059,16 @@ typedef struct acvp_drbg_tc_t {
     unsigned int drb_len;              /**< Expected drb length (in bytes) */
 } ACVP_DRBG_TC;
 
-/*!
+/**
  * @struct ACVP_TEST_CASE
- * @brief This is the abstracted test case representation used for
- * passing test case data to/from the crypto module. Because the
- * callback prototype is generic to all algorithms, we abstract
- * the various classes of test cases using a union.  This
- * struct is then used to pass a reference to the test case
- * between libacvp and the crypto module.
+ * @brief This is the abstracted test case representation used for passing test case data to/from
+ *        the crypto module. Because the callback prototype is generic to all algorithms, we
+ *        abstract the various classes of test cases using a union. This struct is then used to
+ *        pass a reference to the test case between libacvp and the crypto module.
  */
 typedef struct acvp_test_case_t {
     union {
         ACVP_SYM_CIPHER_TC *symmetric;
-        ACVP_ENTROPY_TC *entropy;
         ACVP_HASH_TC *hash;
         ACVP_DRBG_TC *drbg;
         ACVP_DSA_TC *dsa;
@@ -2075,8 +2098,8 @@ typedef struct acvp_test_case_t {
     } tc;
 } ACVP_TEST_CASE;
 
-/*
- * lookup function for err strings is in acvp_util.c
+/**
+ * see typedef enum acvp_result ACVP_RESULT
  */
 enum acvp_result {
     ACVP_SUCCESS = 0,
@@ -2107,90 +2130,84 @@ enum acvp_result {
     ACVP_RESULT_MAX
 };
 
-/*! @brief Allows an application to specify a symmetric cipher capability
-           to be tested by the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    symmetric ciphers that will be tested by the ACVP server.  This
-    includes AES and 3DES.  This function may be called multiple times
-    to specify more than one crypto capability, such as AES-CBC, AES-CTR,
-    AES-GCM, etc.
-
-    When the application enables a crypto capability, such as AES-GCM, it
-    also needs to specify a callback function that will be used by libacvp
-    when that crypto capability is needed during a test session.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param dir ACVP_SYM_CIPH_DIR enum value identifying the crypto operation
-       (e.g. encrypt or decrypt).
-    @param keying_option ACVP_SYM_CIPH_KO enum value identifying the TDES keying options
-    @param ivgen_source The source of the IV used by the crypto module
-        (e.g. internal or external)
-    @param ivgen_mode The IV generation mode
-    @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-    @return ACVP_RESULT
+/**
+ * @brief Allows an application to specify a symmetric cipher capability to be tested by the ACVP
+ *        server.
+ *
+ *        This function should be called to enable crypto capabilities for symmetric ciphers that
+ *        will be tested by the ACVP server. This includes AES and 3DES. This function may be
+ *        called multiple times to specify more than one crypto capability, such as AES-CBC,
+ *        AES-CTR, AES-GCM, etc.
+ *
+ *        When the application enables a crypto capability, such as AES-GCM, it also needs to
+ *        specify a callback function that will be used by libacvp when that crypto capability is
+ *        needed during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param dir ACVP_SYM_CIPH_DIR enum value identifying the crypto operation (e.g. encrypt or
+ *        decrypt).
+ * @param keying_option ACVP_SYM_CIPH_KO enum value identifying the TDES keying options
+ * @param ivgen_source The source of the IV used by the crypto module (e.g. internal or external)
+ * @param ivgen_mode The IV generation mode
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
                                        ACVP_CIPHER cipher,
                                        int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_sym_cipher_cap_parm() allows an application to specify
-       length-based operational parameters to be used for a given cipher during
-       a test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    symmetric ciphers that will be tested by the ACVP server.  This
-    includes AES and 3DES.
-
-    This function may be called multiple times to specify more than one
-    crypto parameter value for the cipher.  For instance, if cipher supports
-    key lengths of 128, 192, and 256 bits, then this function would
-    be called three times.  Once for 128, once for 192, and once again
-    for 256. The ACVP_CIPHER value passed to this function should
-    already have been setup by invoking acvp_enable_sym_cipher_cap() for
-    that cipher earlier.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param parm ACVP_SYM_CIPH_PARM enum value identifying the algorithm parameter
-       that is being specified.  An example would be the supported plaintext
-       length of the algorithm.
-    @param length The length value for the symmetric cipher parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_sym_cipher_cap_parm() allows an application to specify length-based
+ *        operational parameters to be used for a given cipher during a test session with the ACVP
+ *        server.
+ *
+ *        This function should be called to enable crypto capabilities for symmetric ciphers that
+ *        will be tested by the ACVP server. This includes AES and 3DES.
+ *
+ *        This function may be called multiple times to specify more than one crypto parameter
+ *        value for the cipher. For instance, if cipher supports key lengths of 128, 192, and 256
+ *        bits, then this function would be called three times. Once for 128, once for 192, and
+ *        once again for 256. The ACVP_CIPHER value passed to this function should already have
+ *        been setup by invoking acvp_enable_sym_cipher_cap() for that cipher earlier.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param parm ACVP_SYM_CIPH_PARM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be the supported plaintext length of the algorithm.
+ * @param length The length value for the symmetric cipher parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
                                          ACVP_CIPHER cipher,
                                          ACVP_SYM_CIPH_PARM parm,
                                          int length);
 
- /*! @brief acvp_cap_sym_cipher_set_domain allow an application to specify length-based
-        operational parameters to be used for a given cipher during a test session with
-        the ACVP server.
- 
-    The user should call this to specify the supported key PT lengths, AAD lengths,
-    and IV lengths This is called multiple times, for different parms.
-
-    The ACVP_CIPHER value passed to this function should already have been setup by 
-    invoking acvp_enable_sym_cipher_cap() for that cipher earlier.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param parm ACVP_SYM_CIPH_PARM enum value identifying the algorithm parameter
-       that is being specified.  An example would be the supported key
-       length of the algorithm.
-    @param min the minimum value of the domain (range of possible values) being set
-    @param max the maximum value of the domain being set
-    @param increment the increment of the domain being set. Should evenly divide into
-       the other values.
-
-    @return ACVP_RESULT
- */
+/**
+ * @brief acvp_cap_sym_cipher_set_domain allow an application to specify length-based operational
+ *        parameters to be used for a given cipher during a test session with the ACVP server.
+ *
+ *        The user should call this to specify the supported key PT lengths, AAD lengths, and IV
+ *        lengths This is called multiple times, for different parms.
+ *
+ *        The ACVP_CIPHER value passed to this function should already have been setup by invoking
+ *        acvp_enable_sym_cipher_cap() for that cipher earlier.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param parm ACVP_SYM_CIPH_PARM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be the supported key length of the algorithm.
+ * @param min the minimum value of the domain (range of possible values) being set
+ * @param max the maximum value of the domain being set
+ * @param increment the increment of the domain being set. Should evenly divide into the other
+ *        values.
+ *
+ * @return ACVP_RESULT
+*/
 ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
                                            ACVP_CIPHER cipher,
                                            ACVP_SYM_CIPH_DOMAIN_PARM parm,
@@ -2198,52 +2215,48 @@ ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
                                            int max,
                                            int increment);
 
-/*! @brief acvp_enable_hash_cap() allows an application to specify a
-       hash capability to be tested by the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    hash algorithms that will be tested by the ACVP server.  This
-    includes SHA-1, SHA-256, SHA-384, etc.  This function may be called
-    multiple times to specify more than one crypto capability.
-
-    When the application enables a crypto capability, such as SHA-1, it
-    also needs to specify a callback function that will be used by libacvp
-    when that crypto capability is needed during a test session.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_hash_cap() allows an application to specify a hash capability to be tested
+ *        by the ACVP server.
+ *
+ *        This function should be called to enable crypto capabilities for hash algorithms that
+ *        will be tested by the ACVP server. This includes SHA-1, SHA-256, SHA-384, etc. This
+ *        function may be called multiple times to specify more than one crypto capability.
+ *
+ *        When the application enables a crypto capability, such as SHA-1, it also needs to specify
+ *        a callback function that will be used by libacvp when that crypto capability is needed
+ *        during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_hash_enable(ACVP_CTX *ctx,
                                  ACVP_CIPHER cipher,
                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_hash_cap_parm() allows an application to specify
-       operational parameters to be used for a given hash alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    hash capabilities that will be tested by the ACVP server.  This
-    includes SHA-1, SHA-256, SHA-384, etc.
-
-    This function may be called multiple times to specify more than one
-    crypto parameter value for the hash algorithm. The ACVP_CIPHER value
-    passed to this function should already have been setup by invoking
-    acvp_enable_hash_cap().
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param param ACVP_HASH_PARM enum value identifying the algorithm parameter
-       that is being specified.  An example would be a flag indicating if
-       empty input values are allowed.
-    @param value the value corresponding to the parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_hash_cap_parm() allows an application to specify operational parameters to be
+ *        used for a given hash alg during a test session with the ACVP server.
+ *
+ *        This function should be called to enable crypto capabilities for hash capabilities that
+ *        will be tested by the ACVP server. This includes SHA-1, SHA-256, SHA-384, etc.
+ *
+ *        This function may be called multiple times to specify more than one crypto parameter
+ *        value for the hash algorithm. The ACVP_CIPHER value passed to this function should
+ *        already have been setup by invoking acvp_enable_hash_cap().
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param param ACVP_HASH_PARM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be a flag indicating if empty input values are allowed.
+ * @param value the value corresponding to the parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_hash_set_parm(ACVP_CTX *ctx,
                                    ACVP_CIPHER cipher,
@@ -2257,49 +2270,46 @@ ACVP_RESULT acvp_cap_hash_set_domain(ACVP_CTX *ctx,
                                      int max,
                                      int increment);
 
-/*! @brief acvp_enable_drbg_cap() allows an application to specify a
-       hash capability to be tested by the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    hash algorithms that will be tested by the ACVP server.  This
-    includes HASHDRBG, HMACDRBG, CTRDRBG. This function may be called
-    multiple times to specify more than one crypto capability.
-
-    When the application enables a crypto capability, such as ACVP_HASHDRBG,
-    it also needs to specify a callback function that will be used by libacvp
-    when that crypto capability is needed during a test session.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_drbg_cap() allows an application to specify a hash capability to be tested by
+ *        the ACVP server.
+ *
+ *        This function should be called to enable crypto capabilities for hash algorithms that
+ *        will be tested by the ACVP server. This includes HASHDRBG, HMACDRBG, CTRDRBG. This
+ *        function may be called multiple times to specify more than one crypto capability.
+ *
+ *        When the application enables a crypto capability, such as ACVP_HASHDRBG, it also needs to
+ *        specify a callback function that will be used by libacvp when that crypto capability is
+ *        needed during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_drbg_enable(ACVP_CTX *ctx,
                                  ACVP_CIPHER cipher,
                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_drbg_cap_parm() allows an application to specify
-       operational parameters to be used for a given DRBG alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    hash capabilities that will be tested by the ACVP server.  This
-    includes HASHDRBG, HMACDRBG, CTRDRBG. This function may be called
-    multiple times to specify more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param mode ACVP_DRBG_MODE enum value specifying mode. An example would be
-        ACVP_DRBG_SHA_1
-    @param param ACVP_DRBG_PARM enum value identifying the algorithm parameter
-       that is being specified.  An example would be prediction resistance.
-    @param value the value corresponding to the parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_drbg_cap_parm() allows an application to specify operational parameters to be
+ *        used for a given DRBG alg during a test session with the ACVP server.
+ *
+ *        This function should be called to enable crypto capabilities for hash capabilities that
+ *        will be tested by the ACVP server. This includes HASHDRBG, HMACDRBG, CTRDRBG. This
+ *        function may be called multiple times to specify more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param mode ACVP_DRBG_MODE enum value specifying mode. An example would be ACVP_DRBG_SHA_1
+ * @param param ACVP_DRBG_PARM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be prediction resistance.
+ * @param value the value corresponding to the parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_drbg_set_parm(ACVP_CTX *ctx,
                                    ACVP_CIPHER cipher,
@@ -2307,24 +2317,24 @@ ACVP_RESULT acvp_cap_drbg_set_parm(ACVP_CTX *ctx,
                                    ACVP_DRBG_PARM param,
                                    int value);
 
-/*! @brief acvp_enable_drbg_length_cap() allows an application to register
-        a DRBG capability length-based paramter.
-
-        This function should be used to register a length-based parameter
-        for a DRBG capability. An example would be entropy, nonce, perso
-        where a minimum, step, and maximum can be specified.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param mode ACVP_DRBG_MODE enum value specifying mode. An example would be
-        ACVP_DRBG_SHA_1
-   @param param ACVP_DRBG_PARM enum value specifying paramter. An example
-        would be ACVP_DRBG_ENTROPY_LEN
-   @param min minimum value
-   @param step increment value
-   @param max maximum value
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_drbg_length_cap() allows an application to register a DRBG capability
+ *        length-based paramter.
+ *
+ *        This function should be used to register a length-based parameter for a DRBG capability.
+ *        An example would be entropy, nonce, perso where a minimum, step, and maximum can be
+ *        specified.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param mode ACVP_DRBG_MODE enum value specifying mode. An example would be ACVP_DRBG_SHA_1
+ * @param param ACVP_DRBG_PARM enum value specifying paramter. An example would be
+ *        ACVP_DRBG_ENTROPY_LEN
+ * @param min minimum value
+ * @param step increment value
+ * @param max maximum value
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_drbg_set_length(ACVP_CTX *ctx,
                                      ACVP_CIPHER cipher,
@@ -2334,45 +2344,41 @@ ACVP_RESULT acvp_cap_drbg_set_length(ACVP_CTX *ctx,
                                      int step,
                                      int max);
 
-/*! @brief acvp_enable_dsa_cap()
-
-   This function should be used to enable DSA capabilities. Specific modes
-   and parameters can use acvp_enable_dsa_cap_parm.
-
-   When the application enables a crypto capability, such as DSA, it
-   also needs to specify a callback function that will be used by libacvp
-   when that crypto capability is needed during a test session.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_dsa_cap()
+ *        This function should be used to enable DSA capabilities. Specific modes and parameters
+ *        can use acvp_enable_dsa_cap_parm.
+ *
+ *        When the application enables a crypto capability, such as DSA, it also needs to specify a
+ *        callback function that will be used by libacvp when that crypto capability is needed
+ *        during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_dsa_enable(ACVP_CTX *ctx,
                                 ACVP_CIPHER cipher,
                                 int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_dsa_cap_parm() allows an application to specify
-       operational parameters to be used for a given hash alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    DSA modes and functions. It may be called  multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param mode ACVP_DSA_MODE enum value specifying mode. An example would be
-        ACVP_DSA_MODE_PQGGEN
-    @param param ACVP_DSA_PARM enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_DSA_GENPQ.
-    @param value the value corresponding to the parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_dsa_cap_parm() allows an application to specify operational parameters to be
+ *        used for a given hash alg during a test session with the ACVP server. This function
+ *        should be called to enable crypto capabilities for DSA modes and functions. It may be
+ *        called multiple times to specify more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param mode ACVP_DSA_MODE enum value specifying mode. An example would be ACVP_DSA_MODE_PQGGEN
+ * @param param ACVP_DSA_PARM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be ACVP_DSA_GENPQ.
+ * @param value the value corresponding to the parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_dsa_set_parm(ACVP_CTX *ctx,
                                   ACVP_CIPHER cipher,
@@ -2380,44 +2386,41 @@ ACVP_RESULT acvp_cap_dsa_set_parm(ACVP_CTX *ctx,
                                   ACVP_DSA_PARM param,
                                   int value);
 
-/*! @brief acvp_enable_kas_ecc_cap()
-
-   This function should be used to enable KAS-ECC capabilities. Specific modes
-   and parameters can use acvp_enable_kas_ecc_cap_parm.
-
-   When the application enables a crypto capability, such as KAS-ECC, it
-   also needs to specify a callback function that will be used by libacvp
-   when that crypto capability is needed during a test session.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kas_ecc_cap()
+ *        This function should be used to enable KAS-ECC capabilities. Specific modes and
+ *        parameters can use acvp_enable_kas_ecc_cap_parm.
+ *
+ *        When the application enables a crypto capability, such as KAS-ECC, it also needs to
+ *        specify a callback function that will be used by libacvp when that crypto capability is
+ *        needed during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_ecc_enable(ACVP_CTX *ctx,
                                     ACVP_CIPHER cipher,
                                     int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_kas_ecc_prereq_cap() allows an application to specify
-        a prerequisite algorithm for a given KAS-ECC mode during a test session
-        with the ACVP server.
-
-        This function should be called to enable a prerequisite for
-        an KAS-ECC mode capability that will be tested by the server.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param mode ACVP_KAS_ECC_MODE enum value specifying mode. An example would be
-        ACVP_KAS_ECC_MODE_PARTIAL
-   @param pre_req ACVP_PREREQ_ALG enum that the specified cipher/mode
-        depends on
-   @param value "same" or number
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kas_ecc_prereq_cap() allows an application to specify a prerequisite
+ *        algorithm for a given KAS-ECC mode during a test session with the ACVP server. This
+ *        function should be called to enable a prerequisite for an KAS-ECC mode capability that
+ *        will be tested by the server.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param mode ACVP_KAS_ECC_MODE enum value specifying mode. An example would be
+ *        ACVP_KAS_ECC_MODE_PARTIAL
+ * @param pre_req ACVP_PREREQ_ALG enum that the specified cipher/mode depends on
+ * @param value "same" or number
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_ecc_set_prereq(ACVP_CTX *ctx,
                                         ACVP_CIPHER cipher,
@@ -2425,23 +2428,21 @@ ACVP_RESULT acvp_cap_kas_ecc_set_prereq(ACVP_CTX *ctx,
                                         ACVP_PREREQ_ALG pre_req,
                                         char *value);
 
-/*! @brief acvp_enable_kas_ecc_cap_parm() allows an application to specify
-       operational parameters to be used for a given hash alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    KAS-ECC modes and functions. It may be called  multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param mode ACVP_KAS_ECC_MODE enum value specifying mode. An example would be
-        ACVP_KAS_ECC_MODE_PARTIALVAL
-    @param param ACVP_KAS_ECC_PARAM enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_KAS_ECC_????
-    @param value the value corresponding to the parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kas_ecc_cap_parm() allows an application to specify operational parameters to
+ *        be used for a given hash alg during a test session with the ACVP server  This function
+ *        should be called to enable crypto capabilities for KAS-ECC modes and functions. It may be
+ *        called multiple times to specify more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param mode ACVP_KAS_ECC_MODE enum value specifying mode. An example would be
+ *        ACVP_KAS_ECC_MODE_PARTIALVAL
+ * @param param ACVP_KAS_ECC_PARAM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be ACVP_KAS_ECC_????
+ * @param value the value corresponding to the parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_ecc_set_parm(ACVP_CTX *ctx,
                                       ACVP_CIPHER cipher,
@@ -2458,65 +2459,60 @@ ACVP_RESULT acvp_cap_kas_ecc_set_scheme(ACVP_CTX *ctx,
                                         int value);
 
 
-/*! @brief acvp_cap_kas_ifc_enable()
-
-   This function should be used to enable KAS-IFC capabilities. Specific modes
-   and parameters can use acvp_enable_kas_ifc_cap_parm.
-
-   When the application enables a crypto capability, such as KAS-IFC, it
-   also needs to specify a callback function that will be used by libacvp
-   when that crypto capability is needed during a test session.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_cap_kas_ifc_enable()
+ *        This function should be used to enable KAS-IFC capabilities. Specific modes and
+ *        parameters can use acvp_enable_kas_ifc_cap_parm.
+ *
+ *        When the application enables a crypto capability, such as KAS-IFC, it also needs to
+ *        specify a callback function that will be used by libacvp when that crypto capability is
+ *        needed during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that
+ *        is invoked by libacvp when the crypto capability is needed during a test session. This
+ *        crypto_handler function is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_ifc_enable(ACVP_CTX *ctx,
                                     ACVP_CIPHER cipher,
                                     int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
 
-/*! @brief acvp_cap_kas_ifc_set_parm() allows an application to specify
-       operational parameters to be used for a given alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    KAS-IFC modes and functions. It may be called  multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param param ACVP_KAS_IFC_PARAM enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_KAS_IFC_????
-    @param value the value corresponding to the parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_cap_kas_ifc_set_parm() allows an application to specify operational parameters to be
+ *        used for a given alg during a test session with the ACVP server. This function should be
+ *        called to enable crypto capabilities for KAS-IFC modes and functions. It may be called
+ *        multiple times to specify more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param param ACVP_KAS_IFC_PARAM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be ACVP_KAS_IFC_????
+ * @param value the value corresponding to the parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_ifc_set_parm(ACVP_CTX *ctx,
                                       ACVP_CIPHER cipher,
                                       ACVP_KAS_IFC_PARAM param,
                                       int value);
 
-/*! @brief acvp_cap_kas_ifc_set_exponent() allows an application to specify
-       public exponent to be used for a given alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    KAS-IFC modes and functions. It may be called  multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param param ACVP_KAS_IFC_PARAM enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_KAS_IFC_????
-    @param value the string value corresponding to the public exponent being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_cap_kas_ifc_set_exponent() allows an application to specify public exponent to be
+ *        used for a given alg during a test session with the ACVP server.  This function should be
+ *        called to enable crypto capabilities for KAS-IFC modes and functions. It may be called
+ *        multiple times to specify more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param param ACVP_KAS_IFC_PARAM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be ACVP_KAS_IFC_????
+ * @param value the string value corresponding to the public exponent being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_ifc_set_exponent(ACVP_CTX *ctx,
                                           ACVP_CIPHER cipher,
@@ -2524,68 +2520,64 @@ ACVP_RESULT acvp_cap_kas_ifc_set_exponent(ACVP_CTX *ctx,
                                           char *value);
 
 
-/*! @brief acvp_cap_kts_ifc_enable()
-
-   This function should be used to enable KTS-IFC capabilities. Specific modes
-   and parameters can use acvp_enable_kts_ifc_set_parm, acvp_cap_kts_ifc_set_param_string
-   and acvp_cap_kts_ifc_set_scheme_string.
-
-   When the application enables a crypto capability, such as KTS-IFC, it
-   also needs to specify a callback function that will be used by libacvp
-   when that crypto capability is needed during a test session.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_cap_kts_ifc_enable()
+ *        This function should be used to enable KTS-IFC capabilities. Specific modes and
+ *        parameters can use acvp_enable_kts_ifc_set_parm, acvp_cap_kts_ifc_set_param_string and
+ *        acvp_cap_kts_ifc_set_scheme_string.
+ *
+ *        When the application enables a crypto capability, such as KTS-IFC, it also needs to
+ *        specify a callback function that will be used by libacvp when that crypto capability is
+ *        needed during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kts_ifc_enable(ACVP_CTX *ctx,
                                     ACVP_CIPHER cipher,
                                     int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
 
-/*! @brief acvp_cap_kts_ifc_set_parm() allows an application to specify
-       operational parameters to be used for a given alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    KTS-IFC modes and functions. It may be called  multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param param ACVP_KTS_IFC_PARAM enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_KTS_IFC_????
-    @param value the value corresponding to the parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_cap_kts_ifc_set_parm() allows an application to specify operational parameters to be
+ *        used for a given alg during a test session with the ACVP server. This function should be
+ *        called to enable crypto capabilities for KTS-IFC modes and functions. It may be called
+ *        multiple times to specify more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param param ACVP_KTS_IFC_PARAM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be ACVP_KTS_IFC_????
+ * @param value the value corresponding to the parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kts_ifc_set_parm(ACVP_CTX *ctx,
                                       ACVP_CIPHER cipher,
                                       ACVP_KTS_IFC_PARAM param,
                                       int value);
 
-/*! @brief acvp_cap_kts_ifc_set_scheme_parm() allows an application to specify
-       operational parameters to be used for KTS-IFC scheme parameters  during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    KTS-IFC modes and functions. It may be called  multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param param ACVP_KTS_IFC_SCHEME enum value identifying the scheme type
-       that is being specified.  An example would be ACVP_KTS_IFC_KAS1_BASIC
-    @param param ACVP_KTS_IFC_SCHEME_PARAM enum value identifying the scheme option
-       that is being specified.  An example would be ACVP_KTS_IFC_ROLE
-    @param value the value corresponding to the parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_cap_kts_ifc_set_scheme_parm() allows an application to specify operational
+ *        parameters to be used for KTS-IFC scheme parameters  during a test session with the ACVP
+ *        server. This function should be called to enable crypto capabilities for KTS-IFC modes
+ *        and functions. It may be called  multiple times to specify more than one crypto
+ *        capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param scheme ACVP_KTS_IFC_SCHEME enum value identifying the scheme type that is being specified.
+ *        An example would be ACVP_KTS_IFC_KAS1_BASIC
+ * @param param ACVP_KTS_IFC_SCHEME_PARAM enum value identifying the scheme option that is being
+ *        specified. An example would be ACVP_KTS_IFC_ROLE
+ * @param value the value corresponding to the parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kts_ifc_set_scheme_parm(ACVP_CTX *ctx,
                                              ACVP_CIPHER cipher,
@@ -2593,44 +2585,42 @@ ACVP_RESULT acvp_cap_kts_ifc_set_scheme_parm(ACVP_CTX *ctx,
                                              ACVP_KTS_IFC_SCHEME_PARAM param,
                                              int value);
 
-/*! @brief acvp_cap_kts_ifc_set_param_string() allows an application to specify
-       string based params to be used for a given alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    KTS-IFC modes and functions. It may be called  multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param param ACVP_KTS_IFC_PARAM enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_KTS_IFC_FIXEDPUBEXP
-    @param value the string value corresponding to the public exponent being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_cap_kts_ifc_set_param_string() allows an application to specify
+ *     string based params to be used for a given alg during a
+ *      test session with the ACVP server.
+ *     This function should be called to enable crypto capabilities for
+ *    KTS-IFC modes and functions. It may be called  multiple times to specify
+ *   more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param param ACVP_KTS_IFC_PARAM enum value identifying the algorithm parameter
+ *        that is being specified. An example would be ACVP_KTS_IFC_FIXEDPUBEXP
+ * @param value the string value corresponding to the public exponent being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kts_ifc_set_param_string(ACVP_CTX *ctx,
                                              ACVP_CIPHER cipher,
                                              ACVP_KTS_IFC_PARAM param,
                                              char *value);
 
-/*! @brief acvp_cap_kts_ifc_set_scheme_string() allows an application to specify
-       string based params to be used for a given alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    KTS-IFC modes and functions. It may be called  multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param param ACVP_KTS_IFC_SCHEME enum value identifying the scheme type
-       that is being specified.  An example would be ACVP_KTS_IFC_KAS1_BASIC
-    @param param ACVP_KTS_IFC_PARAM enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_KTS_IFC_ENCODING
-    @param value the string value corresponding to the public exponent being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_cap_kts_ifc_set_scheme_string() allows an application to specify string based params
+ *        to be used for a given alg during a test session with the ACVP server. This function
+ *        should be called to enable crypto capabilities for KTS-IFC modes and functions. It may be
+ *        called multiple times to specify more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param param ACVP_KTS_IFC_SCHEME enum value identifying the scheme type that is being specified.
+ *        An example would be ACVP_KTS_IFC_KAS1_BASIC
+ * @param param ACVP_KTS_IFC_PARAM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be ACVP_KTS_IFC_ENCODING
+ * @param value the string value corresponding to the public exponent being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kts_ifc_set_scheme_string(ACVP_CTX *ctx,
                                                ACVP_CIPHER cipher,
@@ -2638,45 +2628,42 @@ ACVP_RESULT acvp_cap_kts_ifc_set_scheme_string(ACVP_CTX *ctx,
                                                ACVP_KTS_IFC_PARAM param,
                                                char *value);
 
-/*! @brief acvp_enable_kas_ffc_cap()
-
-   This function should be used to enable KAS-FFC capabilities. Specific modes
-   and parameters can use acvp_enable_kas_ffc_cap_parm.
-
-   When the application enables a crypto capability, such as KAS-FFC, it
-   also needs to specify a callback function that will be used by libacvp
-   when that crypto capability is needed during a test session.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kas_ffc_cap()
+ *        This function should be used to enable KAS-FFC capabilities. Specific modes and
+ *        parameters can use acvp_enable_kas_ffc_cap_parm.
+ *
+ *        When the application enables a crypto capability, such as KAS-FFC, it also needs to
+ *        specify a callback function that will be used by libacvp when that crypto capability is
+ *        needed during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 
 ACVP_RESULT acvp_cap_kas_ffc_enable(ACVP_CTX *ctx,
                                     ACVP_CIPHER cipher,
                                     int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_kas_ffc_prereq_cap() allows an application to specify
-        a prerequisite algorithm for a given KAS-FFC mode during a test session
-        with the ACVP server.
-
-        This function should be called to enable a prerequisite for
-        an KAS-FFC mode capability that will be tested by the server.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param mode ACVP_KAS_FFC_MODE enum value specifying mode. An example would be
-        ACVP_KAS_FFC_MODE_PARTIAL
-   @param pre_req ACVP_PREREQ_ALG enum that the specified cipher/mode
-        depends on
-   @param value "same" or number
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kas_ffc_prereq_cap() allows an application to specify a prerequisite
+ *        algorithm for a given KAS-FFC mode during a test session with the ACVP server. This
+ *        function should be called to enable a prerequisite for an KAS-FFC mode capability that
+ *        will be tested by the server.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param mode ACVP_KAS_FFC_MODE enum value specifying mode. An example would be
+ *        ACVP_KAS_FFC_MODE_PARTIAL
+ * @param pre_req ACVP_PREREQ_ALG enum that the specified cipher/mode depends on
+ * @param value "same" or number
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_ffc_set_prereq(ACVP_CTX *ctx,
                                         ACVP_CIPHER cipher,
@@ -2684,23 +2671,21 @@ ACVP_RESULT acvp_cap_kas_ffc_set_prereq(ACVP_CTX *ctx,
                                         ACVP_PREREQ_ALG pre_req,
                                         char *value);
 
-/*! @brief acvp_enable_kas_ffc_cap_parm() allows an application to specify
-       operational parameters to be used for a given alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    KAS-FFC modes and functions. It may be called  multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param mode ACVP_KAS_FFC_MODE enum value specifying mode. An example would be
-        ACVP_KAS_FFC_MODE_DPGEN
-    @param param ACVP_KAS_FFC_PARAM enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_KAS_FFC_????
-    @param value the value corresponding to the parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kas_ffc_cap_parm() allows an application to specify operational parameters to
+ *        be used for a given alg during a test session with the ACVP server. This function should
+ *        be called to enable crypto capabilities for KAS-FFC modes and functions. It may be called
+ *        multiple times to specify more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param mode ACVP_KAS_FFC_MODE enum value specifying mode. An example would be
+ *        ACVP_KAS_FFC_MODE_DPGEN
+ * @param param ACVP_KAS_FFC_PARAM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be ACVP_KAS_FFC_????
+ * @param value the value corresponding to the parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_ffc_set_parm(ACVP_CTX *ctx,
                                       ACVP_CIPHER cipher,
@@ -2709,25 +2694,23 @@ ACVP_RESULT acvp_cap_kas_ffc_set_parm(ACVP_CTX *ctx,
                                       int value);
 
 
-/*! @brief acvp_enable_kas_ffc_cap_scheme() allows an application to specify
-       scheme parameters to be used for a given alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    KAS-FFC modes and functions. It may be called  multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param mode ACVP_KAS_FFC_MODE enum value specifying mode. An example would be
-        ACVP_KAS_FFC_MODE_COMPONENT
-    @param param ACVP_KAS_FFC_SCHEME enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_KAS_FFC_DH_EPHEMERAL
-    @param param ACVP_KAS_FFC_PARAM enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_KAS_FFC_KDF
-    @param value the value corresponding to the parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kas_ffc_cap_scheme() allows an application to specify scheme parameters to be
+ *        used for a given alg during a test session with the ACVP server. This function should be
+ *        called to enable crypto capabilities for KAS-FFC modes and functions. It may be called
+ *        multiple times to specify more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param mode ACVP_KAS_FFC_MODE enum value specifying mode. An example would be
+ *        ACVP_KAS_FFC_MODE_COMPONENT
+ * @param param ACVP_KAS_FFC_SCHEME enum value identifying the algorithm parameter that is being
+ *        specified. An example would be ACVP_KAS_FFC_DH_EPHEMERAL
+ * @param param ACVP_KAS_FFC_PARAM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be ACVP_KAS_FFC_KDF
+ * @param value the value corresponding to the parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_ffc_set_scheme(ACVP_CTX *ctx,
                                         ACVP_CIPHER cipher,
@@ -2736,23 +2719,21 @@ ACVP_RESULT acvp_cap_kas_ffc_set_scheme(ACVP_CTX *ctx,
                                         ACVP_KAS_FFC_PARAM param,
                                         int value);
 
-/*! @brief acvp_enable_kas_kdf_set_domain() allows an application to specify
-    operational parameters to be used for a given alg during a
-    test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    KAS-KDF modes and functions. It may be called multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param param ACVP_KAS_KDF_PARM enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_KAS_HKDF_???
-    @param min Minumum supported value for the corresponding parameter
-    @param max Maximum supported value for the corresponding parameter
-    @param increment Increment value supported
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kas_kdf_set_domain() allows an application to specify operational parameters
+ *        to be used for a given alg during a test session with the ACVP server. This function
+ *        should be called to enable crypto capabilities for KAS-KDF modes and functions. It may be
+ *        called multiple times to specify more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param param ACVP_KAS_KDF_PARM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be ACVP_KAS_HKDF_???
+ * @param min Minumum supported value for the corresponding parameter
+ * @param max Maximum supported value for the corresponding parameter
+ * @param increment Increment value supported
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_kdf_set_domain(ACVP_CTX *ctx,
                                        ACVP_CIPHER cipher,
@@ -2761,24 +2742,21 @@ ACVP_RESULT acvp_cap_kas_kdf_set_domain(ACVP_CTX *ctx,
                                        int max,
                                        int increment);
 
-
-     /*! @brief acvp_enable_kas_kdf_set_parm() allows an application to specify
-    operational parameters to be used for a given alg during a
-    test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    KAS-KDF modes and functions. It may be called multiple times to specify
-    more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param param ACVP_KAS_KDF_PARM enum value identifying the algorithm parameter
-       that is being specified.  An example would be ACVP_KAS_HKDF_???
-    @param value the value corresponding to the parameter being set
-    @param string a constant string value required by some parameters, will return
-       an error if incorrectly used with wrong parameters
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kas_kdf_set_parm() allows an application to specify operational parameters
+ *        to be used for a given alg during a test session with the ACVP server. This function
+ *        should be called to enable crypto capabilities for KAS-KDF modes and functions. It may be
+ *        called multiple times to specify more than one crypto capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param param ACVP_KAS_KDF_PARM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be ACVP_KAS_HKDF_???
+ * @param value the value corresponding to the parameter being set
+ * @param string a constant string value required by some parameters, will return an error if
+ *        incorrectly used with wrong parameters
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_kdf_set_parm(ACVP_CTX *ctx,
                                       ACVP_CIPHER cipher,
@@ -2788,46 +2766,44 @@ ACVP_RESULT acvp_cap_kas_kdf_set_parm(ACVP_CTX *ctx,
 
 
 
-/*! @brief acvp_enable_kas_kdf_enable()
-
-   This function should be used to enable KAS-KDF functions. Parameters are set using
-   acvp_cap_kas_kdf_set_parm().
-
-   When the application enables a crypto capability, such as KAS-HKDF, it
-   also needs to specify a callback function that will be used by libacvp
-   when that crypto capability is needed during a test session.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kas_kdf_enable()
+ *        This function should be used to enable KAS-KDF functions. Parameters are set using
+ *        acvp_cap_kas_kdf_set_parm().
+ *
+ *        When the application enables a crypto capability, such as KAS-HKDF, it also needs to
+ *        specify a callback function that will be used by libacvp when that crypto capability is
+ *        needed during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kas_kdf_enable(ACVP_CTX *ctx,
                                     ACVP_CIPHER cipher,
                                     int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_rsa_*_cap()
-
-   This function should be used to enable RSA capabilities. Specific modes
-   and parameters can use acvp_enable_rsa_cap_parm, acvp_enable_rsa_bignum_parm,
-   acvp_enable_rsa_primes_parm depending on the need.
-
-   When the application enables a crypto capability, such as RSA, it
-   also needs to specify a callback function that will be used by libacvp
-   when that crypto capability is needed during a test session.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_rsa_*_cap()
+ *        This function should be used to enable RSA capabilities. Specific modes and parameters
+ *        can use acvp_enable_rsa_cap_parm, acvp_enable_rsa_bignum_parm,
+ *        acvp_enable_rsa_primes_parm depending on the need.
+ *
+ *        When the application enables a crypto capability, such as RSA, it also needs to specify a
+ *        callback function that will be used by libacvp when that crypto capability is needed
+ *        during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_rsa_keygen_enable(ACVP_CTX *ctx,
                                        ACVP_CIPHER cipher,
@@ -2845,23 +2821,21 @@ ACVP_RESULT acvp_cap_ecdsa_enable(ACVP_CTX *ctx,
                                   ACVP_CIPHER cipher,
                                   int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_rsa_*_cap_parm() allows an application to specify
-       operational parameters to be used for a given RSA alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable parameters for
-    RSA capabilities that will be tested by the ACVP server. This function may be called
-    multiple times to specify more than one crypto capability.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param mode ACVP_RSA_MODE enum value specifying mode. An example would be
-        ACVP_RSA_MODE_KEYGEN
-    @param param ACVP_RSA_PARM enum value identifying the algorithm parameter
-       that is being specified.  An example would be public exponent
-    @param value the value corresponding to the parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_rsa_*_cap_parm() allows an application to specify operational parameters to
+ *        be used for a given RSA alg during a test session with the ACVP server. This function
+ *        should be called to enable parameters for RSA capabilities that will be tested by the
+ *        ACVP server. This function may be called multiple times to specify more than one crypto
+ *        capability.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param mode ACVP_RSA_MODE enum value specifying mode. An example would be ACVP_RSA_MODE_KEYGEN
+ * @param param ACVP_RSA_PARM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be public exponent
+ * @param value the value corresponding to the parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_rsa_keygen_set_parm(ACVP_CTX *ctx,
                                          ACVP_RSA_PARM param,
@@ -2911,22 +2885,20 @@ ACVP_RESULT acvp_cap_ecdsa_set_curve_hash_alg(ACVP_CTX *ctx,
                                               ACVP_HASH_ALG alg);
 
 
-/*! @brief acvp_enable_rsa_bignum_parm() allows an application to specify
-       BIGNUM operational parameters to be used for a given RSA alg during a
-       test session with the ACVP server.
-
-    This function behaves the same as acvp_enable_rsa_cap_parm() but instead
-    allows the application to specify a BIGNUM parameter
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param mode ACVP_RSA_MODE enum value specifying mode. An example would be
-        ACVP_RSA_MODE_KEYGEN
-    @param param ACVP_RSA_PARM enum value identifying the algorithm parameter
-       that is being specified.  An example would be public exponent
-    @param value BIGNUM value corresponding to the parameter being set
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_rsa_bignum_parm() allows an application to specify BIGNUM operational
+ *        parameters to be used for a given RSA alg during a test session with the ACVP server.
+ *        This function behaves the same as acvp_enable_rsa_cap_parm() but instead allows the
+ *        application to specify a BIGNUM parameter
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param mode ACVP_RSA_MODE enum value specifying mode. An example would be ACVP_RSA_MODE_KEYGEN
+ * @param param ACVP_RSA_PARM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be public exponent
+ * @param value BIGNUM value corresponding to the parameter being set
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_rsa_keygen_set_exponent(ACVP_CTX *ctx,
                                              ACVP_RSA_PARM param,
@@ -2935,27 +2907,23 @@ ACVP_RESULT acvp_cap_rsa_sigver_set_exponent(ACVP_CTX *ctx,
                                              ACVP_RSA_PARM param,
                                              char *value);
 
-/*! @brief acvp_enable_rsa_primes_parm() allows an application to specify
-        RSA key generation provable or probable primes parameters for use
-        during a test session with the ACVP server.
-
-        The function behaves similarly to acvp_enable_rsa_cap_parm() and
-        acvp_enable_rsa_*_exp_parm() but allows for a modulo and hash
-        algorithm parameter to be specified alongside the provable or
-        probable parameter.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param mode ACVP_RSA_MODE enum value specifying mode. In this case it
-       will always be ACVP_RSA_MODE_KEYGEN
-   @param mod Supported RSA modulo value for probable or provable prime
-       generation
-   @param param ACVP_RSA_PRIME_PARAM enum value identifying the parameter
-                that will be given for the \p value.
-                One of: ACVP_RSA_PRIME_HASH_ALG, ACVP_RSA_PRIME_TEST
-   @param value Integer value corresponding to the specified \p param.
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_rsa_primes_parm() allows an application to specify RSA key generation
+ *        provable or probable primes parameters for use during a test session with the ACVP
+ *        server. The function behaves similarly to acvp_enable_rsa_cap_parm() and
+ *        acvp_enable_rsa_*_exp_parm() but allows for a modulo and hash algorithm parameter to be
+ *        specified alongside the provable or probable parameter.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param mode ACVP_RSA_MODE enum value specifying mode. In this case it will always be
+ *        ACVP_RSA_MODE_KEYGEN
+ * @param mod Supported RSA modulo value for probable or provable prime generation
+ * @param param ACVP_RSA_PRIME_PARAM enum value identifying the parameter that will be given for
+ *              the \p value. One of: ACVP_RSA_PRIME_HASH_ALG, ACVP_RSA_PRIME_TEST
+ * @param value Integer value corresponding to the specified \p param.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_rsa_keygen_set_primes(ACVP_CTX *ctx,
                                            ACVP_RSA_KEYGEN_MODE mode,
@@ -2963,64 +2931,59 @@ ACVP_RESULT acvp_cap_rsa_keygen_set_primes(ACVP_CTX *ctx,
                                            ACVP_RSA_PRIME_PARAM param,
                                            int value);
 
-/*! @brief acvp_enable_hmac_cap() allows an application to specify an
-       HMAC capability to be tested by the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    hmac algorithms that will be tested by the ACVP server.  This
-    includes HMAC-SHA-1, HMAC-SHA2-256, HMAC-SHA2-384, etc.  This function may be called
-    multiple times to specify more than one crypto capability.
-
-    When the application enables a crypto capability, such as HMAC-SHA-1, it
-    also needs to specify a callback function that will be used by libacvp
-    when that crypto capability is needed during a test session.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_hmac_cap() allows an application to specify an HMAC capability to be tested
+ *        by the ACVP server. This function should be called to enable crypto capabilities for hmac
+ *        algorithms that will be tested by the ACVP server. This includes HMAC-SHA-1,
+ *        HMAC-SHA2-256, HMAC-SHA2-384, etc. This function may be called multiple times to specify
+ *        more than one crypto capability.
+ *
+ *        When the application enables a crypto capability, such as HMAC-SHA-1, it also needs to
+ *        specify a callback function that will be used by libacvp when that crypto capability is
+ *        needed during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_hmac_enable(ACVP_CTX *ctx,
                                  ACVP_CIPHER cipher,
                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_hmac_cap_parm() allows an application to specify
-        operational parameters for use during a test session with the
-        ACVP server.
-
-        This function allows the application to specify parameters for use
-        when registering HMAC capability with the server.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param parm ACVP_HMAC_PARM enum value specifying parameter
-   @param value Supported value for the corresponding parameter
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_hmac_cap_parm() allows an application to specify operational parameters for
+ *        use during a test session with the ACVP server. This function allows the application to
+ *        specify parameters for use when registering HMAC capability with the server.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param parm ACVP_HMAC_PARM enum value specifying parameter
+ * @param value Supported value for the corresponding parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_hmac_set_parm(ACVP_CTX *ctx,
                                    ACVP_CIPHER cipher,
                                    ACVP_HMAC_PARM parm,
                                    int value);
 
-/*! @brief Allows an application to specify operational parameters for use
-        during a test session with the ACVP server.
-
-        This function allows the application to specify parameters for use
-        when registering HMAC capability with the server.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param parm ACVP_HMAC_PARM enum value specifying parameter
-   @param min Minumum supported value for the corresponding parameter
-   @param max Maximum supported value for the corresponding parameter
-   @param increment Increment value supported
-
-   @return ACVP_RESULT
+/**
+ * @brief Allows an application to specify operational parameters for use during a test session
+ *        with the ACVP server.This function allows the application to specify parameters for use
+ *        when registering HMAC capability with the server.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param parm ACVP_HMAC_PARM enum value specifying parameter
+ * @param min Minumum supported value for the corresponding parameter
+ * @param max Maximum supported value for the corresponding parameter
+ * @param increment Increment value supported
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_hmac_set_domain(ACVP_CTX *ctx,
                                      ACVP_CIPHER cipher,
@@ -3029,65 +2992,59 @@ ACVP_RESULT acvp_cap_hmac_set_domain(ACVP_CTX *ctx,
                                      int max,
                                      int increment);
 
-/*! @brief acvp_enable_cmac_cap() allows an application to specify an
-       CMAC capability to be tested by the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    cmac algorithms that will be tested by the ACVP server.  This
-    includes CMAC-AES-128, CMAC-AES-192, CMAC-AES-256, etc.  This function may be called
-    multiple times to specify more than one crypto capability.
-
-    When the application enables a crypto capability, such as CMAC-AES-128, it
-    also needs to specify a callback function that will be used by libacvp
-    when that crypto capability is needed during a test session.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_cmac_cap() allows an application to specify an CMAC capability to be tested
+ *         by the ACVP server. This function should be called to enable crypto capabilities for
+ *         cmac algorithms that will be tested by the ACVP server. This includes CMAC-AES-128,
+ *         CMAC-AES-192, CMAC-AES-256, etc. This function may be called multiple times to specify
+ *         more than one crypto capability.
+ *
+ *         When the application enables a crypto capability, such as CMAC-AES-128, it also needs to
+ *         specify a callback function that will be used by libacvp when that crypto capability is
+ *         needed during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_cmac_enable(ACVP_CTX *ctx,
                                  ACVP_CIPHER cipher,
                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_cmac_cap_parm() allows an application to specify
-        operational parameters for use during a test session with the
-        ACVP server.
-
-        This function allows the application to specify parameters for use
-        when registering CMAC capability with the server.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param parm ACVP_CMAC_PARM enum value specifying parameter
-   @param value Supported value for the corresponding parameter
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_cmac_cap_parm() allows an application to specify operational parameters for
+ *        use during a test session with the ACVP server. This function allows the application to
+ *        specify parameters for use when registering CMAC capability with the server.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param parm ACVP_CMAC_PARM enum value specifying parameter
+ * @param value Supported value for the corresponding parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_cmac_set_parm(ACVP_CTX *ctx,
                                    ACVP_CIPHER cipher,
                                    ACVP_CMAC_PARM parm,
                                    int value);
 
-/*! @brief acvp_cap_cmac_set_domain() allows an application to specify
-        operational parameters for use during a test session with the
-        ACVP server.
-
-        This function allows the application to specify parameters for use
-        when registering CMAC capability with the server.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-   @param parm ACVP_CMAC_PARM enum value specifying parameter
-   @param min Minumum upported value for the corresponding parameter
-   @param max Maximum ssupported value for the corresponding parameter
-   @param increment Increment value supported
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_cap_cmac_set_domain() allows an application to specify operational parameters for
+ *        use during a test session with the ACVP server. This function allows the application to
+ *        specify parameters for use when registering CMAC capability with the server.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param parm ACVP_CMAC_PARM enum value specifying parameter
+ * @param min Minumum upported value for the corresponding parameter
+ * @param max Maximum ssupported value for the corresponding parameter
+ * @param increment Increment value supported
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_cmac_set_domain(ACVP_CTX *ctx,
                                      ACVP_CIPHER cipher,
@@ -3096,21 +3053,19 @@ ACVP_RESULT acvp_cap_cmac_set_domain(ACVP_CTX *ctx,
                                      int max,
                                      int increment);
 
-/*! @brief acvp_enable_kdf135_*_cap() allows an application to specify a
-       kdf cipher capability to be tested by the ACVP server.
-
-    When the application enables a crypto capability, such as KDF135_TLS, it
-    also needs to specify a callback function that will be used by libacvp
-    when that crypto capability is needed during a test session.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param crypto_handler Address of function implemented by application that
-       is invoked by libacvp when the crypto capability is needed during
-       a test session. This crypto_handler function is expected to return
-       0 on success and 1 for failure.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_*_cap() allows an application to specify a kdf cipher capability to be
+ *        tested by the ACVP server. When the application enables a crypto capability, such as
+ *        KDF135_TLS, it also needs to specify a callback function that will be used by libacvp
+ *        when that crypto capability is needed during a test session.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param crypto_handler Address of function implemented by application that is invoked by libacvp
+ *        when the crypto capability is needed during a test session. This crypto_handler function
+ *        is expected to return 0 on success and 1 for failure.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf135_tls_enable(ACVP_CTX *ctx,
                                        int (*crypto_handler)(ACVP_TEST_CASE *test_case));
@@ -3142,40 +3097,36 @@ ACVP_RESULT acvp_cap_pbkdf_enable(ACVP_CTX *ctx,
 ACVP_RESULT acvp_cap_kdf_tls13_enable(ACVP_CTX *ctx,
                                   int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_kdf135_tls_cap_parm() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_enable_kdf135_tls_cap() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cap ACVP_CIPHER enum value identifying the crypto capability, here it
-        will always be ACVP_KDF135_TLS
-   @param method ACVP_KDF135_TLS_METHOD enum value specifying method type
-   @param param ACVP_HASH_ALG enum value
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_tls_cap_parm() allows an application to specify operational parameters
+ *        to be used during a test session with the ACVP server. This function should be called
+ *        after acvp_enable_kdf135_tls_cap() to specify the parameters for the corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cap ACVP_CIPHER enum value identifying the crypto capability, here it will always be
+ *        ACVP_KDF135_TLS
+ * @param method ACVP_KDF135_TLS_METHOD enum value specifying method type
+ * @param param ACVP_HASH_ALG enum value
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf135_tls_set_parm(ACVP_CTX *ctx,
                                          ACVP_CIPHER cap,
                                          ACVP_KDF135_TLS_METHOD method,
                                          ACVP_HASH_ALG param);
 
-/*! @brief acvp_enable_kdf135_ssh_cap_parm() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_enable_kdf135_tls_cap() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cap ACVP_CIPHER enum value identifying the crypto capability, here it
-        will always be ACVP_KDF135_SSH
-   @param method ACVP_KDF135_SSH_METHOD enum value specifying method type
-   @param param ACVP_HASH_ALG enum value
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_ssh_cap_parm() allows an application to specify operational parameters
+ *        to be used during a test session with the ACVP server. This function should be called
+ *        after acvp_enable_kdf135_tls_cap() to specify the parameters for the corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cap ACVP_CIPHER enum value identifying the crypto capability, here it will always be
+ *        ACVP_KDF135_SSH
+ * @param method ACVP_KDF135_SSH_METHOD enum value specifying method type
+ * @param param ACVP_HASH_ALG enum value
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf135_ssh_set_parm(ACVP_CTX *ctx,
                                          ACVP_CIPHER cap,
@@ -3183,159 +3134,151 @@ ACVP_RESULT acvp_cap_kdf135_ssh_set_parm(ACVP_CTX *ctx,
                                          ACVP_HASH_ALG param);
 
 
-/*! @brief acvp_enable_kdf135_srtp_cap_parm() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_enable_kdf135_srtp_cap() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cap ACVP_CIPHER enum value identifying the crypto capability, here it
-        will always be ACVP_KDF135_SRTP
-   @param param acvp_enable_kdf135_srtp_cap_parm enum value specifying parameter
-   @param value integer value for parameter
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_srtp_cap_parm() allows an application to specify operational
+ *        parameters to be used during a test session with the ACVP server. This function should be
+ *        called after acvp_enable_kdf135_srtp_cap() to specify the parameters for the
+ *        corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cap ACVP_CIPHER enum value identifying the crypto capability, here it will always be
+ *        ACVP_KDF135_SRTP
+ * @param param acvp_enable_kdf135_srtp_cap_parm enum value specifying parameter
+ * @param value integer value for parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf135_srtp_set_parm(ACVP_CTX *ctx,
                                           ACVP_CIPHER cap,
                                           ACVP_KDF135_SRTP_PARAM param,
                                           int value);
 
-/*! @brief acvp_enable_kdf108_cap_parm() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_enable_kdf108_cap() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param cap ACVP_KDF108_MODE enum value identifying the kdf108 mode
-   @param param ACVP_KDF108_PARM enum value specifying parameter
-   @param value integer value for parameter
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf108_cap_parm() allows an application to specify operational parameters to
+ *        be used during a test session with the ACVP server. This function should be called after
+ *        acvp_enable_kdf108_cap() to specify the parameters for the corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cap ACVP_KDF108_MODE enum value identifying the kdf108 mode
+ * @param param ACVP_KDF108_PARM enum value specifying parameter
+ * @param value integer value for parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf108_set_parm(ACVP_CTX *ctx,
                                      ACVP_KDF108_MODE mode,
                                      ACVP_KDF108_PARM param,
                                      int value);
 
-/*! @brief acvp_enable_kdf135_x963_cap_param() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_enable_kdf135_srtp_cap() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param param ACVP_KDF135_X963_PARM enum value specifying parameter
-   @param value integer value for parameter. The acceptable hash algs are defined
-            in an enum ACVP_KDF135_X963_HASH_VALS in the library
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_x963_cap_param() allows an application to specify operational
+ *        parameters to be used during a test session with the ACVP server. This function should be
+ *        called after acvp_enable_kdf135_srtp_cap() to specify the parameters for the
+ *        corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param param ACVP_KDF135_X963_PARM enum value specifying parameter
+ * @param value integer value for parameter. The acceptable hash algs are defined in an enum
+ *        ACVP_KDF135_X963_HASH_VALS in the library
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf135_x963_set_parm(ACVP_CTX *ctx,
                                           ACVP_KDF135_X963_PARM param,
                                           int value);
 
-/*! @brief acvp_enable_kdf135_snmp_cap_parm() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_enable_kdf135_srtp_cap() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param kcap ACVP_CIPHER enum value specifying parameter
-   @param param ACVP_KDF135_SNMP_PARAM enum value specifying parameter
-   @param value integer value for parameter
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_snmp_cap_parm() allows an application to specify operational
+ *        parameters to be used during a test session with the ACVP server.  This function should
+ *        be called after acvp_enable_kdf135_srtp_cap() to specify the parameters for the
+ *        corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param kcap ACVP_CIPHER enum value specifying parameter
+ * @param param ACVP_KDF135_SNMP_PARAM enum value specifying parameter
+ * @param value integer value for parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf135_snmp_set_parm(ACVP_CTX *ctx,
                                           ACVP_CIPHER kcap,
                                           ACVP_KDF135_SNMP_PARAM param,
                                           int value);
 
-/*! @brief acvp_enable_kdf135_snmp_engid_parm() allows an application to specify
-        a custom engid to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_enable_kdf135_snmp_cap() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param kcap ACVP_CIPHER enum value specifying parameter
-   @param engid a hexadecimal string representing engine ID
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_snmp_engid_parm() allows an application to specify a custom engid to
+ *        be used during a test session with the ACVP server. This function should be called after
+ *        acvp_enable_kdf135_snmp_cap() to specify the parameters for the corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param kcap ACVP_CIPHER enum value specifying parameter
+ * @param engid a hexadecimal string representing engine ID
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf135_snmp_set_engid(ACVP_CTX *ctx,
                                            ACVP_CIPHER kcap,
                                            const char *engid);
 
-/*! @brief acvp_enable_kdf135_ikev2_cap_param() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param param ACVP_KDF135_IKEV2_PARM enum specifying parameter to enable.
-            Here it is always ACVP_KDF_HASH_ALG. Other params should be enabled
-            with acvp_enable_kdf135_ikev2_domain_param
-    @param value String value for parameter
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_ikev2_cap_param() allows an application to specify operational
+ *        parameters to be used during a test session with the ACVP server.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param param ACVP_KDF135_IKEV2_PARM enum specifying parameter to enable. Here it is always
+ *        ACVP_KDF_HASH_ALG. Other params should be enabled with
+ *        acvp_enable_kdf135_ikev2_domain_param
+ * @param value String value for parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf135_ikev2_set_parm(ACVP_CTX *ctx,
                                            ACVP_KDF135_IKEV2_PARM param,
                                            int value);
 
-/*! @brief acvp_enable_kdf135_ikev1_cap_param() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param param ACVP_KDF135_IKEV1_PARM enum specifying parameter to enable.
-            Here it is ACVP_KDF_HASH_ALG or ACVP_KDF_IKEv1_AUTH_METHOD. Other
-            params should be enabled with acvp_enable_kdf135_ikev1_domain_param
-    @param value String value for parameter
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_ikev1_cap_param() allows an application to specify operational
+ *        parameters to be used during a test session with the ACVP server.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param param ACVP_KDF135_IKEV1_PARM enum specifying parameter to enable. Here it is
+ *        ACVP_KDF_HASH_ALG or ACVP_KDF_IKEv1_AUTH_METHOD. Other params should be enabled with
+ *        acvp_enable_kdf135_ikev1_domain_param
+ * @param value String value for parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf135_ikev1_set_parm(ACVP_CTX *ctx,
                                            ACVP_KDF135_IKEV1_PARM param,
                                            int value);
 
-/*! @brief acvp_enable_kdf135_ikev2_cap_len_param() allows an application to specify
-        operational lengths to be used during a test session with the ACVP
-        server.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param param ACVP_KDF135_IKEV2_PARM enum specifying parameter to enable.
-    @param value length
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_ikev2_cap_len_param() allows an application to specify operational
+ *        lengths to be used during a test session with the ACVP server.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param param ACVP_KDF135_IKEV2_PARM enum specifying parameter to enable.
+ * @param value length
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf135_ikev2_set_length(ACVP_CTX *ctx,
                                              ACVP_KDF135_IKEV2_PARM param,
                                              int value);
 
-/*! @brief acvp_enable_kdf135_ikev2_domain_param() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_enable_kdf135_ikev2_cap() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param param ACVP_KDF135_IKEV2_PARM enum value identifying the IKEv2 parameter
-   @param min integer minimum for domain parameter
-   @param max integer maximum for domain parameter
-   @param increment integer increment for domain parameter
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_ikev2_domain_param() allows an application to specify operational
+ *        parameters to be used during a test session with the ACVP server. This function should be
+ *        called after acvp_enable_kdf135_ikev2_cap() to specify the parameters for the
+ *        corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param param ACVP_KDF135_IKEV2_PARM enum value identifying the IKEv2 parameter
+ * @param min integer minimum for domain parameter
+ * @param max integer maximum for domain parameter
+ * @param increment integer increment for domain parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf135_ikev2_set_domain(ACVP_CTX *ctx,
                                              ACVP_KDF135_IKEV2_PARM param,
@@ -3343,20 +3286,19 @@ ACVP_RESULT acvp_cap_kdf135_ikev2_set_domain(ACVP_CTX *ctx,
                                              int max,
                                              int increment);
 
-/*! @brief acvp_enable_kdf135_ikev1_set_domain() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_cap_kdf135_ikev1_enable() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param param ACVP_KDF135_IKEV1_PARM enum value identifying the IKEv1 parameter
-   @param min integer minimum for domain parameter
-   @param max integer maximum for domain parameter
-   @param increment integer increment for domain parameter
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf135_ikev1_set_domain() allows an application to specify operational
+ *        parameters to be used during a test session with the ACVP server. This function should be
+ *        called after acvp_cap_kdf135_ikev1_enable() to specify the parameters for the
+ *        corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param param ACVP_KDF135_IKEV1_PARM enum value identifying the IKEv1 parameter
+ * @param min integer minimum for domain parameter
+ * @param max integer maximum for domain parameter
+ * @param increment integer increment for domain parameter
+ *
+ * @return ACVP_RESULT
  */
 
 ACVP_RESULT acvp_cap_kdf135_ikev1_set_domain(ACVP_CTX *ctx,
@@ -3365,21 +3307,19 @@ ACVP_RESULT acvp_cap_kdf135_ikev1_set_domain(ACVP_CTX *ctx,
                                              int max,
                                              int increment);
 
-/*! @brief acvp_enable_kdf108_set_domain() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_cap_kdf108_enable() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param param ACVP_KDF108_MODE enum value identifying the KDF108 mode
-   @param param ACVP_KDF108_PARM enum value identifying the KDF108 parameter
-   @param min integer minimum for domain parameter
-   @param max integer maximum for domain parameter
-   @param increment integer increment for domain parameter
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_kdf108_set_domain() allows an application to specify operational parameters
+ *        to be used during a test session with the ACVP server. This function should be called
+ *        after acvp_cap_kdf108_enable() to specify the parameters for the corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param param ACVP_KDF108_MODE enum value identifying the KDF108 mode
+ * @param param ACVP_KDF108_PARM enum value identifying the KDF108 parameter
+ * @param min integer minimum for domain parameter
+ * @param max integer maximum for domain parameter
+ * @param increment integer increment for domain parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf108_set_domain(ACVP_CTX *ctx,
                                        ACVP_KDF108_MODE mode,
@@ -3388,55 +3328,49 @@ ACVP_RESULT acvp_cap_kdf108_set_domain(ACVP_CTX *ctx,
                                        int max,
                                        int increment);
 
-/*! @brief acvp_enable_pbkdf_set_domain() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_cap_pbkdf_enable() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param param ACVP_PBKDF_PARM enum value identifying the PBKDF parameter
-   @param min integer minimum for domain parameter
-   @param max integer maximum for domain parameter
-   @param increment integer increment for domain parameter
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_enable_pbkdf_set_domain() allows an application to specify operational parameters to
+ *        be used during a test session with the ACVP server. This function should be called after
+ *        acvp_cap_pbkdf_enable() to specify the parameters for the corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param param ACVP_PBKDF_PARM enum value identifying the PBKDF parameter
+ * @param min integer minimum for domain parameter
+ * @param max integer maximum for domain parameter
+ * @param increment integer increment for domain parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_pbkdf_set_domain(ACVP_CTX *ctx,
                                       ACVP_PBKDF_PARM param,
-                                      int min, int max, 
+                                      int min, int max,
                                       int increment);
 
-/*! @brief acvp_cap_pbkdf_set_parm() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_cap_pbkdf_enable() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param param ACVP_PBKDF_PARM enum value specifying parameter
-   @param value integer value for parameter
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_cap_pbkdf_set_parm() allows an application to specify operational parameters to be
+ *        used during a test session with the ACVP server. This function should be called after
+ *        acvp_cap_pbkdf_enable() to specify the parameters for the corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param param ACVP_PBKDF_PARM enum value specifying parameter
+ * @param value integer value for parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_pbkdf_set_parm(ACVP_CTX *ctx,
                                     ACVP_PBKDF_PARM param,
                                     int value);
 
-/*! @brief acvp_cap_kdf_tls13_set_parm() allows an application to specify
-        operational parameters to be used during a test session with the ACVP
-        server.
-
-        This function should be called after acvp_cap_kdf_tls13_enable() to
-        specify the parameters for the corresponding KDF.
-
-   @param ctx Address of pointer to a previously allocated ACVP_CTX.
-   @param param ACVP_KDF_TLS13_PARM enum value specifying parameter
-   @param value integer value for parameter
-
-   @return ACVP_RESULT
+/**
+ * @brief acvp_cap_kdf_tls13_set_parm() allows an application to specify operational parameters to
+ *        be used during a test session with the ACVP server. This function should be called after
+ *        acvp_cap_kdf_tls13_enable() to specify the parameters for the corresponding KDF.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param param ACVP_KDF_TLS13_PARM enum value specifying parameter
+ * @param value integer value for parameter
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_kdf_tls13_set_parm(ACVP_CTX *ctx,
                                         ACVP_KDF_TLS13_PARM param,
@@ -3446,27 +3380,24 @@ ACVP_RESULT acvp_cap_safe_primes_enable(ACVP_CTX *ctx,
                                         ACVP_CIPHER cipher,
                                         int (*crypto_handler)(ACVP_TEST_CASE *test_case));
 
-/*! @brief acvp_enable_safe_primes_cap_parm() allows an application to specify
-       operational parameters to be used for a given safe_primes alg during a
-       test session with the ACVP server.
-
-    This function should be called to enable crypto capabilities for
-    safe_primes capabilities that will be tested by the ACVP server.  This
-    includes KEYGEN and KEYVER.
-
-    This function may be called multiple times to specify more than one
-    crypto parameter value for the safe_primes algorithm. The ACVP_CIPHER value
-    passed to this function should already have been setup by invoking
-    acvp_cap_safe_primes_enable().
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability.
-    @param param ACVP_SAFE_PRIMES_PARAM enum value identifying the algorithm parameter
-       that is being specified.  
-    @param value the value corresponding to the parameter being set, at present only
-       generation mode is supported.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_safe_primes_cap_parm() allows an application to specify operational
+ *        parameters to be used for a given safe_primes alg during a test session with the ACVP
+ *        server. This function should be called to enable crypto capabilities for safe_primes
+ *        capabilities that will be tested by the ACVP server. This includes KEYGEN and KEYVER.
+ *
+ *        This function may be called multiple times to specify more than one crypto parameter
+ *        value for the safe_primes algorithm. The ACVP_CIPHER value passed to this function should
+ *        already have been setup by invoking acvp_cap_safe_primes_enable().
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param param ACVP_SAFE_PRIMES_PARAM enum value identifying the algorithm parameter that is being
+ *        specified.
+ * @param value the value corresponding to the parameter being set, at present only generation mode
+ *        is supported.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_safe_primes_set_parm(ACVP_CTX *ctx,
                                           ACVP_CIPHER cipher,
@@ -3475,240 +3406,216 @@ ACVP_RESULT acvp_cap_safe_primes_set_parm(ACVP_CTX *ctx,
 
 
 
-/*! @brief acvp_enable_prereq_cap() allows an application to specify a
-       prerequisite for a cipher capability that was previously registered.
-
-    @param ctx Address of pointer to a previously allocated ACVP_CTX.
-    @param cipher ACVP_CIPHER enum value identifying the crypto capability that has a prerequisite
-    @param pre_req_alg ACVP_PREREQ_ALG enum identifying the prerequisite
-    @param value value for specified prerequisite
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_enable_prereq_cap() allows an application to specify a prerequisite for a cipher
+ *        capability that was previously registered.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability that has a prerequisite
+ * @param pre_req_alg ACVP_PREREQ_ALG enum identifying the prerequisite
+ * @param value value for specified prerequisite
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cap_set_prereq(ACVP_CTX *ctx,
                                 ACVP_CIPHER cipher,
                                 ACVP_PREREQ_ALG pre_req_cap,
                                 char *value);
 
-/*! @brief acvp_create_test_session() creates a context that can be used to
-      commence a test session with an ACVP server.
-
-    This function should be called first to create a context that is used
-    to manage all the API calls into libacvp.  The context should be released
-    after the test session has completed by invoking acvp_free_test_session().
-
-    When creating a new test session, a function pointer can be provided
-    to receive logging messages from libacvp.  The application can then
-    forward the log messages to any logging service it desires, such as
-    syslog.
-
-    @param ctx Address of pointer to unallocated ACVP_CTX.
-    @param progress_cb Address of function to receive log messages from libacvp.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_create_test_session() creates a context that can be used to commence a test session
+ *        with an ACVP server. This function should be called first to create a context that is
+ *        used to manage all the API calls into libacvp. The context should be released after the
+ *        test session has completed by invoking acvp_free_test_session().
+ *
+ *        When creating a new test session, a function pointer can be provided to receive logging
+ *        messages from libacvp. The application can then forward the log messages to any logging
+ *        service it desires, such as syslog.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param progress_cb Address of function to receive log messages from libacvp.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_create_test_session(ACVP_CTX **ctx,
                                      ACVP_RESULT (*progress_cb)(char *msg),
                                      ACVP_LOG_LVL level);
 
-/*! @brief acvp_free_test_session() releases the memory associated with
-       an ACVP_CTX.
-
-    This function will free an ACVP_CTX.  Failure to invoke this function
-    will result in a memory leak in the application layer.  This function should
-    be invoked after a test session has completed and a reference to the context
-    is no longer needed.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param level Select the debug level, see ACVP_LOG_LVL
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_free_test_session() releases the memory associated withan ACVP_CTX. This function
+ *        will free an ACVP_CTX. Failure to invoke this function will result in a memory leak in
+ *        the application layer. This function should be invoked after a test session has completed
+ *        and a reference to the context is no longer needed.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param level Select the debug level, see ACVP_LOG_LVL
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_free_test_session(ACVP_CTX *ctx);
 
-/*! @brief acvp_set_server() specifies the ACVP server and TCP port
-       number to use when contacting the server.
-
-    This function is used to specify the hostname or IP address of
-    the ACVP server.  The TCP port number can also be specified if the
-    server doesn't use port 443.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param server_name Name or IP address of the ACVP server.
-    @param port TCP port number the server listens on.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_set_server() specifies the ACVP server and TCP port number to use when contacting
+ *        the server. This function is used to specify the hostname or IP address of the ACVP
+ *        server. The TCP port number can also be specified if the server doesn't use port 443.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param server_name Name or IP address of the ACVP server.
+ * @param port TCP port number the server listens on.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_set_server(ACVP_CTX *ctx, const char *server_name, int port);
 
-/*! @brief acvp_set_path_segment() specifies the URI prefix used by
-       the ACVP server.
-
-    Some ACVP servers use a prefix in the URI for the path to the ACVP
-    REST interface.  Calling this function allows the path segment
-    prefix to be specified.  The value provided to this function is
-    prepended to the path segment of the URI used for the ACVP
-    REST calls.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param path_segment Value to embed in the URI path after the server name and
-       before the ACVP well-known path.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_set_path_segment() specifies the URI prefix used by the ACVP server. Some ACVP
+ *        servers use a prefix in the URI for the path to the ACVP REST interface. Calling this
+ *        function allows the path segment prefix to be specified. The value provided to this
+ *        function is prepended to the path segment of the URI used for the ACVP REST calls.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param path_segment Value to embed in the URI path after the server name and before the ACVP
+ *        well-known path.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_set_path_segment(ACVP_CTX *ctx, const char *path_segment);
 
-/*! @brief acvp_set_api_context() specifies the URI prefix used by
-       the ACVP server.
-
-    Some ACVP servers use a context string in the URI for the path to
-    the REST interface.  Calling this function allows the API context
-    prefix to be specified.  The value provided to this function is
-    prepended to the path segment of the URI used for the ACVP
-    REST calls.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param api_context Value to embed in the URI path after the server name and
-       before the ACVP well-known path.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_set_api_context() specifies the URI prefix used by the ACVP server. Some ACVP
+ *        servers use a context string in the URI for the path to the REST interface. Calling this
+ *        function allows the API context prefix to be specified. The value provided to this
+ *        function is prepended to the path segment of the URI used for the ACVP REST calls.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param api_context Value to embed in the URI path after the server name and before the ACVP
+ *        well-known path.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_set_api_context(ACVP_CTX *ctx, const char *api_context);
 
-/*! @brief acvp_set_cacerts() specifies PEM encoded certificates to use
-       as the root trust anchors for establishing the TLS session with
-       the ACVP server.
-
-    ACVP uses TLS as the transport.  In order to verify the identity of
-    the ACVP server, the TLS stack requires one or more root certificates
-    that can be used to verify the identify of the ACVP TLS certificate
-    during the TLS handshake.  These root certificates are set using
-    this function.  They must be PEM encoded and all contained in the
-    same file.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param ca_file Name of file containing all the PEM encoded X.509 certificates used
-       as trust anchors for the TLS session.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_set_cacerts() specifies PEM encoded certificates to use as the root trust anchors
+ *        for establishing the TLS session with the ACVP server. ACVP uses TLS as the transport. In
+ *        order to verify the identity of the ACVP server, the TLS stack requires one or more root
+ *        certificates that can be used to verify the identify of the ACVP TLS certificate during
+ *        the TLS handshake. These root certificates are set using this function. They must be PEM
+ *        encoded and all contained in the same file.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param ca_file Name of file containing all the PEM encoded X.509 certificates used as trust
+ *        anchors for the TLS session.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_set_cacerts(ACVP_CTX *ctx, const char *ca_file);
 
-/*! @brief acvp_set_certkey() specifies PEM encoded certificate and
-       private key to use for establishing the TLS session with the
-       ACVP server.
-
-    ACVP uses TLS as the transport.  In order for the ACVP server to
-    verify the identity the DUT using libacvp, a certificate needs to
-    be presented during the TLS handshake.  The certificate used by libacvp
-    needs to be trusted by the ACVP server.  Otherwise the TLS handshake
-    will fail.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param cert_file Name of file containing the PEM encoded X.509 certificate to
-       use as the client identity.
-    @param key_file Name of file containing PEM encoded private key associated with
-       the client certificate.
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_set_certkey() specifies PEM encoded certificate and private key to use for
+ *        establishing the TLS session with the ACVP server. ACVP uses TLS as the transport. In
+ *        order for the ACVP server to verify the identity the DUT using libacvp, a certificate
+ *        needs to be presented during the TLS handshake. The certificate used by libacvp needs to
+ *        be trusted by the ACVP server. Otherwise the TLS handshake will fail.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cert_file Name of file containing the PEM encoded X.509 certificate to use as the client
+ *        identity.
+ * @param key_file Name of file containing PEM encoded private key associated with the client
+ *        certificate.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_set_certkey(ACVP_CTX *ctx, char *cert_file, char *key_file);
 
-/*! @brief acvp_mark_as_sample() marks the registration as a sample.
-
-    This function sets a flag that will allow the client to retrieve
-    the correct answers later on, allowing for comparison and
-    debugging.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
+/**
+ * @brief acvp_mark_as_sample() marks the registration as a sample. This function sets a flag that
+ *        will allow the client to retrieve the correct answers later on, allowing for comparison
+ *        and debugging.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_mark_as_sample(ACVP_CTX *ctx);
 
-/*! @brief acvp_mark_as_request_only() marks the registration as a request only.
-
-    This function sets a flag that will allow the client to retrieve
-    the vectors from the server and store them in a file for later use.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param filename Name of the file to be used for the request vectors
-
+/**
+ * @brief acvp_mark_as_request_only() marks the registration as a request only. This function sets
+ *         a flag that will allow the client to retrieve the vectors from the server and store them
+ *         in a file for later use.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param filename Name of the file to be used for the request vectors
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_mark_as_request_only(ACVP_CTX *ctx, char *filename);
 
-/*! @brief acvp_mark_as_get_only() marks the operation as a GET only.
-
-    This function will take the string parameter and perform a GET to check
-    the get of a specific request.  The request ID must be part of the string.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param string used for the get, such as '/acvp/v1/requests/383'
-
+/**
+ * @brief acvp_mark_as_get_only() marks the operation as a GET only. This function will take the
+ *        string parameter and perform a GET to check the get of a specific request. The request ID
+ *        must be part of the string.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param string used for the get, such as '/acvp/v1/requests/383'
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_mark_as_get_only(ACVP_CTX *ctx, char *string);
 
-/*! @brief acvp_set_get_save_file() indicates a file to save get requests to.
-
-    This function will only work if acvp_mark_as_get_only() has already been
-    successfully called. It will take a string parameter for the location
-    to save the results from the GET request indicated in acvp_mark_as_get_only()
-    to as a file.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param filename location to save the GET results to (assumes data in JSON format)
-
+/**
+ * @brief acvp_set_get_save_file() indicates a file to save get requests to. This function will
+ *        only work if acvp_mark_as_get_only() has already been successfully called. It will take a
+ *        string parameter for the location to save the results from the GET request indicated in
+ *        acvp_mark_as_get_only() to as a file.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param filename location to save the GET results to (assumes data in JSON format)
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_set_get_save_file(ACVP_CTX *ctx, char *filename);
 
-/*! @brief acvp_mark_as_post_only() marks the operation as a POST only.
-
-    This function will take the filename and perform a POST of the data
-    in the file to the URL /acvp/v1/<first field in file>
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param filename file containing URL and content to POST
-
+/**
+ * @brief acvp_mark_as_post_only() marks the operation as a POST only. This function will take the
+ *        filename and perform a POST of the data in the file to the URL
+ *        /acvp/v1/<first field in file>
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param filename file containing URL and content to POST
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_mark_as_post_only(ACVP_CTX *ctx, char *filename);
 
-/*! @brief acvp_mark_as_delete only() marks the operation as a DELETE only.
-
-    This function will perform an HTTP DELETE call on the resource at the
-    givenURL.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param request_url url of resource to delete
-
+/**
+ * @brief acvp_mark_as_delete only() marks the operation as a DELETE only. This function will
+ *        perform an HTTP DELETE call on the resource at the givenURL.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param request_url url of resource to delete
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_mark_as_delete_only(ACVP_CTX *ctx, char *request_url);
 
 ACVP_RESULT acvp_mark_as_put_after_test(ACVP_CTX *ctx, char *filename);
 
 
-/*! @brief Performs the ACVP testing procedures.
+/**
+ * @brief Performs the ACVP testing procedures.
+ *        This function will do the following actions:
+ *          1. Verify the provided metadata if user has specified \p fips_validation.
+ *          2. Register a new testSession with the ACVP server with the capabilities attached to
+ *             the \p ctx.
+ *          3. Communicate with the ACVP server to acquire the test vectors, calculate the results
+ *             and upload the results to the server.
+ *          4. Check the results of each vector associated with the testSession. The success or
+ *             failure information will be printed to stderr.
+ *          5. Request that the ACVP server perform a FIPS validation (if \p fips_validation == 1
+ *             and testSession is passed).
  *
- * This function will do the following actions:
- *   1. Verify the provided metadata if user has specified \p fips_validation.
- *   2. Register a new testSession with the ACVP server with the capabilities attached to the \p ctx.
- *   3. Communicate with the ACVP server to acquire the test vectors, calculate the results
- *      and upload the results to the server.
- *   4. Check the results of each vector associated with the testSession. The success or failure
- *      information will be printed to stderr.
- *   5. Request that the ACVP server perform a FIPS validation (if \p fips_validation == 1 and testSession is passed).
- *
- * @param ctx Pointer to ACVP_CTX that was previously created by
- *            calling acvp_create_test_session.
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
  *
  * @return ACVP_RESULT
  */
@@ -3740,144 +3647,148 @@ ACVP_RESULT acvp_oe_oe_set_dependency(ACVP_CTX *ctx,
                                       unsigned int oe_id,
                                       unsigned int dependency_id);
 
-/*! @brief acvp_set_json_filename specifies JSON registration file
- *  to be used during registration. This allows the app to skip the
- *  acvp_enable_* API calls
+/**
+ * @brief acvp_set_json_filename specifies JSON registration file to be used during registration.
+ *        This allows the app to skip the acvp_enable_* API calls
  *
- * @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
- * @param json_filename Name of the file that contains the JSON
- *      registration
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param json_filename Name of the file that contains the JSON registration
+ *
  * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_set_json_filename(ACVP_CTX *ctx, const char *json_filename);
 
-/*! @brief acvp_load_kat_filename loads and processes JSON kat vector file
- *  This option will not communicate with the server at all.
+/**
+ * @brief acvp_load_kat_filename loads and processes JSON kat vector file This option will not
+ *        communicate with the server at all.
  *
- * @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
- * @param kat_filename Name of the file that contains the JSON
- *      kat vectors
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param kat_filename Name of the file that contains the JSON kat vectors
+ *
  * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_load_kat_filename(ACVP_CTX *ctx, const char *kat_filename);
 
-/*! @brief Uploads a set of vector set responses that were processed from an
- * offline vector set JSON file.
+/**
+ * @brief Uploads a set of vector set responses that were processed from an offline vector set JSON
+ *        file.
  *
- * @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
- * @param rsp_filename Name of the file that contains the completed vector set
- *      results
- * @param fips_validation Should be != 0 in case of fips validation (metadata must
- *      be provided)
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param rsp_filename Name of the file that contains the completed vector set results
+ * @param fips_validation Should be != 0 in case of fips validation (metadata must be provided)
+ *
  * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_upload_vectors_from_file(ACVP_CTX *ctx, const char *rsp_filename, int fips_validation);
 
-/*! @brief Runs a set of tests from vector sets that were saved to a file and saves
- * the results in a different file.
+/**
+ * @brief Runs a set of tests from vector sets that were saved to a file and saves the results in a
+ *        different file.
  *
- * @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
  * @param req_filename Name of the file that contains the unprocessed vector sets
  * @param rsp_filename Name of the file to save vector set test results to
+ *
  * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_run_vectors_from_file(ACVP_CTX *ctx, const char *req_filename, const char *rsp_filename);
 
-/*! @brief performs an HTTP PUT on a given libacvp JSON file to the ACV server
+/**
+ * @brief performs an HTTP PUT on a given libacvp JSON file to the ACV server
  *
- * @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
  * @param put_filename name of the file to PUT to the ACV server
+ *
  * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_put_data_from_file(ACVP_CTX *ctx, const char *put_filename);
 
-/*! @brief Retrieves the results of an already-completed test session
+/**
+ * @brief Retrieves the results of an already-completed test session
  *
- * @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
  * @param request_filename File containing the session info created by libacvp
+ *
  * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_get_results_from_server(ACVP_CTX *ctx, const char *request_filename);
 
-/*! @brief Gets the expected test results for test sessions marked as samples
- * 
- * @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
+/**
+ * @brief Gets the expected test results for test sessions marked as samples
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
  * @param request_filename File containing the session info created by libacvp
- * @param save_filename path/name for file to save the expected results too. OPTIONAL.
-          If null, will print expected results to log.
-   @return ACVP_RESULT
+ * @param save_filename path/name for file to save the expected results too. OPTIONAL. If null,
+ *        will print expected results to log.
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_get_expected_results(ACVP_CTX *ctx, const char *request_filename, const char *save_filename);
 
-/*! @brief Queries the server for any vector sets that have not received a response
- * (e.x. in case of lose of connectivity during testing), downloads those vector sets,
- * and continues to process them
+/**
+ * @brief Queries the server for any vector sets that have not received a response (e.x. in case of
+ *        lose of connectivity during testing), downloads those vector sets, and continues to
+ *        process them
  *
- * @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
  * @param request_filename File containing the session info created by libacvp
- * @param fips_validation Should be != 0 in case of fips validation (metadata must
- *      be provided)
+ * @param fips_validation Should be != 0 in case of fips validation (metadata must be provided)
+ *
  * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_resume_test_session(ACVP_CTX *ctx, const char *request_filename, int fips_validation);
 
 
-/*! @brief Requests the server to cancel a test session and delete associated data
+/**
+ * @brief Requests the server to cancel a test session and delete associated data
  *
- * @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
  * @param request_filename File containing the session info created by libacvp
  * @param save_filename OPTIONAL arugment indicated a file the server response can be saved to.
- *      leave NULL if not applicable
+ *        Leave NULL if not applicable
  *
  * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_cancel_test_session(ACVP_CTX *ctx, const char *request_filename, const char *save_filename);
 
-/*! @brief acvp_set_2fa_callback() sets a callback function which
-    will create or obtain a TOTP password for the second part of
-    the two-factor authentication.
-
-    @param ctx Pointer to ACVP_CTX that was previously created by
-        calling acvp_create_test_session.
-    @param totp_cb Function that will get the TOTP password
-
-
-    @return ACVP_RESULT
+/**
+ * @brief acvp_set_2fa_callback() sets a callback function which will create or obtain a TOTP
+ *        password for the second part of the two-factor authentication.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param totp_cb Function that will get the TOTP password
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_set_2fa_callback(ACVP_CTX *ctx, ACVP_RESULT (*totp_cb)(char **token, int token_max));
 
-/*! @brief acvp_bin_to_hexstr() Converts a binary string to hex
-
-    @param src Pointer to the binary source string
-    @param src_len Length of source sting in bytes
-    @param dest Length of destination hex string
-    @param dest_max Maximum length allowed for destination
-    @return ACVP_RESULT
+/**
+ * @brief acvp_bin_to_hexstr() Converts a binary string to hex
+ *
+ * @param src Pointer to the binary source string
+ * @param src_len Length of source sting in bytes
+ * @param dest Length of destination hex string
+ * @param dest_max Maximum length allowed for destination
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_bin_to_hexstr(const unsigned char *src, int src_len, char *dest, int dest_max);
 
-/*! @brief acvp_hexstr_to_bin() Converts a hex string to binary
-
-    @param src Pointer to the hex source string
-    @param src_len Length of source sting in bytes
-    @param dest Length of destination binary string
-    @param dest_max Maximum length allowed for destination
-    @return ACVP_RESULT
+/**
+ * @brief acvp_hexstr_to_bin() Converts a hex string to binary
+ *
+ * @param src Pointer to the hex source string
+ * @param src_len Length of source sting in bytes
+ * @param dest Length of destination binary string
+ * @param dest_max Maximum length allowed for destination
+ *
+ * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_hexstr_to_bin(const char *src, unsigned char *dest, int dest_max, int *converted_len);
 
-/*! @brief acvp_lookup_error_string() is a utility that
- * returns a more descriptive string for an ACVP_RESULT
- * error code
+/**
+ * @brief acvp_lookup_error_string() is a utility that returns a more descriptive string for an ACVP_RESULT
+ *        error code
  *
  * @param rv ACVP_RESULT error code
  *
@@ -3887,20 +3798,26 @@ const char *acvp_lookup_error_string(ACVP_RESULT rv);
 
 char *lower_string(const char *s);
 
-/*! @brief acvp_cleanup() extends the curl_global_cleanup
- * function to applications using libacvp to perform
- * cleanup of curl resources
+/**
+ * @brief acvp_cleanup() extends the curl_global_cleanup function to applications using libacvp to
+ *        perform cleanup of curl resources
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ *
+ * @return ACVP_RESULT
  *
  */
 ACVP_RESULT acvp_cleanup(ACVP_CTX *ctx);
 
-/*! @brief acvp_version() fetch the library version string
+/**
+ * @brief acvp_version() fetch the library version string
  *
  * @return (char *) library string, formatted like: libacvp_oss-1.0.0
  */
 const char *acvp_version(void);
 
-/*! @brief acvp_protocol_version() fetch the protocol version string
+/**
+ * @brief acvp_protocol_version() fetch the protocol version string
  *
  * @return (char *) protocol version, formated like: 0.5
  */


### PR DESCRIPTION
This is the first of several PRs designed to improve/overhaul the existing documentation for libacvp. There are very few changes to the actual descriptions in this PR, though there are a few near the top (e.g. log level descriptions). 

acvp.h used multiple styles of comment blocks (alternating between javadoc and Qt style). Many enums were missing `@enum` descriptors, or used `@struct` descriptors. Spacing and line lengths were inconsistent. Some areas had a leading asterisk on each line, others didnt.

This unifies all of the existing documentation. We use Javadoc style for it all now. Each line leads with an asterisk. Each line gets as close to 100 chars as possible. many `@struct` blocks were corrected to `@enum` and many new `@enum` blocks were added.
Finally, the leading whitespace for multi-line descriptions was made uniform.

There will be more fixes in coming very soon PRs, more related to actual content. 