### PR TITLE
Tdes cleanup; removed outdated values; added support for keyingOption 2; initial progress for new algs

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -894,19 +894,9 @@ static int enable_tdes(ACVP_CTX *ctx) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_ECB, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_KEYLEN, 192);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PTLEN, 512);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     CHECK_ENABLE_CAP_RV(rv);
 
     /*
@@ -914,49 +904,59 @@ static int enable_tdes(ACVP_CTX *ctx) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBC, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_KEYLEN, 192);
+#if 0
+    /*
+     * Enable 3DES-CBCI
+     */
+    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBCI, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_IVLEN, 192 / 3);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBCI, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBCI, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 2);
+
+    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_OFBI, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 3);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFBI, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 12);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFBI, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     CHECK_ENABLE_CAP_RV(rv);
+
+    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFBP1, &app_des_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFBP1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFBP1, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
+    CHECK_ENABLE_CAP_RV(rv);
+
+    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFBP8, &app_des_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFBP8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFBP8, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
+    CHECK_ENABLE_CAP_RV(rv);
+
+    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFBP64, &app_des_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFBP64, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFBP64, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
+    CHECK_ENABLE_CAP_RV(rv);
+#endif
 
     /*
      * Enable 3DES-OFB
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_OFB, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_KEYLEN, 192);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_IVLEN, 192 / 3);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PTLEN, 64);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     CHECK_ENABLE_CAP_RV(rv);
 
     /*
@@ -964,21 +964,9 @@ static int enable_tdes(ACVP_CTX *ctx) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB64, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_KEYLEN, 192);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_IVLEN, 192 / 3);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PTLEN, 64 * 5);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     CHECK_ENABLE_CAP_RV(rv);
 
     /*
@@ -986,23 +974,9 @@ static int enable_tdes(ACVP_CTX *ctx) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB8, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_KEYLEN, 192);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_IVLEN, 192 / 3);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PTLEN, 64);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PTLEN, 64 * 4);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     CHECK_ENABLE_CAP_RV(rv);
 
     /*
@@ -1010,25 +984,12 @@ static int enable_tdes(ACVP_CTX *ctx) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB1, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_KEYLEN, 192);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_IVLEN, 192 / 3);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PTLEN, 64);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     CHECK_ENABLE_CAP_RV(rv);
 
 end:
-
     return rv;
 }
 

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -96,7 +96,9 @@ typedef enum acvp_result {
     ACVP_CRYPTO_WRAP_FAIL,
     ACVP_NO_TOKEN,
     ACVP_NO_CAP,
-    ACVP_MALFORMED_JSON,
+    ACVP_MALFORMED_JSON, /**< For use if the json is unable to be parsed properly */
+    ACVP_TC_DATA_INVALID, /**< Test case JSON is formatted properly, but the data is bad or does
+                           * not match the spec */
     ACVP_DATA_TOO_LARGE,
     ACVP_DUP_CIPHER,
     ACVP_TOTP_DECODE_FAIL,
@@ -539,7 +541,8 @@ typedef enum acvp_hmac_alg_val {
 /** @enum ACVP_SYM_CIPH_KO */
 typedef enum acvp_sym_cipher_keying_option {
     ACVP_SYM_CIPH_KO_NA = 1,
-    ACVP_SYM_CIPH_KO_THREE,
+    ACVP_SYM_CIPH_KO_ONE,
+    ACVP_SYM_CIPH_KO_THREE, /**< This is outdated and will eventually be removed */
     ACVP_SYM_CIPH_KO_TWO,
     ACVP_SYM_CIPH_KO_BOTH,
     ACVP_SYM_CIPH_KO_MAX
@@ -1013,6 +1016,9 @@ typedef struct acvp_sym_cipher_tc_t {
     unsigned int mct_index;  /**< used to identify init vs. update */
     unsigned int incr_ctr;
     unsigned int ovrflw_ctr;
+    unsigned int keyingOption; /**< For some TDES, indicates keyingOption. 
+                                 * 1 is 3 key TDES. 2 is 2-key TDES, supported
+                                 * for decrypt only. 0 indicates is not applicable */
 } ACVP_SYM_CIPHER_TC;
 
 /**

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -708,12 +708,12 @@ static ACVP_RESULT acvp_validate_kdf135_srtp_param_value(ACVP_KDF135_SRTP_PARAM 
     return retval;
 }
 
-static ACVP_RESULT acvp_validate_kdf108_param_value(ACVP_KDF108_PARM param, int value) {
+static ACVP_RESULT acvp_validate_kdf108_param_value(ACVP_CTX *ctx, ACVP_KDF108_PARM param, int value) {
     ACVP_RESULT retval = ACVP_INVALID_ARG;
 
     switch (param) {
     case ACVP_KDF108_KDF_MODE:
-        printf("No need to explicity enable mode string. It is set implicity as params are added to a mode.");
+        ACVP_LOG_ERR("No need to explicity enable mode string. It is set implicity as params are added to a mode.");
         break;
     case ACVP_KDF108_MAC_MODE:
         if (value > ACVP_KDF108_MAC_MODE_MIN && value < ACVP_KDF108_MAC_MODE_MAX) {
@@ -2726,7 +2726,7 @@ ACVP_RESULT acvp_cap_hash_enable(ACVP_CTX *ctx,
 
     alg = acvp_get_hash_alg(cipher);
     if (alg == 0) {
-        printf("Invalid cipher value");
+        ACVP_LOG_ERR("Invalid cipher value");
         return ACVP_INVALID_ARG;
     }
 
@@ -2793,7 +2793,7 @@ ACVP_RESULT acvp_cap_hash_set_parm(ACVP_CTX *ctx,
 
     alg = acvp_get_hash_alg(cipher);
     if (alg == 0) {
-        printf("Invalid cipher value");
+        ACVP_LOG_ERR("Invalid cipher value");
         return ACVP_INVALID_ARG;
     }
 
@@ -2889,7 +2889,7 @@ ACVP_RESULT acvp_cap_hash_set_domain(ACVP_CTX *ctx,
 
     alg = acvp_get_hash_alg(cipher);
     if (alg == 0) {
-        printf("Invalid cipher value");
+        ACVP_LOG_ERR("Invalid cipher value");
         return ACVP_INVALID_ARG;
     }
 
@@ -5628,7 +5628,7 @@ ACVP_RESULT acvp_cap_kdf108_set_parm(ACVP_CTX *ctx,
         return ACVP_NO_CAP;
     }
 
-    if (acvp_validate_kdf108_param_value(param, value) != ACVP_SUCCESS) {
+    if (acvp_validate_kdf108_param_value(ctx, param, value) != ACVP_SUCCESS) {
         return ACVP_INVALID_ARG;
     }
 
@@ -7624,7 +7624,7 @@ ACVP_RESULT acvp_cap_kas_kdf_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KA
 
     alg = acvp_get_kas_alg(cipher);
     if (alg == 0) {
-        printf("Invalid cipher value");
+        ACVP_LOG_ERR("Invalid cipher value");
         return 1;
     }
 
@@ -7941,7 +7941,7 @@ ACVP_RESULT acvp_cap_kas_kdf_set_domain(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
 
     alg = acvp_get_kas_alg(cipher);
     if (alg == 0) {
-        printf("Invalid cipher value");
+        ACVP_LOG_ERR("Invalid cipher value");
         return 1;
     }
 

--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -40,7 +40,8 @@ static ACVP_RESULT acvp_des_init_tc(ACVP_CTX *ctx,
                                     ACVP_CIPHER alg_id,
                                     ACVP_SYM_CIPH_DIR dir,
                                     unsigned int incr_ctr,
-                                    unsigned int ovrflw_ctr);
+                                    unsigned int ovrflw_ctr,
+                                    unsigned int keyingOption);
 
 static ACVP_RESULT acvp_des_release_tc(ACVP_SYM_CIPHER_TC *stc);
 
@@ -489,16 +490,15 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
         for (n = 0; n < 8; ++n) {
             stc->key[8 + n] ^= nk[8 + n];
         }
-        for (n = 0; n < 8; ++n) {
-            stc->key[16 + n] ^= nk[n];
-        }
-
-#if 0   /* TODO: Do we really need to special case 2-key ? */
-        if (numkeys == 2)
+        if (stc->keyingOption == 1) {
             for (n = 0; n < 8; ++n) {
-                stc->key[n + 16] = stc->key[n];
+                stc->key[16 + n] ^= nk[n];
             }
-#endif
+        } else {
+            for (n = 0; n < 8; ++n) {
+                stc->key[16 + n] = stc->key[n];
+            }
+        }
 
         acvp_des_set_odd_parity(stc->key);
         memcpy_s(stc->iv, ACVP_SYM_IV_BYTE_MAX, stc->iv_ret_after, 8); /* only on encrypt */
@@ -656,7 +656,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     ACVP_CIPHER alg_id = 0;
     char *json_result = NULL;
     const char *test_type_str = NULL, *dir_str = NULL;
-    unsigned int tc_id = 0, keylen = 0;
+    unsigned int tc_id = 0, keylen = 0, keyingOption = 0;
     unsigned int ovrflw_ctr = 0, incr_ctr = 0;  /* assume false */
 
     if (!ctx) {
@@ -774,12 +774,23 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         // keyLen will always be the same for TDES
         keylen = ACVP_TDES_KEY_BIT_LEN;
 
+        //get keyingOption if it exists. Otherwise it remains set to 0, which means not applicable.
+        if (json_object_get_value(groupobj, "keyingOption")) {
+            keyingOption = json_object_get_number(groupobj, "keyingOption");
+            if (keyingOption > 2 || keyingOption < 1) {
+                ACVP_LOG_ERR("Server JSON invalid 'keyingOption', %d", keyingOption);
+                rv = ACVP_TC_DATA_INVALID;
+                goto err;
+            }
+        }
+
         ACVP_LOG_VERBOSE("    Test group: %d", i);
         ACVP_LOG_VERBOSE("        keylen: %d", keylen);
-        ACVP_LOG_VERBOSE("         dir:   %s", dir_str);
+        ACVP_LOG_VERBOSE("           dir: %s", dir_str);
         ACVP_LOG_VERBOSE("      testtype: %s", test_type_str);
         ACVP_LOG_VERBOSE("      incr_ctr: %d", incr_ctr);
         ACVP_LOG_VERBOSE("    ovrflw_ctr: %d", ovrflw_ctr);
+        ACVP_LOG_VERBOSE("  keyingOption: %d", keyingOption);
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
@@ -954,7 +965,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_des_init_tc(ctx, &stc, tc_id, test_type, key, pt, ct, iv,
                                   keylen, ivlen, ptlen, ctlen, alg_id, dir,
-                                  incr_ctr, ovrflw_ctr);
+                                  incr_ctr, ovrflw_ctr, keyingOption);
             if (rv != ACVP_SUCCESS) {
                 acvp_des_release_tc(&stc);
                 free(key);
@@ -1118,7 +1129,8 @@ static ACVP_RESULT acvp_des_init_tc(ACVP_CTX *ctx,
                                     ACVP_CIPHER alg_id,
                                     ACVP_SYM_CIPH_DIR dir,
                                     unsigned int incr_ctr,
-                                    unsigned int ovrflw_ctr) {
+                                    unsigned int ovrflw_ctr,
+                                    unsigned int keyingOption) {
     ACVP_RESULT rv;
 
     memzero_s(stc, sizeof(ACVP_SYM_CIPHER_TC));
@@ -1202,6 +1214,7 @@ static ACVP_RESULT acvp_des_init_tc(ACVP_CTX *ctx,
     stc->test_type = test_type;
     stc->incr_ctr = incr_ctr;
     stc->ovrflw_ctr = ovrflw_ctr;
+    stc->keyingOption = keyingOption;
 
     return ACVP_SUCCESS;
 }

--- a/src/parson.c
+++ b/src/parson.c
@@ -1475,8 +1475,11 @@ JSON_Value * json_value_init_array(void) {
 }
 
 JSON_Value * json_value_init_string(const char *string) {
+    if (string == NULL) {
+        return NULL;
+    }
     int len = strnlen_s(string, STRING_VALUE_MAX + 1);
-    if (string == NULL || len > STRING_VALUE_MAX) {
+    if (len > STRING_VALUE_MAX) {
         return NULL;
     }
     return json_value_init_string_with_len(string, len);

--- a/test/json/des/des.json
+++ b/test/json/des/des.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -271,7 +271,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",
@@ -791,7 +791,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "7CA110454A1A6E57",
@@ -951,7 +951,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "8001010101010101",
@@ -1407,7 +1407,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",
@@ -1927,7 +1927,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -2191,7 +2191,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",
@@ -2711,7 +2711,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "7CA110454A1A6E57",
@@ -2871,7 +2871,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "8001010101010101",
@@ -3327,7 +3327,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",

--- a/test/json/des/des_1.json
+++ b/test/json/des/des_1.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -23,7 +23,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_10.json
+++ b/test/json/des/des_10.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -22,7 +22,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_11.json
+++ b/test/json/des/des_11.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -23,7 +23,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_12.json
+++ b/test/json/des/des_12.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -22,7 +22,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_13.json
+++ b/test/json/des/des_13.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -23,7 +23,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_14.json
+++ b/test/json/des/des_14.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -23,7 +23,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_15.json
+++ b/test/json/des/des_15.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -23,7 +23,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_16.json
+++ b/test/json/des/des_16.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -22,7 +22,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_17.json
+++ b/test/json/des/des_17.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -23,7 +23,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_18.json
+++ b/test/json/des/des_18.json
@@ -6,7 +6,7 @@
     "testGroups": [
       {
         "testType": "AFT",
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -22,7 +22,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_19.json
+++ b/test/json/des/des_19.json
@@ -19,13 +19,13 @@
         ],
         "overflowCounter": true,
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "direction": "encrypt"
       },
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_2.json
+++ b/test/json/des/des_2.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -22,7 +22,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_20.json
+++ b/test/json/des/des_20.json
@@ -19,13 +19,13 @@
         ],
         "overflowCounter": "maybe",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "direction": "encrypt"
       },
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_21.json
+++ b/test/json/des/des_21.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -271,7 +271,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",
@@ -791,7 +791,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "7CA110454A1A6E57",
@@ -951,7 +951,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "8001010101010101",
@@ -1407,7 +1407,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",
@@ -1927,7 +1927,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -2191,7 +2191,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",
@@ -2711,7 +2711,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "7CA110454A1A6E57",
@@ -2871,7 +2871,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "8001010101010101",
@@ -3327,7 +3327,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",

--- a/test/json/des/des_22.json
+++ b/test/json/des/des_22.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -271,7 +271,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",
@@ -791,7 +791,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "7CA110454A1A6E57",
@@ -951,7 +951,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "8001010101010101",
@@ -1407,7 +1407,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",
@@ -1927,7 +1927,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -2191,7 +2191,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",
@@ -2711,7 +2711,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "7CA110454A1A6E57",
@@ -2871,7 +2871,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "8001010101010101",
@@ -3327,7 +3327,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "0101010101010101",

--- a/test/json/des/des_3.json
+++ b/test/json/des/des_3.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -23,7 +23,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_4.json
+++ b/test/json/des/des_4.json
@@ -6,7 +6,7 @@
     "testGroups": [
       {
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -22,7 +22,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_5.json
+++ b/test/json/des/des_5.json
@@ -7,7 +7,7 @@
       {
         "testType": "myAFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -23,7 +23,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_6.json
+++ b/test/json/des/des_6.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -22,7 +22,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_7.json
+++ b/test/json/des/des_7.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",
@@ -23,7 +23,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_8.json
+++ b/test/json/des/des_8.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "pt": "0000000000000000",
@@ -22,7 +22,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_9.json
+++ b/test/json/des/des_9.json
@@ -7,7 +7,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "aaaaaaaaaaaaaaaaa",
@@ -23,7 +23,7 @@
       {
         "testType": "AFT",
         "tgId": 999,
-        "keyingOption": 3,
+        "keyingOption": 1,
         "tests": [
           {
             "key2": "1046913489980131",

--- a/test/json/des/des_reg_good.json
+++ b/test/json/des/des_reg_good.json
@@ -13,12 +13,6 @@
           ],
           "keyingOption": [
             1
-          ],
-          "keyLen": [
-            192
-          ],
-          "ptLen": [
-            512
           ]
         },
         {
@@ -29,15 +23,6 @@
           ],
           "keyingOption": [
             1
-          ],
-          "keyLen": [
-            192
-          ],
-          "ptLen": [
-            64,
-            128,
-            192,
-            768
           ]
         },
         {
@@ -48,12 +33,6 @@
           ],
           "keyingOption": [
             1
-          ],
-          "keyLen": [
-            192
-          ],
-          "ptLen": [
-            64
           ]
         },
         {
@@ -64,12 +43,6 @@
           ],
           "keyingOption": [
             1
-          ],
-          "keyLen": [
-            192
-          ],
-          "ptLen": [
-            320
           ]
         },
         {
@@ -80,13 +53,6 @@
           ],
           "keyingOption": [
             1
-          ],
-          "keyLen": [
-            192
-          ],
-          "ptLen": [
-            64,
-            256
           ]
         },
         {
@@ -97,12 +63,6 @@
           ],
           "keyingOption": [
             1
-          ],
-          "keyLen": [
-            192
-          ],
-          "ptLen": [
-            64
           ]
         },
         {
@@ -115,12 +75,6 @@
           "overflowCounter": true,
           "keyingOption": [
               1
-          ],
-          "keyLen": [
-              192
-          ],
-          "payloadLen": [
-              64
           ]
         }
       ]

--- a/test/test_acvp_build_register.c
+++ b/test/test_acvp_build_register.c
@@ -35,19 +35,9 @@ static void add_des_details_good(void) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_ECB, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PTLEN, 512);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
     
     /*
@@ -55,27 +45,9 @@ static void add_des_details_good(void) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_IVLEN, 192 / 3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 2);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 12);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
     
     /*
@@ -83,21 +55,9 @@ static void add_des_details_good(void) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_OFB, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_IVLEN, 192 / 3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PTLEN, 64);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
     
     /*
@@ -105,21 +65,9 @@ static void add_des_details_good(void) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB64, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_IVLEN, 192/3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PTLEN, 64 * 5);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
     
     /*
@@ -127,23 +75,9 @@ static void add_des_details_good(void) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB8, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_IVLEN, 192/3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PTLEN, 64);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PTLEN, 64 * 4);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
     
     /*
@@ -151,21 +85,9 @@ static void add_des_details_good(void) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_IVLEN, 192/3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PTLEN, 64);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
 }
 

--- a/test/test_acvp_capabilities.c
+++ b/test/test_acvp_capabilities.c
@@ -965,21 +965,9 @@ Test(EnableCapTDES, properly, .fini = teardown) {
     setup_empty_ctx(&ctx);
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_IVLEN, 64);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 768);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
 }
 

--- a/test/test_acvp_des.c
+++ b/test/test_acvp_des.c
@@ -28,24 +28,7 @@ static void setup(void) {
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_IVLEN, 192 / 3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 2);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 12);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
 
     /*
@@ -56,20 +39,11 @@ static void setup(void) {
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_CTR_INCR, 1);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_CTR_OVRFLW, 1);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PTLEN, 64);
     cr_assert(rv == ACVP_SUCCESS);
 }
 
@@ -84,25 +58,9 @@ static void setup_fail(void) {
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_IVLEN, 192 / 3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 2);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 12);
-    cr_assert(rv == ACVP_SUCCESS);
 
     /*
      * Enable TDES-CTR
@@ -112,20 +70,11 @@ static void setup_fail(void) {
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_CTR_INCR, 1);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_CTR_OVRFLW, 1);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PTLEN, 64);
     cr_assert(rv == ACVP_SUCCESS);
 }
 
@@ -147,16 +96,7 @@ Test(DES_CAPABILITY, good) {
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PTLEN, 512);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
 
     /*
@@ -167,24 +107,7 @@ Test(DES_CAPABILITY, good) {
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_IVLEN, 192 / 3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 2);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PTLEN, 64 * 12);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
 
     /*
@@ -192,21 +115,9 @@ Test(DES_CAPABILITY, good) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_OFB, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_IVLEN, 192 / 3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PTLEN, 64);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
 
     /*
@@ -214,21 +125,9 @@ Test(DES_CAPABILITY, good) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB64, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_IVLEN, 192/3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PTLEN, 64 * 5);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
 
     /*
@@ -239,20 +138,7 @@ Test(DES_CAPABILITY, good) {
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_IVLEN, 192/3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PTLEN, 64);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PTLEN, 64 * 4);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
 
     /*
@@ -260,21 +146,9 @@ Test(DES_CAPABILITY, good) {
      */
     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB1, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_IVLEN, 192/3);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PTLEN, 64);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
 
 
@@ -286,20 +160,11 @@ Test(DES_CAPABILITY, good) {
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_THREE);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
-    cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_CTR_INCR, 1);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_CTR_OVRFLW, 1);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_KEYLEN, 192);
-    cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PTLEN, 64);
     cr_assert(rv == ACVP_SUCCESS);
 
     teardown_ctx(&ctx);

--- a/test/ut_common.c
+++ b/test/ut_common.c
@@ -29,7 +29,7 @@ void teardown_ctx(ACVP_CTX **ctx) {
     acvp_cleanup(*ctx);
 }
 
-void setup_empty_ctx (ACVP_CTX **ctx) {
+void setup_empty_ctx(ACVP_CTX **ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     ACVP_LOG_LVL level = ACVP_LOG_LVL_STATUS;
     


### PR DESCRIPTION
The existing TDES algorithms now support keying option 2 (two-key decrypt operations). It is not enabled by default as two key DES is not something we wish to perpetuate unless it is needed.

TDES algorithms were registering keyLengths, payloadLengths, and IV info. These are all unneeded and were going ignored by the NIST server. The app registration and all test code has been updated accordingly. 

KeyingOption 3 is no longer part of the spec; it does the same thing in the code as keyingOption 1 and has been updated. Will be removed eventually.

Added disabled registrations for new TDES algorithms. The registrations work, but the monte carlo algorithms have not yet been added (work in progress). 

Also work in progress is adding more validation as for what parameters can be set for what symmetric ciphers, as so many of them have different values in their registrations. 