### PR TITLE
Add SSL/FOM info to version command, save request URLs to testSession file

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -15,8 +15,10 @@
 #include "safe_lib.h"
 
 #ifdef ACVP_NO_RUNTIME
-# include "app_fips_lcl.h"
+#include "app_fips_lcl.h"
 #endif
+
+#include <openssl/crypto.h>
 
 #define ANSI_COLOR_RED "\x1b[31m"
 #define ANSI_COLOR_YELLOW "\x1b[33m"
@@ -181,6 +183,34 @@ static void print_usage(int code) {
     printf("        ACV_OE_COMPILER\n\n");
 }
 
+static void print_version_info() {
+    printf("\nACVP library version(protocol version): %s(%s)\n\n", acvp_version(), acvp_protocol_version());
+
+#ifdef ACVP_NO_RUNTIME
+    printf("        Runtime mode: no\n");
+    printf(" FIPS module version: %s\n", FIPS_module_version_text());
+#else
+    printf("        Runtime mode: yes\n");
+    if (FIPS_mode()) {
+        printf("           FIPS mode: yes\n");
+    } else {
+        printf("           FIPS mode: no\n");
+    }
+#endif
+
+#ifdef OPENSSL_VERSION_TEXT
+    printf("Compiled SSL version: %s\n", OPENSSL_VERSION_TEXT);
+#else
+    printf("Compiled SSL version: not detected\n");
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    printf("  Linked SSL version: %s\n", SSLeay_version(SSLEAY_VERSION));
+#else
+    printf("  Linked SSL version: %s\n", OpenSSL_version(OPENSSL_VERSION));
+#endif
+}
+
 static ko_longopt_t longopts[] = {
     { "version", ko_no_argument, 301 },
     { "help", ko_optional_argument, 302 },
@@ -300,10 +330,8 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
 
         switch (c) {
         case 'v':
-            printf("\nACVP library version(protocol version): %s(%s)\n", acvp_version(), acvp_protocol_version());
-            return 1;
         case 301:
-            printf("\nACVP library version(protocol version): %s(%s)\n", acvp_version(), acvp_protocol_version());
+            print_version_info();
             return 1;
         case 'h':
         case 302:

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1642,6 +1642,7 @@ struct acvp_ctx_t {
     char *tls_key;          /* Location of PEM encoded priv key to use for TLS client auth */
 
     char *http_user_agent;   /* String containing info to be sent with HTTP requests, currently OE info */
+    char *session_file_path; /* String containing the path of the testSession file after it is created when applicable */
     
     ACVP_OPERATING_ENV op_env; /**< The Operating Environment resources available */
     ACVP_STRING_LIST *vsid_url_list;


### PR DESCRIPTION
When running version command in no-runtime mode, the output will now look similar to this:
```
ACVP library version(protocol version): libacvp_oss-1.4.0(1.0)

        Runtime mode: no
 FIPS module version: FIPS 2.0.16 validated module 24 Apr 2017
Compiled SSL version: OpenSSL 1.0.2u-fips  20 Dec 2019
  Linked SSL version: OpenSSL 1.0.2u-fips  20 Dec 2019
```
When running in runtime mode, it will look similar to this. We dont set FIPS mode in runtime mode, but I feel it is worth communicating that fact to people.
```
ACVP library version(protocol version): libacvp_oss-1.4.0(1.0)

        Runtime mode: yes
           FIPS mode: no
Compiled SSL version: OpenSSL 1.0.2u-fips  20 Dec 2019
  Linked SSL version: OpenSSL 1.0.2u-fips  20 Dec 2019
```

I did not change the acvp version string itself in case ours or other people's pipelines are looking for it. 

Finally, for test sessions run with --fips_validation, the request URL that libacvp prints at the very end will also be saved to the testSession file as "validationRequestUrl". This is to help avoid issues where the request URLs get misplaced as they do not contain much context for their contents until they are approved.