### PR TITLE
Misc build fixes for some platforms

### DIFF
--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -28,7 +28,7 @@ extern "C"
 #define JSON_STRING_LENGTH 32
 #define JSON_REQUEST_LENGTH 128
 
-char value[JSON_STRING_LENGTH];
+extern char value[JSON_STRING_LENGTH];
 
 typedef struct app_config {
     ACVP_LOG_LVL level;

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -27,12 +27,12 @@
 #ifdef fips_selftest_fail
 extern int fips_selftest_fail;
 #else
-int fips_selftest_fail;
+static int fips_selftest_fail;
 #endif
 #ifdef fips_mode
 extern int fips_mode;
 #else
-int fips_mode;
+static int fips_mode;
 #endif
 #endif
 #include "safe_mem_lib.h"

--- a/ms/make_app.bat
+++ b/ms/make_app.bat
@@ -7,20 +7,19 @@ set ACV_ROOT_PATH=
 rem Visual Studio wants absolute paths in some cases
 set ACV_ROOT_PATH_REL=%~dp0..\
 for %%i in ("%ACV_ROOT_PATH_REL%") do SET "ACV_ROOT_PATH=%%~fi
-
-if [%FOM_DIR%]==[] (
+if [%FOM_DIR%] == [] (
   echo "No fom, some algorithms will not be available for testing"
   set PROJ_CONFIG=nofom
-) ELSE (
+) else (
   set ACV_LIB_PATHS=%FOM_DIR%\lib
   set ACV_INC_PATHS=%FOM_DIR%\include
   set PROJ_CONFIG=fom
 )
 
-if [%SSL_DIR%]==[] (
+if [%SSL_DIR%] == [] (
   echo "Missing SSL dir, stopping"
-  goto :end
-) ELSE (
+  goto :error
+) else (
   set ACV_LIB_PATHS=%ACV_LIB_PATHS%;%SSL_DIR%\lib
   set ACV_INC_PATHS=%ACV_INC_PATHS%;%SSL_DIR%\include
 )
@@ -29,10 +28,10 @@ if %LEGACY_SSL%==TRUE (
   set PROJ_CONFIG=%PROJ_CONFIG%_legacy_ssl
 )
 
-if [%SAFEC_DIR%]==[] (
+if [%SAFEC_DIR%] == [] (
   set PROJ_CONFIG=%PROJ_CONFIG%_no_safec
   set ACV_INC_PATHS=%ACV_INC_PATHS%;%ACV_ROOT_PATH%\safe_c_stub\include
-) ELSE (
+) else (
   set ACV_LIB_PATHS=%ACV_LIB_PATHS%;%SAFEC_DIR%
   set ACV_INC_PATHS=%ACV_INC_PATHS%;%SAFEC_DIR%\include
 )
@@ -48,6 +47,11 @@ if %STATIC_BUILD%==TRUE (
 set ACV_LIB_PATHS=%ACV_LIB_PATHS%;%~dp0%build
 set ACV_INC_PATHS=%ACV_INC_PATHS%;%ACV_ROOT_PATH%\include
 
-msbuild ms\acvp_app.sln /p:Configuration=%PROJ_CONFIG% /p:Platform=%ACVP_ARCH% /p:UseEnv=True
+msbuild ms\acvp_app.sln /p:Configuration=%PROJ_CONFIG% /p:Platform=%ACVP_ARCH% /p:UseEnv=True || goto :error
+goto :end
+
+:error
+  exit 1
 
 :end
+

--- a/ms/make_lib.bat
+++ b/ms/make_lib.bat
@@ -6,45 +6,50 @@ set ACV_LIB_PATHS=
 rem Visual Studio wants absolute paths in some cases
 set ACV_ROOT_PATH_REL=%~dp0..\
 for %%i in ("%ACV_ROOT_PATH_REL%") do SET "ACV_ROOT_PATH=%%~fi
-
-if %STATIC_BUILD%==TRUE (
+if "%STATIC_BUILD%" == "TRUE" (
   set PROJ_CONFIG=static
-) ELSE (
+) else (
   set PROJ_CONFIG=shared
 )
 
-if %OFFLINE_BUILD%==TRUE (
+if "%OFFLINE_BUILD%" == "TRUE" (
   set PROJ_CONFIG=%PROJ_CONFIG%_offline
-) ELSE (
-  if [%LIBCURL_DIR%]==[] (
+) else (
+  if [%LIBCURL_DIR%] == [] (
     echo "curl dir not specified - attempting to use murl and link to ssl..."
-	if [%SSL_DIR%]==[] (
-	  echo "No SSL dir specified. Curl directory, or SSL dir if using Murl, must be specified. exiting..."
-      exit 1
-	) ELSE (
+	  if [%SSL_DIR%] == [] (
+	    echo "No SSL dir specified. Curl directory, or SSL dir if using Murl, must be specified. exiting..."
+      goto :error
+	  ) else (
       set ACV_LIB_PATHS=%SSL_DIR%\lib
-	  set ACV_INC_PATHS=%SSL_DIR%\include
-	)
-  ) ELSE (
+	    set ACV_INC_PATHS=%SSL_DIR%\include
+	  )
+  ) else (
     set ACV_LIB_PATHS=%LIBCURL_DIR%\lib
    	set ACV_INC_PATHS=%LIBCURL_DIR%\include
   )
 )
 
-if [%SAFEC_DIR%]==[] (
+if [%SAFEC_DIR%] == [] (
   set PROJ_CONFIG=%PROJ_CONFIG%_no_safec
   set ACV_INC_PATHS=%ACV_INC_PATHS%;%ACV_ROOT_PATH%\safe_c_stub\include
-) ELSE (
+) else (
   set ACV_LIB_PATHS=%ACV_LIB_PATHS%;%SAFEC_DIR%
   set ACV_INC_PATHS=%ACV_INC_PATHS%;%SAFEC_DIR%\include
-  
 )
 
-if [%LIBCURL_DIR%]==[] (
+if [%LIBCURL_DIR%] == [] (
   set PROJ_CONFIG=%PROJ_CONFIG%_murl
   set ACV_INC_PATHS=%ACV_INC_PATHS%;%ACV_ROOT_PATH%\murl
 )
 
 set ACV_INC_PATHS=%ACV_INC_PATHS%;%ACV_ROOT_PATH%\include\acvp
 
-msbuild ms\libacvp.sln /p:Configuration=%PROJ_CONFIG% /p:Platform=%ACVP_ARCH% /p:UseEnv=True
+msbuild ms\libacvp.sln /p:Configuration=%PROJ_CONFIG% /p:Platform=%ACVP_ARCH% /p:UseEnv=True || goto :error
+goto :end
+
+:error
+  exit 1
+
+:end
+


### PR DESCRIPTION
Some FreeBSD platforms complain about multiple definition for the "value" array.
Also getting multiple definition on fips_mode and fips_selftest_fail on some FOM on freeBSD. I presume this is because its in the module somewhere but not in a public header. Either way, these changes silence the errors without causing any build failures.
Some windows batch cleanup included as well.