### PR TITLE
Update Muse to Lift config and use sudo

### DIFF
--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -1,0 +1,2 @@
+setup = ".lift/setup.sh"
+build = "make"

--- a/.lift/setup.sh
+++ b/.lift/setup.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 if [ $(whoami) = "root" ]; then
-    apt update && apt install -y libssl-dev libcurl4-gnutls-dev
+    sudo apt update && sudo apt install -y libssl-dev libcurl4-gnutls-dev
 fi
 
-cd $1
 sed -i 's/gcc_z_support=yes/gcc_z_support=no/' configure
 sed -i 's/-z,noexecstack//' configure
 ./configure LIBS=-lcurl --with-libcurl-dir=/usr/lib/x86_64-linux-gnu/

--- a/.muse/config
+++ b/.muse/config
@@ -1,2 +1,0 @@
-setup = ".muse/setup.sh"
-build = "make"


### PR DESCRIPTION
The MuseDev product has been rebranded to Lift. This MR migrates and updates the tool's configuration file.