### PR TITLE
Add support for TLS 1.2 KDF

### DIFF
--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -1,0 +1,2 @@
+setup = ".lift/setup.sh"
+build = "make"

--- a/.lift/setup.sh
+++ b/.lift/setup.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 if [ $(whoami) = "root" ]; then
-    apt update && apt install -y libssl-dev libcurl4-gnutls-dev
+    sudo apt update && sudo apt install -y libssl-dev libcurl4-gnutls-dev
 fi
 
-cd $1
 sed -i 's/gcc_z_support=yes/gcc_z_support=no/' configure
 sed -i 's/-z,noexecstack//' configure
 ./configure LIBS=-lcurl --with-libcurl-dir=/usr/lib/x86_64-linux-gnu/

--- a/.muse/config
+++ b/.muse/config
@@ -1,2 +1,0 @@
-setup = ".muse/setup.sh"
-build = "make"

--- a/app/app_kdf.c
+++ b/app/app_kdf.c
@@ -16,6 +16,8 @@
 
 #define TLS_MD_MASTER_SECRET_CONST              "master secret"
 #define TLS_MD_MASTER_SECRET_CONST_SIZE         13
+#define TLS_MD_EXTENDED_MASTER_SECRET_CONST     "extended master secret"
+#define TLS_MD_EXTENDED_MASTER_SECRET_CONST_SIZE 22
 #define TLS_MD_KEY_EXPANSION_CONST              "key expansion"
 #define TLS_MD_KEY_EXPANSION_CONST_SIZE         13
 
@@ -76,6 +78,13 @@ int app_kdf135_ssh_handler(ACVP_TEST_CASE *test_case) {
 }
 
 int app_pbkdf_handler(ACVP_TEST_CASE *test_case) {
+    if (!test_case) {
+        return -1;
+    }
+    return 1;
+}
+
+int app_kdf_tls12_handler(ACVP_TEST_CASE *test_case) {
     if (!test_case) {
         return -1;
     }

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -106,6 +106,7 @@ int app_kdf108_handler(ACVP_TEST_CASE *test_case);
 int app_kdf135_ikev1_handler(ACVP_TEST_CASE *test_case);
 int app_kdf135_x963_handler(ACVP_TEST_CASE *test_case);
 int app_pbkdf_handler(ACVP_TEST_CASE *test_case);
+int app_kdf_tls12_handler(ACVP_TEST_CASE *test_case);
 int app_kdf_tls13_handler(ACVP_TEST_CASE *test_case);
 
 void app_dsa_cleanup(void);

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1294,9 +1294,21 @@ static int enable_kdf(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     int i, flags = 0;
 
-    /*
-     * Enable KDF-135
-     */
+
+    rv = acvp_cap_kdf_tls12_enable(ctx, &app_kdf_tls12_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_SHA, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_HMAC, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf_tls12_set_parm(ctx, ACVP_KDF_TLS12_HASH_ALG, ACVP_SHA256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf_tls12_set_parm(ctx, ACVP_KDF_TLS12_HASH_ALG, ACVP_SHA384);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf_tls12_set_parm(ctx, ACVP_KDF_TLS12_HASH_ALG, ACVP_SHA512);
+    CHECK_ENABLE_CAP_RV(rv);
+
+#if 0 //replaced by KDF TLS12. Testing support will be removed from NIST server at the beginning of 2022.
     rv = acvp_cap_kdf135_tls_enable(ctx, &app_kdf135_tls_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_TLS, ACVP_PREREQ_SHA, value);
@@ -1306,6 +1318,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf135_tls_set_parm(ctx, ACVP_KDF135_TLS, ACVP_KDF135_TLS12,
                                       ACVP_SHA256 | ACVP_SHA384 | ACVP_SHA512);
     CHECK_ENABLE_CAP_RV(rv);
+#endif
 
     rv = acvp_cap_kdf135_snmp_enable(ctx, &app_kdf135_snmp_handler);
     CHECK_ENABLE_CAP_RV(rv);

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -113,6 +113,7 @@
 #define ACVP_REV_STR_SP800_56BR2 "Sp800-56Br2"
 #define ACVP_REV_STR_SP800_56CR1 "Sp800-56Cr1"
 #define ACVP_REV_STR_RFC8446 "RFC8446"
+#define ACVP_REV_STR_RFC7627 "RFC7627"
 
 /* AES */
 #define ACVP_REV_AES_ECB             ACVP_REV_STR_DEFAULT
@@ -227,6 +228,7 @@
 #define ACVP_REV_KDF108              ACVP_REV_STR_DEFAULT
 #define ACVP_REV_PBKDF               ACVP_REV_STR_DEFAULT
 #define ACVP_REV_SAFE_PRIMES         ACVP_REV_STR_DEFAULT
+#define ACVP_REV_KDF_TLS12           ACVP_REV_STR_RFC7627
 #define ACVP_REV_KDF_TLS13           ACVP_REV_STR_RFC8446
 
 
@@ -419,6 +421,9 @@
 #define ACVP_STR_KDF_TLS13_PSK     "PSK"
 #define ACVP_STR_KDF_TLS13_DHE     "DHE"
 #define ACVP_STR_KDF_TLS13_PSK_DHE "PSK-DHE"
+
+#define ACVP_ALG_TLS12           "TLS-v1.2"
+#define ACVP_ALG_KDF_TLS12       "KDF"
 
 #define ACVP_CAPABILITY_STR_MAX 512 /**< Arbitrary string length limit */
 
@@ -722,6 +727,15 @@
 /*
  * END PBKDF
  */
+ 
+ /**
+ * Accepted length ranges for TLS 1.2 KDF
+ */
+#define ACVP_KDF_TLS12_MSG_MAX 1024 * 4
+
+#define ACVP_KDF_TLS12_PMSECRET_BIT_MAX 384
+#define ACVP_KDF_TLS12_PMSECRET_BYTE_MAX (ACVP_KDF135_TLS_PMSECRET_BIT_MAX >> 3)
+#define ACVP_KDF_TLS12_PMSECRET_STR_MAX (ACVP_KDF135_TLS_PMSECRET_BIT_MAX >> 2)
 
 /**
  * Accepted length ranges for TLS 1.3 KDF
@@ -977,6 +991,7 @@ typedef enum acvp_capability_type {
     ACVP_KDF135_TPM_TYPE,
     ACVP_KDF108_TYPE,
     ACVP_PBKDF_TYPE,
+    ACVP_KDF_TLS12_TYPE,
     ACVP_KDF_TLS13_TYPE,
     ACVP_KAS_ECC_CDH_TYPE,
     ACVP_KAS_ECC_COMP_TYPE,
@@ -1162,6 +1177,10 @@ typedef struct acvp_pbkdf_capability {
     ACVP_JSON_DOMAIN_OBJ password_len_domain;
     ACVP_JSON_DOMAIN_OBJ salt_len_domain;
 } ACVP_PBKDF_CAP;
+
+typedef struct acvp_kdf_tls12_capability {
+    ACVP_NAME_LIST *hash_algs;
+} ACVP_KDF_TLS12_CAP;
 
 typedef struct acvp_kdf_tls13_capability {
     ACVP_NAME_LIST *hmac_algs;
@@ -1485,6 +1504,7 @@ typedef struct acvp_caps_list_t {
         ACVP_KDF135_X963_CAP *kdf135_x963_cap;
         ACVP_KDF108_CAP *kdf108_cap;
         ACVP_PBKDF_CAP *pbkdf_cap;
+        ACVP_KDF_TLS12_CAP *kdf_tls12_cap;
         ACVP_KDF_TLS13_CAP *kdf_tls13_cap;
         ACVP_KAS_ECC_CAP *kas_ecc_cap;
         ACVP_KAS_FFC_CAP *kas_ffc_cap;
@@ -1788,6 +1808,8 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj);
 ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj);
 
 ACVP_RESULT acvp_pbkdf_kat_handler(ACVP_CTX *ctx, JSON_Object *obj);
+
+ACVP_RESULT acvp_kdf_tls12_kat_handler(ACVP_CTX *ctx, JSON_Object *obj);
 
 ACVP_RESULT acvp_kdf_tls13_kat_handler(ACVP_CTX *ctx, JSON_Object *obj);
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,7 @@ libacvp_la_SOURCES =  acvp.c \
                     acvp_kdf135_x963.c \
                     acvp_kdf108.c \
                     acvp_pbkdf.c \
+                    acvp_kdf_tls12.c \
                     acvp_kdf_tls13.c \
                     acvp_kas_ecc.c \
                     acvp_kas_ffc.c \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -142,9 +142,10 @@ am_libacvp_la_OBJECTS = acvp.lo acvp_build_register.lo \
 	acvp_dsa.lo acvp_kdf135_tls.lo acvp_kdf135_snmp.lo \
 	acvp_kdf135_ssh.lo acvp_kdf135_srtp.lo acvp_kdf135_ikev2.lo \
 	acvp_kdf135_ikev1.lo acvp_kdf135_x963.lo acvp_kdf108.lo \
-	acvp_pbkdf.lo acvp_kdf_tls13.lo acvp_kas_ecc.lo \
-	acvp_kas_ffc.lo acvp_kas_ifc.lo acvp_kas_kdf.lo \
-	acvp_kts_ifc.lo acvp_safe_primes.lo acvp_ecdsa.lo
+	acvp_pbkdf.lo acvp_kdf_tls12.lo acvp_kdf_tls13.lo \
+	acvp_kas_ecc.lo acvp_kas_ffc.lo acvp_kas_ifc.lo \
+	acvp_kas_kdf.lo acvp_kts_ifc.lo acvp_safe_primes.lo \
+	acvp_ecdsa.lo
 libacvp_la_OBJECTS = $(am_libacvp_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -180,7 +181,8 @@ am__depfiles_remade = ./$(DEPDIR)/acvp.Plo ./$(DEPDIR)/acvp_aes.Plo \
 	./$(DEPDIR)/acvp_kdf135_ssh.Plo \
 	./$(DEPDIR)/acvp_kdf135_tls.Plo \
 	./$(DEPDIR)/acvp_kdf135_x963.Plo \
-	./$(DEPDIR)/acvp_kdf_tls13.Plo ./$(DEPDIR)/acvp_kts_ifc.Plo \
+	./$(DEPDIR)/acvp_kdf_tls12.Plo ./$(DEPDIR)/acvp_kdf_tls13.Plo \
+	./$(DEPDIR)/acvp_kts_ifc.Plo \
 	./$(DEPDIR)/acvp_operating_env.Plo ./$(DEPDIR)/acvp_pbkdf.Plo \
 	./$(DEPDIR)/acvp_rsa_keygen.Plo ./$(DEPDIR)/acvp_rsa_prim.Plo \
 	./$(DEPDIR)/acvp_rsa_sig.Plo ./$(DEPDIR)/acvp_safe_primes.Plo \
@@ -391,6 +393,7 @@ libacvp_la_SOURCES = acvp.c \
                     acvp_kdf135_x963.c \
                     acvp_kdf108.c \
                     acvp_pbkdf.c \
+                    acvp_kdf_tls12.c \
                     acvp_kdf_tls13.c \
                     acvp_kas_ecc.c \
                     acvp_kas_ffc.c \
@@ -507,6 +510,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_kdf135_ssh.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_kdf135_tls.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_kdf135_x963.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_kdf_tls12.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_kdf_tls13.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_kts_ifc.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_operating_env.Plo@am__quote@ # am--include-marker
@@ -728,6 +732,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/acvp_kdf135_ssh.Plo
 	-rm -f ./$(DEPDIR)/acvp_kdf135_tls.Plo
 	-rm -f ./$(DEPDIR)/acvp_kdf135_x963.Plo
+	-rm -f ./$(DEPDIR)/acvp_kdf_tls12.Plo
 	-rm -f ./$(DEPDIR)/acvp_kdf_tls13.Plo
 	-rm -f ./$(DEPDIR)/acvp_kts_ifc.Plo
 	-rm -f ./$(DEPDIR)/acvp_operating_env.Plo
@@ -807,6 +812,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/acvp_kdf135_ssh.Plo
 	-rm -f ./$(DEPDIR)/acvp_kdf135_tls.Plo
 	-rm -f ./$(DEPDIR)/acvp_kdf135_x963.Plo
+	-rm -f ./$(DEPDIR)/acvp_kdf_tls12.Plo
 	-rm -f ./$(DEPDIR)/acvp_kdf_tls13.Plo
 	-rm -f ./$(DEPDIR)/acvp_kts_ifc.Plo
 	-rm -f ./$(DEPDIR)/acvp_operating_env.Plo

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -150,6 +150,7 @@ ACVP_ALG_HANDLER alg_tbl[ACVP_ALG_MAX] = {
     { ACVP_KDF135_X963,       &acvp_kdf135_x963_kat_handler,     ACVP_KDF135_ALG_STR,        ACVP_ALG_KDF135_X963, ACVP_REV_KDF135_X963, {ACVP_SUB_KDF_X963}},
     { ACVP_KDF108,            &acvp_kdf108_kat_handler,          ACVP_ALG_KDF108,            NULL, ACVP_REV_KDF108, {ACVP_SUB_KDF_108}},
     { ACVP_PBKDF,             &acvp_pbkdf_kat_handler,           ACVP_ALG_PBKDF,             NULL, ACVP_REV_PBKDF, {ACVP_SUB_KDF_PBKDF}},
+    { ACVP_KDF_TLS12,         &acvp_kdf_tls12_kat_handler,       ACVP_ALG_TLS12,             ACVP_ALG_KDF_TLS12, ACVP_REV_KDF_TLS12, {ACVP_SUB_KDF_TLS12}},
     { ACVP_KDF_TLS13,         &acvp_kdf_tls13_kat_handler,       ACVP_ALG_TLS13,             ACVP_ALG_KDF_TLS13, ACVP_REV_KDF_TLS13, {ACVP_SUB_KDF_TLS13}},
     { ACVP_KAS_ECC_CDH,       &acvp_kas_ecc_kat_handler,         ACVP_ALG_KAS_ECC,           ACVP_ALG_KAS_ECC_CDH, ACVP_REV_KAS_ECC, {ACVP_SUB_KAS_ECC_CDH}},
     { ACVP_KAS_ECC_COMP,      &acvp_kas_ecc_kat_handler,         ACVP_ALG_KAS_ECC,           ACVP_ALG_KAS_ECC_COMP, ACVP_REV_KAS_ECC, {ACVP_SUB_KAS_ECC_COMP}},
@@ -775,6 +776,10 @@ ACVP_RESULT acvp_free_test_session(ACVP_CTX *ctx) {
                 acvp_cap_free_nl(cap_entry->cap.kdf_tls13_cap->hmac_algs);
                 acvp_cap_free_pl(cap_entry->cap.kdf_tls13_cap->running_mode);
                 free(cap_entry->cap.kdf_tls13_cap);
+                break;
+            case ACVP_KDF_TLS12_TYPE:
+                acvp_cap_free_nl(cap_entry->cap.kdf_tls12_cap->hash_algs);
+                free(cap_entry->cap.kdf_tls12_cap);
                 break;
             case ACVP_SAFE_PRIMES_KEYGEN_TYPE:
                 if (cap_entry->cap.safe_primes_keygen_cap->mode->genmeth) {

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -998,6 +998,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_KDF135_X963:
         case ACVP_KDF108:
         case ACVP_PBKDF:
+        case ACVP_KDF_TLS12:
         case ACVP_KDF_TLS13:
         case ACVP_KAS_ECC_CDH:
         case ACVP_KAS_ECC_COMP:
@@ -1109,6 +1110,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_KDF135_X963:
         case ACVP_KDF108:
         case ACVP_PBKDF:
+        case ACVP_KDF_TLS12:
         case ACVP_KDF_TLS13:
         case ACVP_KAS_ECC_CDH:
         case ACVP_KAS_ECC_COMP:
@@ -1218,6 +1220,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_KDF135_X963:
         case ACVP_KDF108:
         case ACVP_PBKDF:
+        case ACVP_KDF_TLS12:
         case ACVP_KDF_TLS13:
         case ACVP_KAS_ECC_CDH:
         case ACVP_KAS_ECC_COMP:
@@ -1333,6 +1336,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_KDF135_X963:
         case ACVP_KDF108:
         case ACVP_PBKDF:
+        case ACVP_KDF_TLS12:
         case ACVP_KDF_TLS13:
         case ACVP_KAS_ECC_CDH:
         case ACVP_KAS_ECC_COMP:
@@ -1439,6 +1443,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_KDF135_X963:
         case ACVP_KDF108:
         case ACVP_PBKDF:
+        case ACVP_KDF_TLS12:
         case ACVP_KDF_TLS13:
         case ACVP_KAS_ECC_CDH:
         case ACVP_KAS_ECC_COMP:
@@ -1758,6 +1763,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
     case ACVP_KDF135_X963:
     case ACVP_KDF108:
     case ACVP_PBKDF:
+    case ACVP_KDF_TLS12:
     case ACVP_KDF_TLS13:
     case ACVP_KAS_ECC_CDH:
     case ACVP_KAS_ECC_COMP:
@@ -1930,6 +1936,12 @@ static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG 
         if (pre_req == ACVP_PREREQ_HMAC) {
             return ACVP_SUCCESS;
         }
+        break;
+    case ACVP_KDF_TLS12:
+        if (pre_req == ACVP_PREREQ_HMAC ||
+            pre_req == ACVP_PREREQ_SHA) {
+                return ACVP_SUCCESS;
+            }
         break;
     case ACVP_KDF_TLS13:
         if (pre_req == ACVP_PREREQ_HMAC) {
@@ -2203,6 +2215,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
     case ACVP_KDF135_X963:
     case ACVP_KDF108:
     case ACVP_PBKDF:
+    case ACVP_KDF_TLS12:
     case ACVP_KDF_TLS13:
     case ACVP_KAS_ECC_CDH:
     case ACVP_KAS_ECC_COMP:
@@ -2410,6 +2423,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
     case ACVP_KDF135_X963:
     case ACVP_KDF108:
     case ACVP_PBKDF:
+    case ACVP_KDF_TLS12:
     case ACVP_KDF_TLS13:
     case ACVP_KAS_ECC_CDH:
     case ACVP_KAS_ECC_COMP:
@@ -2732,6 +2746,7 @@ ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
     case ACVP_KDF135_X963:
     case ACVP_KDF108:
     case ACVP_PBKDF:
+    case ACVP_KDF_TLS12:
     case ACVP_KDF_TLS13:
     case ACVP_KAS_ECC_CDH:
     case ACVP_KAS_ECC_COMP:
@@ -5138,6 +5153,8 @@ ACVP_RESULT acvp_cap_kdf135_tls_enable(ACVP_CTX *ctx,
         ACVP_LOG_ERR("Failed to allocate capability object");
     }
 
+    ACVP_LOG_WARN("Warning: kdf135_tls testing support is being removed from the NIST server "
+                  "starting in 2022. Please transition to KDF TLS 1.2 testing.");
     return result;
 }
 
@@ -6413,6 +6430,102 @@ ACVP_RESULT acvp_cap_kdf108_set_domain(ACVP_CTX *ctx,
 
     return ACVP_SUCCESS;
 }
+
+ACVP_RESULT acvp_cap_kdf_tls12_enable(ACVP_CTX *ctx,
+                                       int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
+    ACVP_RESULT result = ACVP_SUCCESS;
+
+    if (!ctx) {
+        return ACVP_NO_CTX;
+    }
+
+    if (!crypto_handler) {
+        return ACVP_INVALID_ARG;
+
+        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
+    }
+
+    result = acvp_cap_list_append(ctx, ACVP_KDF_TLS12_TYPE, ACVP_KDF_TLS12, crypto_handler);
+
+    if (result == ACVP_DUP_CIPHER) {
+        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
+    } else if (result == ACVP_MALLOC_FAIL) {
+        ACVP_LOG_ERR("Failed to allocate capability object");
+    }
+
+    return result;
+}
+
+/*
+ * The user should call this after invoking acvp_cap_kdf_tls12_enable()
+ * to specify the kdf parameters.
+ */
+ACVP_RESULT acvp_cap_kdf_tls12_set_parm(ACVP_CTX *ctx,
+                                         ACVP_KDF_TLS12_PARM param,
+                                         int value) {
+    ACVP_CAPS_LIST *cap_list;
+    ACVP_KDF_TLS12_CAP *cap;
+    ACVP_NAME_LIST *hash_alg_list = NULL;
+    const char *alg_str = NULL;
+
+    if (!ctx) {
+        return ACVP_NO_CTX;
+    }
+
+    cap_list = acvp_locate_cap_entry(ctx, ACVP_KDF_TLS12);
+    if (!cap_list) {
+        ACVP_LOG_ERR("Cap entry not found. You must enable algorithm before setting parameters.");
+        return ACVP_NO_CAP;
+    }
+
+    cap = cap_list->cap.kdf_tls12_cap;
+    if (!cap) {
+        return ACVP_NO_CAP;
+    }    
+
+    switch(param) {
+    case ACVP_KDF_TLS12_HASH_ALG:
+        alg_str = acvp_lookup_hash_alg_name(value);
+        if ((value != ACVP_SHA256 && value != ACVP_SHA384 && value != ACVP_SHA512) || !alg_str) {
+            ACVP_LOG_ERR("Invalid value specified for TLS 1.2 alg.");
+            return ACVP_INVALID_ARG;
+        }
+        if (cap->hash_algs) {
+            hash_alg_list = cap->hash_algs;
+            if (hash_alg_list->name == alg_str) {
+                ACVP_LOG_WARN("Attempting to register a hash alg with TLS 1.2 KDF that has already been registered, skipping.");
+                return ACVP_SUCCESS;
+            }
+            while (hash_alg_list->next) {
+                hash_alg_list = hash_alg_list->next;
+                if (hash_alg_list->name == alg_str) {
+                    ACVP_LOG_WARN("Attempting to register a hash alg with TLS 1.2 KDF that has already been registered, skipping.");
+                    return ACVP_SUCCESS;
+                }
+            }
+            hash_alg_list->next = calloc(1, sizeof(ACVP_NAME_LIST));
+            if (!hash_alg_list->next) {
+                return ACVP_MALLOC_FAIL;
+            }
+            hash_alg_list = hash_alg_list->next;
+        } else {
+            cap->hash_algs = calloc(1, sizeof(ACVP_NAME_LIST));
+            if (!cap->hash_algs) {
+                return ACVP_MALLOC_FAIL;
+            }
+            hash_alg_list = cap->hash_algs;
+        }
+        hash_alg_list->name = alg_str;
+        break;
+    case ACVP_KDF_TLS12_PARAM_MIN:
+    default:
+        return ACVP_INVALID_ARG;
+    }
+
+    return ACVP_SUCCESS;
+}
+
+
 
 ACVP_RESULT acvp_cap_kdf_tls13_enable(ACVP_CTX *ctx,
                                       int (*crypto_handler) (ACVP_TEST_CASE *test_case)) {

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -6441,7 +6441,6 @@ ACVP_RESULT acvp_cap_kdf_tls12_enable(ACVP_CTX *ctx,
 
     if (!crypto_handler) {
         return ACVP_INVALID_ARG;
-
         ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
     }
 

--- a/src/acvp_kdf_tls12.c
+++ b/src/acvp_kdf_tls12.c
@@ -66,8 +66,6 @@ ACVP_RESULT acvp_kdf_tls12_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     ACVP_CIPHER alg_id;
     ACVP_HASH_ALG md = 0;
     const char *pm_secret = NULL;
-    const char *sh_rnd = NULL;
-    const char *ch_rnd = NULL;
     const char *session_hash = NULL;
     const char *s_rnd = NULL;
     const char *c_rnd = NULL;
@@ -228,8 +226,7 @@ ACVP_RESULT acvp_kdf_tls12_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             ACVP_LOG_VERBOSE("        Test case: %d", j);
             ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
             ACVP_LOG_VERBOSE("         pmSecret: %s", pm_secret);
-            ACVP_LOG_VERBOSE("            shRND: %s", sh_rnd);
-            ACVP_LOG_VERBOSE("            chRND: %s", ch_rnd);
+            ACVP_LOG_VERBOSE("      sessionHash: %s", session_hash);
             ACVP_LOG_VERBOSE("             sRND: %s", s_rnd);
             ACVP_LOG_VERBOSE("             cRND: %s", c_rnd);
 
@@ -362,7 +359,7 @@ static ACVP_RESULT acvp_kdf_tls12_init_tc(ACVP_CTX *ctx,
     if (!stc->session_hash) { return ACVP_MALLOC_FAIL; }
     rv = acvp_hexstr_to_bin(session_hash, stc->session_hash, ACVP_KDF_TLS12_MSG_MAX, &(stc->session_hash_len));
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Hex conversion failure (sh_rnd)");
+        ACVP_LOG_ERR("Hex conversion failure (session_hash)");
         return rv;
     }
 

--- a/src/acvp_kdf_tls12.c
+++ b/src/acvp_kdf_tls12.c
@@ -1,0 +1,421 @@
+/** @file */
+/*
+ * Copyright (c) 2019, Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/cisco/libacvp/LICENSE
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "acvp.h"
+#include "acvp_lcl.h"
+#include "parson.h"
+#include "safe_lib.h"
+
+/*
+ * Forward prototypes for local functions
+ */
+static ACVP_RESULT acvp_kdf_tls12_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS12_TC *stc, JSON_Object *tc_rsp);
+
+static ACVP_RESULT acvp_kdf_tls12_init_tc(ACVP_CTX *ctx,
+                                           ACVP_KDF_TLS12_TC *stc,
+                                           unsigned int tc_id,
+                                           ACVP_CIPHER alg_id,
+                                           ACVP_HASH_ALG md,
+                                           unsigned int pm_len,
+                                           unsigned int kb_len,
+                                           const char *pm_secret,
+                                           const char *session_hash,
+                                           const char *s_rnd,
+                                           const char *c_rnd);
+
+static ACVP_RESULT acvp_kdf_tls12_release_tc(ACVP_KDF_TLS12_TC *stc);
+
+ACVP_RESULT acvp_kdf_tls12_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
+    unsigned int tc_id;
+    JSON_Value *groupval;
+    JSON_Object *groupobj = NULL;
+    JSON_Value *testval;
+    JSON_Object *testobj = NULL;
+    JSON_Array *groups;
+    JSON_Array *tests;
+
+    JSON_Value *reg_arry_val = NULL;
+    JSON_Object *reg_obj = NULL;
+    JSON_Array *reg_arry = NULL;
+
+    int i, g_cnt;
+    int j, t_cnt;
+
+    JSON_Value *r_vs_val = NULL;
+    JSON_Object *r_vs = NULL;
+    JSON_Array *r_tarr = NULL, *r_garr = NULL;  /* Response testarray, grouparray */
+    JSON_Value *r_tval = NULL, *r_gval = NULL;  /* Response testval, groupval */
+    JSON_Object *r_tobj = NULL, *r_gobj = NULL; /* Response testobj, groupobj */
+    ACVP_CAPS_LIST *cap;
+    ACVP_KDF_TLS12_TC stc;
+    ACVP_TEST_CASE tc;
+    ACVP_RESULT rv;
+    const char *alg_str = json_object_get_string(obj, "algorithm");
+    const char *mode_str = NULL;
+    ACVP_CIPHER alg_id;
+    ACVP_HASH_ALG md = 0;
+    const char *pm_secret = NULL;
+    const char *sh_rnd = NULL;
+    const char *ch_rnd = NULL;
+    const char *session_hash = NULL;
+    const char *s_rnd = NULL;
+    const char *c_rnd = NULL;
+    const char *sha = NULL;
+    unsigned int kb_len, pm_len;
+    char *json_result;
+
+    if (!ctx) {
+        ACVP_LOG_ERR("No ctx for handler operation");
+        return ACVP_NO_CTX;
+    }
+
+    if (!alg_str) {
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
+        return ACVP_MALFORMED_JSON;
+    }
+
+    mode_str = json_object_get_string(obj, "mode");
+    if (!mode_str) {
+        ACVP_LOG_ERR("unable to parse 'mode' from JSON");
+        return ACVP_MALFORMED_JSON;
+    }
+
+    alg_id = acvp_lookup_cipher_w_mode_index(alg_str, mode_str);
+    if (alg_id != ACVP_KDF_TLS12) {
+        ACVP_LOG_ERR("Server JSON invalid 'algorithm' or 'mode'");
+        return ACVP_INVALID_ARG;
+    }
+
+    /*
+     * Get a reference to the abstracted test case
+     */
+    tc.tc.kdf_tls12 = &stc;
+
+    cap = acvp_locate_cap_entry(ctx, alg_id);
+    if (!cap) {
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
+        return ACVP_UNSUPPORTED_OP;
+    }
+
+    /*
+     * Create ACVP array for response
+     */
+    rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        return rv;
+    }
+
+    /*
+     * Start to build the JSON response
+     */
+    rv = acvp_setup_json_rsp_group(&ctx, &reg_arry_val, &r_vs_val, &r_vs, alg_str, &r_garr);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Failed to setup json response");
+        goto err;
+    }
+
+    groups = json_object_get_array(obj, "testGroups");
+    g_cnt = json_array_get_count(groups);
+    for (i = 0; i < g_cnt; i++) {
+        int tgId = 0;
+        groupval = json_array_get_value(groups, i);
+        groupobj = json_value_get_object(groupval);
+
+        /*
+         * Create a new group in the response with the tgid
+         * and an array of tests
+         */
+        r_gval = json_value_init_object();
+        r_gobj = json_value_get_object(r_gval);
+        tgId = json_object_get_number(groupobj, "tgId");
+        if (!tgId) {
+            ACVP_LOG_ERR("Missing tgid from server JSON groub obj");
+            rv = ACVP_MALFORMED_JSON;
+            goto err;
+        }
+        json_object_set_number(r_gobj, "tgId", tgId);
+        json_object_set_value(r_gobj, "tests", json_value_init_array());
+        r_tarr = json_object_get_array(r_gobj, "tests");
+
+        pm_len = json_object_get_number(groupobj, "preMasterSecretLength");
+        if (!pm_len) {
+            ACVP_LOG_ERR("preMasterSecretLength incorrect, %d", pm_len);
+            rv = ACVP_INVALID_ARG;
+            goto err;
+        }
+
+        kb_len = json_object_get_number(groupobj, "keyBlockLength");
+        if (!kb_len) {
+            ACVP_LOG_ERR("keyBlockLength incorrect, %d", kb_len);
+            rv = ACVP_INVALID_ARG;
+            goto err;
+        }
+
+        sha = json_object_get_string(groupobj, "hashAlg");
+        if (!sha) {
+            ACVP_LOG_ERR("Failed to include hashAlg");
+            rv = ACVP_MISSING_ARG;
+            goto err;
+        }
+        md = acvp_lookup_hash_alg(sha);
+        if (md != ACVP_SHA256 && md != ACVP_SHA384 &&
+            md != ACVP_SHA512) {
+            ACVP_LOG_ERR("Not TLS SHA");
+            rv = ACVP_NO_CAP;
+            goto err;
+        }
+
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("            pmLen: %d", pm_len);
+        ACVP_LOG_VERBOSE("            kbLen: %d", kb_len);
+        ACVP_LOG_VERBOSE("              sha: %s", sha);
+
+        tests = json_object_get_array(groupobj, "tests");
+        t_cnt = json_array_get_count(tests);
+        for (j = 0; j < t_cnt; j++) {
+            ACVP_LOG_VERBOSE("Found new hash test vector...");
+            testval = json_array_get_value(tests, j);
+            testobj = json_value_get_object(testval);
+
+            tc_id = json_object_get_number(testobj, "tcId");
+
+            pm_secret = json_object_get_string(testobj, "preMasterSecret");
+            if (!pm_secret) {
+                ACVP_LOG_ERR("Failed to include preMasterSecret");
+                rv = ACVP_MISSING_ARG;
+                goto err;
+            }
+            if (strnlen_s(pm_secret, pm_len) != pm_len / 4) {
+                ACVP_LOG_ERR("pmLen(%d) or pmSecret length(%d) incorrect",
+                             pm_len / 4, (int)strnlen_s(pm_secret, ACVP_KDF_TLS12_PMSECRET_STR_MAX));
+                rv = ACVP_INVALID_ARG;
+                goto err;
+            }
+
+            session_hash = json_object_get_string(testobj, "sessionHash");
+            if (!session_hash) {
+                ACVP_LOG_ERR("Failed to include sessionHash");
+                rv = ACVP_MISSING_ARG;
+                goto err;
+            }
+
+            s_rnd = json_object_get_string(testobj, "serverRandom");
+            if (!s_rnd) {
+                ACVP_LOG_ERR("Failed to include serverRandom");
+                rv = ACVP_MISSING_ARG;
+                goto err;
+            }
+
+            c_rnd = json_object_get_string(testobj, "clientRandom");
+            if (!c_rnd) {
+                ACVP_LOG_ERR("Failed to include clientRandom");
+                rv = ACVP_MISSING_ARG;
+                goto err;
+            }
+
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("         pmSecret: %s", pm_secret);
+            ACVP_LOG_VERBOSE("            shRND: %s", sh_rnd);
+            ACVP_LOG_VERBOSE("            chRND: %s", ch_rnd);
+            ACVP_LOG_VERBOSE("             sRND: %s", s_rnd);
+            ACVP_LOG_VERBOSE("             cRND: %s", c_rnd);
+
+            /*
+             * Create a new test case in the response
+             */
+            r_tval = json_value_init_object();
+            r_tobj = json_value_get_object(r_tval);
+
+            json_object_set_number(r_tobj, "tcId", tc_id);
+
+            /*
+             * Setup the test case data that will be passed down to
+             * the crypto module.
+             */
+            rv = acvp_kdf_tls12_init_tc(ctx, &stc, tc_id, alg_id, md, pm_len,
+                                         kb_len, pm_secret, session_hash, s_rnd, c_rnd);
+            if (rv != ACVP_SUCCESS) {
+                acvp_kdf_tls12_release_tc(&stc);
+                json_value_free(r_tval);
+                goto err;
+            }
+
+            /* Process the current test vector... */
+            if ((cap->crypto_handler)(&tc)) {
+                ACVP_LOG_ERR("crypto module failed the operation");
+                acvp_kdf_tls12_release_tc(&stc);
+                rv = ACVP_CRYPTO_MODULE_FAIL;
+                json_value_free(r_tval);
+                goto err;
+            }
+
+            /*
+             * Output the test case results using JSON
+             */
+            rv = acvp_kdf_tls12_output_tc(ctx, &stc, r_tobj);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("JSON output failure in hash module");
+                acvp_kdf_tls12_release_tc(&stc);
+                json_value_free(r_tval);
+                goto err;
+            }
+
+            /*
+             * Release all the memory associated with the test case
+             */
+            acvp_kdf_tls12_release_tc(&stc);
+
+            /* Append the test response value to array */
+            json_array_append_value(r_tarr, r_tval);
+        }
+        json_array_append_value(r_garr, r_gval);
+    }
+
+    json_array_append_value(reg_arry, r_vs_val);
+
+    json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
+    json_free_serialized_string(json_result);
+    rv = ACVP_SUCCESS;
+
+err:
+    if (rv != ACVP_SUCCESS) {
+        acvp_release_json(r_vs_val, r_gval);
+    }
+    return rv;
+}
+
+/*
+ * After the test case has been processed by the DUT, the results
+ * need to be JSON formated to be included in the vector set results
+ * file that will be uploaded to the server.  This routine handles
+ * the JSON processing for a single test case.
+ */
+static ACVP_RESULT acvp_kdf_tls12_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS12_TC *stc, JSON_Object *tc_rsp) {
+    char *tmp = NULL;
+    ACVP_RESULT rv = ACVP_SUCCESS;
+
+    tmp = calloc(1, ACVP_KDF_TLS12_MSG_MAX + 1);
+    if (!tmp) {
+        ACVP_LOG_ERR("Unable to malloc in acvp_kdf_tls12_output_tc");
+        return ACVP_MALLOC_FAIL;
+    }
+
+    rv = acvp_bin_to_hexstr(stc->msecret1, stc->pm_len, tmp, ACVP_KDF_TLS12_MSG_MAX);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("hex conversion failure (mac)");
+        goto err;
+    }
+    json_object_set_string(tc_rsp, "masterSecret", tmp);
+    memzero_s(tmp, ACVP_KDF_TLS12_MSG_MAX);
+
+    rv = acvp_bin_to_hexstr(stc->kblock1, stc->kb_len, tmp, ACVP_KDF_TLS12_MSG_MAX);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("hex conversion failure (mac)");
+        goto err;
+    }
+    json_object_set_string(tc_rsp, "keyBlock", tmp);
+
+err:
+    free(tmp);
+
+    return rv;
+}
+
+static ACVP_RESULT acvp_kdf_tls12_init_tc(ACVP_CTX *ctx,
+                                           ACVP_KDF_TLS12_TC *stc,
+                                           unsigned int tc_id,
+                                           ACVP_CIPHER alg_id,
+                                           ACVP_HASH_ALG md,
+                                           unsigned int pm_len,
+                                           unsigned int kb_len,
+                                           const char *pm_secret,
+                                           const char *session_hash,
+                                           const char *s_rnd,
+                                           const char *c_rnd) {
+    ACVP_RESULT rv;
+
+    memzero_s(stc, sizeof(ACVP_KDF_TLS12_TC));
+
+    stc->pm_secret = calloc(1, ACVP_KDF_TLS12_MSG_MAX);
+    if (!stc->pm_secret) { return ACVP_MALLOC_FAIL; }
+    rv = acvp_hexstr_to_bin(pm_secret, stc->pm_secret, ACVP_KDF_TLS12_MSG_MAX, NULL);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Hex conversion failure (pm_secret)");
+        return rv;
+    }
+
+    stc->session_hash = calloc(1, ACVP_KDF_TLS12_MSG_MAX);
+    if (!stc->session_hash) { return ACVP_MALLOC_FAIL; }
+    rv = acvp_hexstr_to_bin(session_hash, stc->session_hash, ACVP_KDF_TLS12_MSG_MAX, &(stc->session_hash_len));
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Hex conversion failure (sh_rnd)");
+        return rv;
+    }
+
+    stc->c_rnd = calloc(1, ACVP_KDF_TLS12_MSG_MAX);
+    if (!stc->c_rnd) { return ACVP_MALLOC_FAIL; }
+
+    rv = acvp_hexstr_to_bin(c_rnd, stc->c_rnd, ACVP_KDF_TLS12_MSG_MAX, &(stc->c_rnd_len));
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Hex conversion failure (c_rnd)");
+        return rv;
+    }
+
+    stc->s_rnd = calloc(1, ACVP_KDF_TLS12_MSG_MAX);
+    if (!stc->s_rnd) { return ACVP_MALLOC_FAIL; }
+
+    rv = acvp_hexstr_to_bin(s_rnd, stc->s_rnd, ACVP_KDF_TLS12_MSG_MAX, &(stc->s_rnd_len));
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Hex conversion failure (s_rnd)");
+        return rv;
+    }
+
+    stc->msecret1 = calloc(1, ACVP_KDF_TLS12_MSG_MAX);
+    if (!stc->msecret1) { return ACVP_MALLOC_FAIL; }
+    stc->msecret2 = calloc(1, ACVP_KDF_TLS12_MSG_MAX);
+    if (!stc->msecret2) { return ACVP_MALLOC_FAIL; }
+    stc->kblock1 = calloc(1, ACVP_KDF_TLS12_MSG_MAX);
+    if (!stc->kblock1) { return ACVP_MALLOC_FAIL; }
+    stc->kblock2 = calloc(1, ACVP_KDF_TLS12_MSG_MAX);
+    if (!stc->kblock2) { return ACVP_MALLOC_FAIL; }
+
+    stc->tc_id = tc_id;
+    stc->cipher = alg_id;
+    stc->pm_len = pm_len / 8;
+    stc->kb_len = kb_len / 8;
+    stc->md = md;
+
+    return ACVP_SUCCESS;
+}
+
+/*
+ * This function simply releases the data associated with
+ * a test case.
+ */
+static ACVP_RESULT acvp_kdf_tls12_release_tc(ACVP_KDF_TLS12_TC *stc) {
+    if (stc->pm_secret) free(stc->pm_secret);
+    if (stc->session_hash) free(stc->session_hash);
+    if (stc->c_rnd) free(stc->c_rnd);
+    if (stc->s_rnd) free(stc->s_rnd);
+    if (stc->msecret1) free(stc->msecret1);
+    if (stc->msecret2) free(stc->msecret2);
+    if (stc->kblock1) free(stc->kblock1);
+    if (stc->kblock2) free(stc->kblock2);
+
+    memzero_s(stc, sizeof(ACVP_KDF_TLS12_TC));
+    return ACVP_SUCCESS;
+}


### PR DESCRIPTION
Due to the nature of the name/mode/revision change as well as the testing change in the new TLS 1.2 KDF revision, I opted to make it into a new cipher that largely replicates the old 1.2 KDF testing. Added warnings to the old cipher (which has been left in for now) that it will be no longer supported come 2022.

Some changes were made to the library side to make it more closely resemble TLS 1.3 KDF for the sake of consistency.