### PR TITLE
Misc. fixes

### DIFF
--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -890,16 +890,9 @@ static ACVP_RESULT acvp_add_dsa_keygen_parm(ACVP_CTX *ctx,
                                             int value) {
     switch (param) {
     case ACVP_DSA_LN2048_224:
-        return acvp_add_dsa_mode_parm(ctx, dsa_cap_mode, param, value);
-
-        break;
     case ACVP_DSA_LN2048_256:
-        return acvp_add_dsa_mode_parm(ctx, dsa_cap_mode, param, value);
-
-        break;
     case ACVP_DSA_LN3072_256:
         return acvp_add_dsa_mode_parm(ctx, dsa_cap_mode, param, value);
-
         break;
     case ACVP_DSA_GENPQ:
     case ACVP_DSA_GENG:

--- a/src/acvp_kas_kdf.c
+++ b/src/acvp_kas_kdf.c
@@ -646,8 +646,8 @@ static ACVP_RESULT acvp_kas_kdf_process(ACVP_CTX *ctx,
     const char *alg_str = NULL,  *pattern_str = NULL, *encoding_str = NULL, 
                *salt_method_str = NULL;
     ACVP_HASH_ALG hmac_alg = 0;
-    unsigned int i, g_cnt;
-    int j, k, t_cnt, tc_id, saltLen, l, tmp;
+    unsigned int i = 0, g_cnt = 0;
+    int j = 0, k = 0, t_cnt = 0, tc_id = 0, saltLen = 0, l = 0, tmp = 0;
     ACVP_RESULT rv;
     const char *test_type_str = NULL;
     ACVP_KAS_KDF_TEST_TYPE test_type;


### PR DESCRIPTION
Fix complaint about uninitialized var (generally, trying to make a habit of initializing all to 0 for now) for saltLen
Change to DSA switch case for an internal extended cflag complaint 