### PR TITLE
Update urlib3 to non-vulnerable version

### DIFF
--- a/metadata/Pipfile.lock
+++ b/metadata/Pipfile.lock
@@ -58,7 +58,7 @@
                 "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
                 "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
             ],
-            "version": "==1.24.3"
+            "version": "==1.26.5"
         }
     },
     "develop": {}


### PR DESCRIPTION
Spending just a bit more time on determining what versions and such to push python and all of the dependencies to, but getting this vulnerability cleared out for now for the upcoming release.