### PR TITLE
Add support for not using a hash algorithm for Z in KAS SSC algorithms

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1613,8 +1613,8 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_P521);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_HASH, ACVP_SHA512);
-    CHECK_ENABLE_CAP_RV(rv);
+  //  rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_HASH, ACVP_SHA512);
+   // CHECK_ENABLE_CAP_RV(rv);
 end:
 
     return rv;
@@ -1658,8 +1658,8 @@ static int enable_kas_ifc(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KEYGEN_METHOD, ACVP_KAS_IFC_RSAKPG1_BASIC);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_HASH, ACVP_SHA512);
-    CHECK_ENABLE_CAP_RV(rv);
+   // rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_HASH, ACVP_SHA512);
+  //  CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ifc_set_exponent(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_FIXEDPUBEXP, expo_str);
     CHECK_ENABLE_CAP_RV(rv);
 end:
@@ -1817,8 +1817,8 @@ static int enable_kas_ffc(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
-    rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_HASH, ACVP_SHA512);
-    CHECK_ENABLE_CAP_RV(rv);
+  //  rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_HASH, ACVP_SHA512);
+   //CHECK_ENABLE_CAP_RV(rv);
 end:
 
     return rv;

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1613,8 +1613,8 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_P521);
     CHECK_ENABLE_CAP_RV(rv);
-  //  rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_HASH, ACVP_SHA512);
-   // CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_HASH, ACVP_SHA512);
+    CHECK_ENABLE_CAP_RV(rv);
 end:
 
     return rv;
@@ -1658,8 +1658,8 @@ static int enable_kas_ifc(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KEYGEN_METHOD, ACVP_KAS_IFC_RSAKPG1_BASIC);
     CHECK_ENABLE_CAP_RV(rv);
-   // rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_HASH, ACVP_SHA512);
-  //  CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_HASH, ACVP_SHA512);
+    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ifc_set_exponent(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_FIXEDPUBEXP, expo_str);
     CHECK_ENABLE_CAP_RV(rv);
 end:
@@ -1817,8 +1817,8 @@ static int enable_kas_ffc(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
-  //  rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_HASH, ACVP_SHA512);
-   //CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_HASH, ACVP_SHA512);
+    CHECK_ENABLE_CAP_RV(rv);
 end:
 
     return rv;

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -1181,7 +1181,7 @@ static ACVP_RESULT acvp_build_rsa_prim_register_cap(JSON_Object *cap_obj, ACVP_C
     return ACVP_SUCCESS;
 }
 
-static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CIPHER cipher, JSON_Object *cap_obj, ACVP_CAPS_LIST *cap_entry) {
+static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CTX *ctx, ACVP_CIPHER cipher, JSON_Object *cap_obj, ACVP_CAPS_LIST *cap_entry) {
     ACVP_RESULT result;
     JSON_Array *caps_arr = NULL, *curves_arr = NULL, *secret_modes_arr = NULL, *hash_arr = NULL;
     ACVP_CURVE_ALG_COMPAT_LIST *current_curve = NULL, *iter = NULL;
@@ -1201,7 +1201,7 @@ static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CIPHER cipher, JSON_Object
 
     alg = acvp_get_ecdsa_alg(cap_entry->cipher);
     if (alg == 0) {
-        printf("Invalid cipher value");
+        ACVP_LOG_ERR("Invalid cipher value");
         return 1;
     }
 
@@ -2614,17 +2614,19 @@ static ACVP_RESULT acvp_build_kas_ecc_register_cap(ACVP_CTX *ctx,
             }
             switch (kas_ecc_mode->hash) {
                 case ACVP_SHA224:
-                     json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-224");
-                     break;
+                    json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-224");
+                    break;
                 case ACVP_SHA256:
-                     json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-256");
-                     break;
+                    json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-256");
+                    break;
                 case ACVP_SHA384:
-                     json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-384");
-                     break;
+                    json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-384");
+                    break;
                 case ACVP_SHA512:
-                     json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-512");
-                     break;
+                    json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-512");
+                    break;
+                case ACVP_NO_SHA:
+                    break;
                 default:
                     ACVP_LOG_ERR("Unsupported KAS-ECC sha param %d", kas_ecc_mode->hash);
                     return ACVP_INVALID_ARG;
@@ -3110,17 +3112,19 @@ static ACVP_RESULT acvp_build_kas_ffc_register_cap(ACVP_CTX *ctx,
 
             switch (kas_ffc_mode->hash) {
                 case ACVP_SHA224:
-                     json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-224");
-                     break;
+                    json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-224");
+                    break;
                 case ACVP_SHA256:
-                     json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-256");
-                     break;
+                    json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-256");
+                    break;
                 case ACVP_SHA384:
-                     json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-384");
-                     break;
+                    json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-384");
+                    break;
                 case ACVP_SHA512:
-                     json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-512");
-                     break;
+                    json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-512");
+                    break;
+                case ACVP_NO_SHA:
+                    break;
                 default:
                     ACVP_LOG_ERR("Unsupported KAS-FFC sha param %d", kas_ffc_mode->hash);
                     return ACVP_INVALID_ARG;
@@ -3220,21 +3224,23 @@ static ACVP_RESULT acvp_build_kas_ifc_register_cap(ACVP_CTX *ctx,
     }
     switch (kas_ifc_cap->hash) {
         case ACVP_SHA224:
-             json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-224");
-             break;
+            json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-224");
+            break;
         case ACVP_SHA256:
-             json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-256");
-             break;
+            json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-256");
+            break;
         case ACVP_SHA384:
-             json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-384");
-             break;
+            json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-384");
+            break;
         case ACVP_SHA512:
-             json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-512");
-             break;
+            json_object_set_string(cap_obj, "hashFunctionZ", "SHA2-512");
+            break;
+        case ACVP_NO_SHA:
+            break;
         default:
-             ACVP_LOG_ERR("Unsupported KAS-IFC sha param %d", kas_ifc_cap->hash);
-             return ACVP_INVALID_ARG;
-             break;
+            ACVP_LOG_ERR("Unsupported KAS-IFC sha param %d", kas_ifc_cap->hash);
+            return ACVP_INVALID_ARG;
+            break;
     }
     json_object_set_string(cap_obj, "fixedPubExp", (const char *)kas_ifc_cap->fixed_pub_exp);
 
@@ -4077,7 +4083,7 @@ ACVP_RESULT acvp_build_test_session(ACVP_CTX *ctx, char **reg, int *out_len) {
             case ACVP_ECDSA_KEYVER:
             case ACVP_ECDSA_SIGGEN:
             case ACVP_ECDSA_SIGVER:
-                rv = acvp_build_ecdsa_register_cap(cap_entry->cipher, cap_obj, cap_entry);
+                rv = acvp_build_ecdsa_register_cap(ctx, cap_entry->cipher, cap_obj, cap_entry);
                 break;
             case ACVP_KDF135_SNMP:
                 rv = acvp_build_kdf135_snmp_register_cap(cap_obj, cap_entry);

--- a/src/acvp_kas_ecc.c
+++ b/src/acvp_kas_ecc.c
@@ -899,40 +899,43 @@ static ACVP_RESULT acvp_kas_ecc_output_ssc_tc(ACVP_CTX *ctx,
             json_object_set_boolean(tc_rsp, "testPassed", 0);
         }
         goto end;
-    }
+    } else {
+        memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
+        rv = acvp_bin_to_hexstr(stc->pix, stc->pixlen, tmp, ACVP_KAS_ECC_STR_MAX);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("hex conversion failure (pix)");
+            goto end;
+        }
+        json_object_set_string(tc_rsp, "ephemeralPublicIutX", tmp);
 
-    memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
-    rv = acvp_bin_to_hexstr(stc->pix, stc->pixlen, tmp, ACVP_KAS_ECC_STR_MAX);
-    if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (pix)");
-        goto end;
-    }
-    json_object_set_string(tc_rsp, "ephemeralPublicIutX", tmp);
+        memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
+        rv = acvp_bin_to_hexstr(stc->piy, stc->piylen, tmp, ACVP_KAS_ECC_STR_MAX);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("hex conversion failure (piy)");
+            goto end;
+        }
+        json_object_set_string(tc_rsp, "ephemeralPublicIutY", tmp);
 
-    memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
-    rv = acvp_bin_to_hexstr(stc->piy, stc->piylen, tmp, ACVP_KAS_ECC_STR_MAX);
-    if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (piy)");
-        goto end;
-    }
-    json_object_set_string(tc_rsp, "ephemeralPublicIutY", tmp);
+        memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
+        rv = acvp_bin_to_hexstr(stc->d, stc->dlen, tmp, ACVP_KAS_ECC_STR_MAX);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("hex conversion failure (d)");
+            goto end;
+        }
+        json_object_set_string(tc_rsp, "ephemeralPrivateIut", tmp);
 
-    memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
-    rv = acvp_bin_to_hexstr(stc->d, stc->dlen, tmp, ACVP_KAS_ECC_STR_MAX);
-    if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (d)");
-        goto end;
+        memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
+        rv = acvp_bin_to_hexstr(stc->chash, stc->chashlen, tmp, ACVP_KAS_ECC_STR_MAX);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("hex conversion failure (Z)");
+            goto end;
+        }
+        if (stc->md == ACVP_NO_SHA) {
+            json_object_set_string(tc_rsp, "Z", tmp);
+        } else {
+            json_object_set_string(tc_rsp, "hashZ", tmp);
+        }
     }
-    json_object_set_string(tc_rsp, "ephemeralPrivateIut", tmp);
-
-    memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
-    rv = acvp_bin_to_hexstr(stc->chash, stc->chashlen, tmp, ACVP_KAS_ECC_STR_MAX);
-    if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (Z)");
-        goto end;
-    }
-    json_object_set_string(tc_rsp, "hashZ", tmp);
-
 end:
     if (tmp) free(tmp);
 
@@ -950,6 +953,7 @@ static ACVP_RESULT acvp_kas_ecc_ssc(ACVP_CTX *ctx,
     JSON_Array *groups;
     JSON_Value *testval;
     JSON_Object *testobj = NULL;
+    ACVP_KAS_ECC_CAP_MODE *kas_ecc_mode = NULL;
     JSON_Array *tests, *r_tarr = NULL;
     JSON_Value *r_tval = NULL, *r_gval = NULL;  /* Response testval, groupval */
     JSON_Object *r_tobj = NULL, *r_gobj = NULL; /* Response testobj, groupobj */
@@ -1000,18 +1004,24 @@ static ACVP_RESULT acvp_kas_ecc_ssc(ACVP_CTX *ctx,
             goto err;
         }
 
-        hash_str = json_object_get_string(groupobj, "hashFunctionZ");
-        if (!hash_str) {
-            ACVP_LOG_ERR("Server JSON missing 'hashFunctionZ'");
-            rv = ACVP_MISSING_ARG;
-            goto err;
-        }
-        hash = acvp_lookup_hash_alg(hash_str);
-        if (!(hash == ACVP_SHA224 || hash == ACVP_SHA256 ||
-              hash == ACVP_SHA384 || hash == ACVP_SHA512)) {
-            ACVP_LOG_ERR("Server JSON invalid 'hashAlg'");
-            rv = ACVP_INVALID_ARG;
-            goto err;
+        //If the user doesn't specify a hash function, neither does the server
+        if (cap && cap->cap.kas_ecc_cap) {
+            kas_ecc_mode = &cap->cap.kas_ecc_cap->kas_ecc_mode[ACVP_KAS_ECC_MODE_NONE - 1];
+            if (kas_ecc_mode && kas_ecc_mode->hash != ACVP_NO_SHA) {
+                hash_str = json_object_get_string(groupobj, "hashFunctionZ");
+                if (!hash_str) {
+                    ACVP_LOG_ERR("Server JSON missing 'hashFunctionZ'");
+                    rv = ACVP_MISSING_ARG;
+                    goto err;
+                }
+                hash = acvp_lookup_hash_alg(hash_str);
+                if (!(hash == ACVP_SHA224 || hash == ACVP_SHA256 ||
+                    hash == ACVP_SHA384 || hash == ACVP_SHA512)) {
+                    ACVP_LOG_ERR("Server JSON invalid 'hashAlg'");
+                    rv = ACVP_INVALID_ARG;
+                    goto err;
+                }
+            }
         }
 
         test_type_str = json_object_get_string(groupobj, "testType");
@@ -1133,13 +1143,25 @@ static ACVP_RESULT acvp_kas_ecc_ssc(ACVP_CTX *ctx,
 
                 z = json_object_get_string(testobj, "hashZ");
                 if (!z) {
-                    ACVP_LOG_ERR("Server JSON missing 'hashZ'");
-                    rv = ACVP_MISSING_ARG;
-                    json_value_free(r_tval);
-                    goto err;
+                    //Assume user did not specify hash function if we don't have capability info for some reason
+                    if (!kas_ecc_mode || kas_ecc_mode->hash == ACVP_NO_SHA) {
+                        z = json_object_get_string(testobj, "z");
+                        if (!z) {
+                            ACVP_LOG_ERR("Server JSON missing 'z'");
+                            rv = ACVP_MISSING_ARG;
+                            json_value_free(r_tval);
+                            goto err;
+                        }
+                    } else {
+                        ACVP_LOG_ERR("Server JSON missing 'hashZ'");
+                        rv = ACVP_MISSING_ARG;
+                        json_value_free(r_tval);
+                        goto err;
+                    }
                 }
+
                 if (strnlen_s(z, ACVP_KAS_ECC_STR_MAX + 1) > ACVP_KAS_ECC_STR_MAX) {
-                    ACVP_LOG_ERR("hashZIut too long, max allowed=(%d)",
+                    ACVP_LOG_ERR("hashZ or z too long, max allowed=(%d)",
                                  ACVP_KAS_ECC_STR_MAX);
                     rv = ACVP_INVALID_ARG;
                     json_value_free(r_tval);

--- a/src/acvp_kas_ifc.c
+++ b/src/acvp_kas_ifc.c
@@ -79,21 +79,26 @@ static ACVP_RESULT acvp_kas_ifc_ssc_val_output_tc(ACVP_KAS_IFC_TC *stc,
             json_object_set_boolean(tc_rsp, "testPassed", 0);
             goto end;
         }
+        if (stc->md != ACVP_NO_SHA) {
+            memcmp_s(stc->chash, ACVP_KAS_IFC_BYTE_MAX,
+                    stc->hashz, stc->hashzlen, &diff1);
 
-        memcmp_s(stc->chash, ACVP_KAS_IFC_BYTE_MAX,
-                 stc->hashz, stc->hashzlen, &diff1);
-
-        if (!diff1) {
-            json_object_set_boolean(tc_rsp, "testPassed", 1);
+            if (!diff1) {
+                json_object_set_boolean(tc_rsp, "testPassed", 1);
+            } else {
+                json_object_set_boolean(tc_rsp, "testPassed", 0);
+            }
         } else {
-            json_object_set_boolean(tc_rsp, "testPassed", 0);
+            json_object_set_boolean(tc_rsp, "testPassed", 1);
         }
     } else {
-        memcmp_s(stc->chash, ACVP_KAS_IFC_BYTE_MAX,
-                 stc->hashz, stc->hashzlen, &diff1);
+        if (stc->md != ACVP_NO_SHA) {
+            memcmp_s(stc->chash, ACVP_KAS_IFC_BYTE_MAX, stc->hashz, stc->hashzlen, &diff1);
+        } else {
+            diff1 = 0;
+        }
 
-        memcmp_s(stc->pt, ACVP_KAS_IFC_BYTE_MAX,
-                 stc->c, stc->clen, &diff2);
+        memcmp_s(stc->pt, ACVP_KAS_IFC_BYTE_MAX, stc->c, stc->clen, &diff2);
 
         if (!diff1 && !diff2) {
             json_object_set_boolean(tc_rsp, "testPassed", 1);
@@ -194,10 +199,12 @@ static ACVP_RESULT acvp_kas_ifc_ssc_init_tc(ACVP_CTX *ctx,
 
         stc->hashz = calloc(1, ACVP_KAS_IFC_BYTE_MAX);
         if (!stc->hashz) { return ACVP_MALLOC_FAIL; }
-        rv = acvp_hexstr_to_bin(hashz, stc->hashz, ACVP_KAS_IFC_BYTE_MAX, &(stc->hashzlen));
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Hex conversion failure (hashz)");
-            return rv;
+        if (hashz) {
+            rv = acvp_hexstr_to_bin(hashz, stc->hashz, ACVP_KAS_IFC_BYTE_MAX, &(stc->hashzlen));
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("Hex conversion failure (hashz)");
+                return rv;
+            }
         }
 
         /* VAL test type initiator role needs this one */
@@ -279,7 +286,7 @@ static ACVP_RESULT acvp_kas_ifc_ssc(ACVP_CTX *ctx,
     const char *p = NULL, *q = NULL, *n = NULL, *d = NULL, *e = NULL;
     const char *pub_exp = NULL, *kas_role = NULL, *scheme = NULL, *hash = NULL;
     const char *ct = NULL, *hashz = NULL, *z = NULL, *c = NULL;
-    ACVP_HASH_ALG hash_alg;
+    ACVP_HASH_ALG hash_alg = 0;
     unsigned int modulo;
     unsigned int i, g_cnt;
     int j, t_cnt, tc_id, diff;
@@ -348,19 +355,23 @@ static ACVP_RESULT acvp_kas_ifc_ssc(ACVP_CTX *ctx,
             rv = ACVP_MISSING_ARG;
             goto err;
         }
-        hash = json_object_get_string(groupobj, "hashFunctionZ");
-        if (!hash) {
-            ACVP_LOG_ERR("Server JSON missing 'hashFunctionZ'");
-            rv = ACVP_MISSING_ARG;
-            goto err;
-        }
 
-        hash_alg = acvp_lookup_hash_alg(hash);
-        if (hash_alg != ACVP_SHA224 && hash_alg != ACVP_SHA256 &&
-            hash_alg != ACVP_SHA384 && hash_alg != ACVP_SHA512) {
-            ACVP_LOG_ERR("Server JSON invalid 'hashFunctionZ'");
-            rv = ACVP_INVALID_ARG;
-            goto err;
+        //If the user doesn't specify a hash function, neither does the server
+        if (cap && cap->cap.kas_ifc_cap && cap->cap.kas_ifc_cap->hash != ACVP_NO_SHA) {
+            hash = json_object_get_string(groupobj, "hashFunctionZ");
+            if (!hash) {
+                ACVP_LOG_ERR("Server JSON missing 'hashFunctionZ'");
+                rv = ACVP_MISSING_ARG;
+                goto err;
+            }
+
+            hash_alg = acvp_lookup_hash_alg(hash);
+            if (hash_alg != ACVP_SHA224 && hash_alg != ACVP_SHA256 &&
+                hash_alg != ACVP_SHA384 && hash_alg != ACVP_SHA512) {
+                ACVP_LOG_ERR("Server JSON invalid 'hashFunctionZ'");
+                rv = ACVP_INVALID_ARG;
+                goto err;
+            }
         }
 
         kas_role = json_object_get_string(groupobj, "kasRole");
@@ -516,32 +527,33 @@ static ACVP_RESULT acvp_kas_ifc_ssc(ACVP_CTX *ctx,
 
             }
             if (test_type == ACVP_KAS_IFC_TT_VAL) {
-
                 z = json_object_get_string(testobj, "z");
-                 if (!z) {
-                     ACVP_LOG_ERR("Server JSON missing 'z'");
-                     rv = ACVP_MISSING_ARG;
-                     goto err;
-                 }
-                 if (strnlen_s(z, ACVP_KAS_IFC_STR_MAX + 1) > ACVP_KAS_IFC_STR_MAX) {
-                     ACVP_LOG_ERR("z too long, max allowed=(%d)",
-                                   ACVP_KAS_IFC_STR_MAX);
-                     rv = ACVP_INVALID_ARG;
-                     goto err;
-                 }
+                if (!z) {
+                    ACVP_LOG_ERR("Server JSON missing 'z'");
+                    rv = ACVP_MISSING_ARG;
+                    goto err;
+                }
+                if (strnlen_s(z, ACVP_KAS_IFC_STR_MAX + 1) > ACVP_KAS_IFC_STR_MAX) {
+                    ACVP_LOG_ERR("z too long, max allowed=(%d)",
+                                ACVP_KAS_IFC_STR_MAX);
+                    rv = ACVP_INVALID_ARG;
+                    goto err;
+                }
 
-                 hashz = json_object_get_string(testobj, "hashZ");
-                 if (!hashz) {
-                     ACVP_LOG_ERR("Server JSON missing hashZ'");
-                     rv = ACVP_MISSING_ARG;
-                     goto err;
-                 }
-                 if (strnlen_s(hashz, ACVP_KAS_IFC_STR_MAX + 1) > ACVP_KAS_IFC_STR_MAX) {
-                     ACVP_LOG_ERR("hashz too long, max allowed=(%d)",
-                                   ACVP_KAS_IFC_STR_MAX);
-                     rv = ACVP_INVALID_ARG;
-                     goto err;
-                 }
+                if (cap && cap->cap.kas_ifc_cap && cap->cap.kas_ifc_cap->hash != ACVP_NO_SHA) {
+                    hashz = json_object_get_string(testobj, "hashZ");
+                    if (!hashz) {
+                        ACVP_LOG_ERR("Server JSON missing hashZ'");
+                        rv = ACVP_MISSING_ARG;
+                        goto err;
+                    }
+                    if (strnlen_s(hashz, ACVP_KAS_IFC_STR_MAX + 1) > ACVP_KAS_IFC_STR_MAX) {
+                        ACVP_LOG_ERR("hashz too long, max allowed=(%d)",
+                                    ACVP_KAS_IFC_STR_MAX);
+                        rv = ACVP_INVALID_ARG;
+                        goto err;
+                    }
+                }
 
                 if (role == ACVP_KAS_IFC_INITIATOR) {
                     c = json_object_get_string(testobj, "iutC");

--- a/src/acvp_kas_ifc.c
+++ b/src/acvp_kas_ifc.c
@@ -53,7 +53,11 @@ static ACVP_RESULT acvp_kas_ifc_ssc_output_tc(ACVP_CTX *ctx,
         ACVP_LOG_ERR("hex conversion failure (Z)");
         goto end;
     }
-    json_object_set_string(tc_rsp, "hashZ", tmp);
+    if (stc->md == ACVP_NO_SHA) {
+        json_object_set_string(tc_rsp, "Z", tmp);
+    } else {
+        json_object_set_string(tc_rsp, "hashZ", tmp);
+    }
 
 end:
     if (tmp) free(tmp);

--- a/test/test_app_kas_ecc.c
+++ b/test/test_app_kas_ecc.c
@@ -227,7 +227,7 @@ Test(APP_KAS_ECC_HANDLER, invalid_hash_ecc_comp) {
     char *pix = "aa";
     char *piy = "aa";
     char *z = "aa";
-    int hash_alg = 0;
+    int hash_alg = 1;
     
     kas_ecc_tc = calloc(1, sizeof(ACVP_KAS_ECC_TC));
     

--- a/test/test_app_kas_ffc.c
+++ b/test/test_app_kas_ffc.c
@@ -152,7 +152,7 @@ err:
  */
 Test(APP_KAS_FFC_HANDLER, invalid_hash_alg) {
     int corrupt = 0;
-    int hash_alg = 0;
+    int hash_alg = 1;
     char *p = "aa";
     char *q = "aa";
     char *g = "aa";

--- a/test/test_app_kas_ifc.c
+++ b/test/test_app_kas_ifc.c
@@ -173,7 +173,7 @@ err:
  */
 Test(APP_KAS_IFC_HANDLER, invalid_hash_alg) {
     int corrupt = 0;
-    int hash_alg = 0;
+    int hash_alg = 1;
     char *p = "aa";
     char *q = "aa";
     char *d = "aa";


### PR DESCRIPTION
Also some misc. other changes/fixes (e.g. no longer including un-needed values for VAL test submissions, spacing)