### PR TITLE
Move user_agent handler from acvp_run to acvp_set_server

### DIFF
--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1759,6 +1759,11 @@ ACVP_RESULT acvp_set_server(ACVP_CTX *ctx, const char *server_name, int port) {
 
     ctx->server_port = port;
 
+    if (!ctx->http_user_agent) {
+        //generate user-agent string to send with HTTP requests
+        acvp_http_user_agent_handler(ctx);
+    }
+
     return ACVP_SUCCESS;
 }
 
@@ -3393,9 +3398,6 @@ ACVP_RESULT acvp_run(ACVP_CTX *ctx, int fips_validation) {
     JSON_Value *val = NULL;
 
     if (ctx == NULL) return ACVP_NO_CTX;
-
-    //generate user-agent string to send with HTTP requests
-    acvp_http_user_agent_handler(ctx);
 
     rv = acvp_login(ctx, 0);
     if (rv != ACVP_SUCCESS) {


### PR DESCRIPTION
Not all acvp functions currently go through acvp_run, (e.g. resume session) so user_agent is not reliably set this way. Moving it to set server, which is a requirement to run any network traffic through libacvp.

