### PR TITLE
Initial work on 3.0 hmac conversion, removing 1.0.2 support

### DIFF
--- a/app/app_hmac.c
+++ b/app/app_hmac.c
@@ -12,21 +12,24 @@
 #include <openssl/hmac.h>
 #include "acvp/acvp.h"
 #include "app_lcl.h"
-#ifdef ACVP_NO_RUNTIME
-# include "app_fips_lcl.h"
+#ifdef ACVP_NO_RUNTIME && OPENSSL_VERSION_NUMBER < 0x30000000L
+#include "app_fips_lcl.h"
 #endif
 
 int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     ACVP_HMAC_TC    *tc;
-    const EVP_MD    *md;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined ACV_LEGACY_HMAC
+    EVP_MAC *mac = NULL;
+    EVP_MAC_CTX *hmac_ctx = NULL;
+    OSSL_PARAM params[2];
+    const char *md_name;
+#else
+    const EVP_MD *md = NULL;
     HMAC_CTX *hmac_ctx = NULL;
+#endif
     int msg_len;
     int rc = 1;
     ACVP_SUB_HMAC alg;
-
-#if OPENSSL_VERSION_NUMBER <= 0x10100000L
-    HMAC_CTX static_ctx;
-#endif
 
     if (!test_case) {
         return rc;
@@ -40,6 +43,84 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
         printf("Invalid cipher value");
         return 1;
     }
+
+    msg_len = tc->msg_len;
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined ACV_LEGACY_HMAC
+    switch (alg) {
+    case ACVP_SUB_HMAC_SHA1:
+        md_name = ACVP_STR_SHA_1;
+        break;
+    case ACVP_SUB_HMAC_SHA2_224:
+        md_name = ACVP_STR_SHA2_224;
+        break;
+    case ACVP_SUB_HMAC_SHA2_256:
+        md_name = ACVP_STR_SHA2_256;
+        break;
+    case ACVP_SUB_HMAC_SHA2_384:
+        md_name = ACVP_STR_SHA2_384;
+        break;
+    case ACVP_SUB_HMAC_SHA2_512:
+        md_name = ACVP_STR_SHA2_512;
+        break;
+    case ACVP_SUB_HMAC_SHA2_512_224:
+        md_name = ACVP_STR_SHA2_512_224;
+        break;
+    case ACVP_SUB_HMAC_SHA2_512_256:
+        md_name = ACVP_STR_SHA2_512_256;
+        break;
+    case ACVP_SUB_HMAC_SHA3_224:
+        md_name = ACVP_STR_SHA3_224;
+        break;
+    case ACVP_SUB_HMAC_SHA3_256:
+        md_name = ACVP_STR_SHA3_256;
+        break;
+    case ACVP_SUB_HMAC_SHA3_384:
+        md_name = ACVP_STR_SHA3_384;
+        break;
+    case ACVP_SUB_HMAC_SHA3_512:
+        md_name = ACVP_STR_SHA3_512;
+        break;
+    default:
+        printf("Error: Unsupported hash algorithm requested by ACVP server\n");
+        return rc;
+
+        break;
+    }
+
+    mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+    if (!mac) {
+        printf("Error: unable to fetch HMAC");
+        goto end;
+    }
+    hmac_ctx = EVP_MAC_CTX_new(mac);
+    if (!hmac_ctx) {
+        printf("Error: unable to create HMAC CTX");
+        goto end;
+    }
+
+    params[0] = OSSL_PARAM_construct_utf8_string("digest", (char*)md_name, 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    if (!EVP_MAC_init(hmac_ctx, tc->key, tc->key_len, params)) {
+        printf("\nCrypto module error, EVP_MAC_init failed\n");
+        ERR_print_errors_cb(&serror_cb, NULL);
+        goto end;
+    }
+
+    if (!EVP_MAC_update(hmac_ctx, tc->msg, msg_len)) {
+        printf("\nCrypto module error, EVP_MAC_update failed\n");
+        goto end;
+    }
+
+    if (!EVP_MAC_final(hmac_ctx, tc->mac, (long unsigned int *)&tc->mac_len, HMAC_BUF_MAX)) {
+        printf("\nCrypto module error, EVP_MAC_final failed\n");
+        goto end;
+    }
+
+    rc = 0;
+
+#else
 
     switch (alg) {
     case ACVP_SUB_HMAC_SHA1:
@@ -57,7 +138,6 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_SUB_HMAC_SHA2_512:
         md = EVP_sha512();
         break;
-#if OPENSSL_VERSION_NUMBER >= 0x10101010L /* OpenSSL 1.1.1 or greater */
     case ACVP_SUB_HMAC_SHA2_512_224:
         md = EVP_sha512_224();
         break;
@@ -76,14 +156,6 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_SUB_HMAC_SHA3_512:
         md = EVP_sha3_512();
         break;
-#else
-    case ACVP_SUB_HMAC_SHA2_512_224:
-    case ACVP_SUB_HMAC_SHA2_512_256:
-    case ACVP_SUB_HMAC_SHA3_224:
-    case ACVP_SUB_HMAC_SHA3_256:
-    case ACVP_SUB_HMAC_SHA3_384:
-    case ACVP_SUB_HMAC_SHA3_512:
-#endif
     default:
         printf("Error: Unsupported hash algorithm requested by ACVP server\n");
         return rc;
@@ -91,13 +163,7 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
         break;
     }
 
-#if OPENSSL_VERSION_NUMBER <= 0x10100000L
-    hmac_ctx = &static_ctx;
-    HMAC_CTX_init(hmac_ctx);
-#else
     hmac_ctx = HMAC_CTX_new();
-#endif
-    msg_len = tc->msg_len;
 
     if (!HMAC_Init_ex(hmac_ctx, tc->key, tc->key_len, md, NULL)) {
         printf("\nCrypto module error, HMAC_Init_ex failed\n");
@@ -117,12 +183,11 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     rc = 0;
 
 end:
-#if OPENSSL_VERSION_NUMBER <= 0x10100000L
-    HMAC_CTX_cleanup(hmac_ctx);
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined ACV_LEGACY_HMAC
+    if (hmac_ctx) EVP_MAC_CTX_free(hmac_ctx);
+    if (mac) EVP_MAC_free(mac);
 #else
     if (hmac_ctx) HMAC_CTX_free(hmac_ctx);
 #endif
-
-    return rc;
 }
 

--- a/app/app_hmac.c
+++ b/app/app_hmac.c
@@ -12,7 +12,7 @@
 #include <openssl/hmac.h>
 #include "acvp/acvp.h"
 #include "app_lcl.h"
-#ifdef ACVP_NO_RUNTIME && OPENSSL_VERSION_NUMBER < 0x30000000L
+#if defined ACVP_NO_RUNTIME && OPENSSL_VERSION_NUMBER < 0x30000000L
 #include "app_fips_lcl.h"
 #endif
 
@@ -181,6 +181,7 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     }
 
     rc = 0;
+#endif
 
 end:
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined ACV_LEGACY_HMAC
@@ -189,5 +190,6 @@ end:
 #else
     if (hmac_ctx) HMAC_CTX_free(hmac_ctx);
 #endif
+    return rc;
 }
 

--- a/app/app_utils.c
+++ b/app/app_utils.c
@@ -130,7 +130,7 @@ static int hmac_totp(const char *key,
     memcpy_s(hash, hash_max, buff, len);
 
 end:
-    HMAC_CTX_cleanup(ctx);
+    if (ctx) HMAC_CTX_free(ctx);
     return len;
 }
 #else

--- a/app/app_utils.c
+++ b/app/app_utils.c
@@ -111,6 +111,7 @@ const int DIGITS_POWER[]
 #define T_LEN 8
 #define MAX_LEN 512
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 static int hmac_totp(const char *key,
                      const unsigned char *msg,
                      char *hash,
@@ -121,15 +122,7 @@ static int hmac_totp(const char *key,
     unsigned char buff[MAX_LEN];
     HMAC_CTX *ctx;
 
-#if OPENSSL_VERSION_NUMBER <= 0x10100000L
-    HMAC_CTX static_ctx;
-
-    ctx = &static_ctx;
-    HMAC_CTX_init(ctx);
-#else
     ctx = HMAC_CTX_new();
-#endif
-
     HMAC_CTX_set_flags(ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
     if (!HMAC_Init_ex(ctx, key, key_len, md, NULL)) goto end;
     if (!HMAC_Update(ctx, msg, T_LEN)) goto end;
@@ -137,14 +130,27 @@ static int hmac_totp(const char *key,
     memcpy_s(hash, hash_max, buff, len);
 
 end:
-#if OPENSSL_VERSION_NUMBER <= 0x10100000L
     HMAC_CTX_cleanup(ctx);
-#else
-    if (ctx) HMAC_CTX_free(ctx);
-#endif
-
     return len;
 }
+#else
+static int hmac_totp(const char *key,
+                     const unsigned char *msg,
+                     char *hash,
+                     int hash_max,
+                     const char *md_name,
+                     unsigned int key_len) {
+    int len = 0;
+    unsigned char buff[MAX_LEN];
+
+    EVP_Q_mac(NULL, "HMAC", NULL, md_name, NULL, key, key_len, msg, T_LEN, buff, MAX_LEN, (long unsigned int *)&len);
+
+    memcpy_s(hash, hash_max, buff, len);
+
+end:
+    return len;
+}
+#endif
 
 static ACVP_RESULT totp(char **token, int token_max) {
     char hash[MAX_LEN] = {0};
@@ -191,7 +197,11 @@ static ACVP_RESULT totp(char **token, int token_max) {
 
 
     // use passed hash function
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
     md_len = hmac_totp(new_seed, token_buff, hash, sizeof(hash), EVP_sha256(), seed_len);
+#else
+    md_len = hmac_totp(new_seed, token_buff, hash, sizeof(hash), "SHA2-256", seed_len);
+#endif
     if (md_len == 0) {
         printf("Failed to create TOTP\n");
         free(new_seed);


### PR DESCRIPTION
Due to uncertainty around release schedules pushing this to a new libacvp_1_TBD_throttle branch currently.
This is not expected to build currently on 3.0 due to autoconf and needing to setup providers in app_main, I will be pushing this work in pieces. I did test the new hmac code to pass a test session in FIPS mode.

If someone wants to test the legacy deprecated APIs I have left in a compiler flag they can use called ACV_LEGACY_HMAC.
