### PR TITLE
TDES support, misc. mac updates, configure update

### DIFF
--- a/app/app_cmac.c
+++ b/app/app_cmac.c
@@ -25,6 +25,7 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
     EVP_MAC_CTX *cmac_ctx = NULL;
     OSSL_PARAM params[2];
     const char *alg_name = NULL;
+    char *aname = NULL;
 #else
     CMAC_CTX *cmac_ctx = NULL;
     const EVP_CIPHER *c = NULL;
@@ -101,8 +102,9 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
         printf("Error: unable to create CMAC CTX");
         goto end;
     }
-
-    params[0] = OSSL_PARAM_construct_utf8_string("cipher", (char*)alg_name, 0);
+    aname = calloc(256, sizeof(char)); //avoid const removal warnings
+    strcpy_s(aname, 256, alg_name);
+    params[0] = OSSL_PARAM_construct_utf8_string("cipher", aname, 0);
     params[1] = OSSL_PARAM_construct_end();
 
 #define CMAC_BUF_MAX 128
@@ -222,6 +224,7 @@ end:
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined ACVP_DEPRECATED_MAC
     if (cmac_ctx) EVP_MAC_CTX_free(cmac_ctx);
     if (mac) EVP_MAC_free(mac);
+    if (aname) free(aname);
 #else
     if (cmac_ctx) CMAC_CTX_free(cmac_ctx);
 #endif

--- a/app/app_des.c
+++ b/app/app_des.c
@@ -25,10 +25,15 @@ void app_des_cleanup(void) {
 }
 
 int app_des_handler(ACVP_TEST_CASE *test_case) {
-    ACVP_SYM_CIPHER_TC      *tc;
+    ACVP_SYM_CIPHER_TC *tc;
     EVP_CIPHER_CTX *cipher_ctx;
-    const EVP_CIPHER        *cipher;
+    const EVP_CIPHER *cipher;
     unsigned char *iv = 0;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    unsigned char *ctx_iv = NULL;
+#else
+    const unsigned char *ctx_iv = NULL;
+#endif
     ACVP_SUB_TDES alg;
 
     if (!test_case) {
@@ -118,8 +123,11 @@ int app_des_handler(ACVP_TEST_CASE *test_case) {
      * one thousand times before we complete each iteration.
      */
     if (tc->test_type == ACVP_SYM_TEST_TYPE_MCT) {
-        const unsigned char *ctx_iv = NULL;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+        ctx_iv = calloc(8, sizeof(unsigned char));
+#else
         ctx_iv = EVP_CIPHER_CTX_iv(cipher_ctx);
+#endif
 
 #define SYM_IV_BYTE_MAX 128
         if (tc->direction == ACVP_SYM_CIPH_DIR_ENCRYPT) {
@@ -128,6 +136,9 @@ int app_des_handler(ACVP_TEST_CASE *test_case) {
                 EVP_CIPHER_CTX_set_padding(cipher_ctx, 0);
             } else {
                 /* TDES needs the pre-operation IV returned */
+                #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+                    EVP_CIPHER_CTX_get_updated_iv(cipher_ctx, (void *)ctx_iv, 8);
+                #endif
                 memcpy_s(tc->iv_ret, SYM_IV_BYTE_MAX, ctx_iv, 8);
             }
             if (tc->cipher == ACVP_TDES_CFB1) {
@@ -137,6 +148,9 @@ int app_des_handler(ACVP_TEST_CASE *test_case) {
             EVP_Cipher(cipher_ctx, tc->ct, tc->pt, tc->pt_len);
             tc->ct_len = tc->pt_len;
             /* TDES needs the post-operation IV returned */
+            #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+                EVP_CIPHER_CTX_get_updated_iv(cipher_ctx, (void *)ctx_iv, 8);
+            #endif
             memcpy_s(tc->iv_ret_after, SYM_IV_BYTE_MAX, ctx_iv, 8);
         } else if (tc->direction == ACVP_SYM_CIPH_DIR_DECRYPT) {
             if (tc->mct_index == 0) {
@@ -144,6 +158,9 @@ int app_des_handler(ACVP_TEST_CASE *test_case) {
                 EVP_CIPHER_CTX_set_padding(cipher_ctx, 0);
             } else {
                 /* TDES needs the pre-operation IV returned */
+                #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+                    EVP_CIPHER_CTX_get_updated_iv(cipher_ctx, (void *)ctx_iv, 8);
+                #endif
                 memcpy_s(tc->iv_ret, SYM_IV_BYTE_MAX, ctx_iv, 8);
             }
             if (tc->cipher == ACVP_TDES_CFB1) {
@@ -152,6 +169,9 @@ int app_des_handler(ACVP_TEST_CASE *test_case) {
             EVP_Cipher(cipher_ctx, tc->pt, tc->ct, tc->ct_len);
             tc->pt_len = tc->ct_len;
             /* TDES needs the post-operation IV returned */
+            #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+                EVP_CIPHER_CTX_get_updated_iv(cipher_ctx, (void *)ctx_iv, 8);
+            #endif
             memcpy_s(tc->iv_ret_after, SYM_IV_BYTE_MAX, ctx_iv, 8);
         } else {
             printf("Unsupported direction\n");
@@ -186,9 +206,14 @@ int app_des_handler(ACVP_TEST_CASE *test_case) {
         EVP_CIPHER_CTX_free(glb_cipher_ctx);
         glb_cipher_ctx = NULL;
     }
-
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    if (ctx_iv) free(ctx_iv);
+#endif
     return 0;
 err:
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    if (ctx_iv) free(ctx_iv);
+#endif
     if (glb_cipher_ctx) EVP_CIPHER_CTX_free(glb_cipher_ctx);
     glb_cipher_ctx = NULL;
     return 1;

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -971,6 +971,7 @@ static int enable_tdes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
+#if !(OPENSSL_VERSION_NUMBER >= 0x30000000L && (defined ACVP_NO_RUNTIME || defined ACVP_FIPS_RUNTIME))
     /*
      * Enable 3DES-OFB
      */
@@ -1010,6 +1011,7 @@ static int enable_tdes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_ONE);
     CHECK_ENABLE_CAP_RV(rv);
+#endif
 
 end:
     return rv;

--- a/configure
+++ b/configure
@@ -11131,10 +11131,49 @@ found_ssl="false"
 ssl_lib64="false"
 
 if test "x$disable_lib_detection" = "xno"; then
+    #Check what version of SSL is being linked. Determines how any FIPS stuff is handled, and what APIs are used in some places
+    proj_temp_cppflags="$CPPFLAGS"
+    CPPFLAGS="-I$ssldir/include"
+    ac_fn_c_check_header_mongrel "$LINENO" "openssl/opensslv.h" "ac_cv_header_openssl_opensslv_h" "$ac_includes_default"
+if test "x$ac_cv_header_openssl_opensslv_h" = xyes; then :
+
+else
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "Unable to read opensslslv.h to determine SSL library version
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+            #include <openssl/opensslv.h>
+            #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+            #error "Detected OpenSSL version 3.0.0 or greater"
+            #endif
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  use_ssl_3="false"
+else
+  use_ssl_3="true"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CPPFLAGS="$proj_temp_cppflags"
+
+    #set LDFLAGS for libdetection
     if test "$is_freebsd" != "1" && test "x$enable_offline" != "xfalse" && test "x$check_ldl" != "xfalse" ; then
         LIBS="-ldl $LIBS"
     fi
-    if test "x$enable_offline" != "xfalse" ; then
+    if test "x$enable_offline" != "xfalse" && test "x$use_ssl_3" != "xtrue" ; then
         #Some platforms have multiple definitions. Allow them for JUST the library test stage.
         LDFLAGS="-static -Wl,--allow-multiple-definition $LDFLAGS"
     fi
@@ -11543,45 +11582,6 @@ fi
 
 
     fi
-
-#Check what version of SSL is being linked. Determines how any FIPS stuff is handled, and what APIs are used in some places
-proj_temp_cppflags="$CPPFLAGS"
-CPPFLAGS="-I$ssldir/include"
-ac_fn_c_check_header_mongrel "$LINENO" "openssl/opensslv.h" "ac_cv_header_openssl_opensslv_h" "$ac_includes_default"
-if test "x$ac_cv_header_openssl_opensslv_h" = xyes; then :
-
-else
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "Unable to read opensslslv.h to determine SSL library version
-See \`config.log' for more details" "$LINENO" 5; }
-fi
-
-
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-        #include <openssl/opensslv.h>
-        #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-        #error "Detected OpenSSL version 3.0.0 or greater"
-        #endif
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  use_ssl_3="false"
-else
-  use_ssl_3="true"
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-CPPFLAGS="$proj_temp_cppflags"
-
 else
     #assume we are using openssl < 3 if lib check is disabled
     use_ssl_3="false"

--- a/configure.ac
+++ b/configure.ac
@@ -209,10 +209,26 @@ found_ssl="false"
 ssl_lib64="false"
 
 if test "x$disable_lib_detection" = "xno"; then
+    #Check what version of SSL is being linked. Determines how any FIPS stuff is handled, and what APIs are used in some places
+    proj_temp_cppflags="$CPPFLAGS"
+    CPPFLAGS="-I$ssldir/include"
+    AC_CHECK_HEADER([openssl/opensslv.h], [], [AC_MSG_FAILURE([Unable to read opensslslv.h to determine SSL library version])])
+    AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([[
+            #include <openssl/opensslv.h>
+            #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+            #error "Detected OpenSSL version 3.0.0 or greater"
+            #endif
+        ]])],
+        [use_ssl_3="false"],
+        [use_ssl_3="true"])
+    CPPFLAGS="$proj_temp_cppflags"
+
+    #set LDFLAGS for libdetection
     if test "$is_freebsd" != "1" && test "x$enable_offline" != "xfalse" && test "x$check_ldl" != "xfalse" ; then
         LIBS="-ldl $LIBS"
     fi
-    if test "x$enable_offline" != "xfalse" ; then
+    if test "x$enable_offline" != "xfalse" && test "x$use_ssl_3" != "xtrue" ; then
         #Some platforms have multiple definitions. Allow them for JUST the library test stage.
         LDFLAGS="-static -Wl,--allow-multiple-definition $LDFLAGS"
     fi
@@ -257,22 +273,6 @@ if test "x$disable_lib_detection" = "xno"; then
             [AC_MSG_NOTICE([Murl not found in provided murl dir])])
 
     fi
-
-#Check what version of SSL is being linked. Determines how any FIPS stuff is handled, and what APIs are used in some places
-proj_temp_cppflags="$CPPFLAGS"
-CPPFLAGS="-I$ssldir/include"
-AC_CHECK_HEADER([openssl/opensslv.h], [], [AC_MSG_FAILURE([Unable to read opensslslv.h to determine SSL library version])])
-AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM([[
-        #include <openssl/opensslv.h>
-        #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-        #error "Detected OpenSSL version 3.0.0 or greater"
-        #endif
-    ]])],
-    [use_ssl_3="false"],
-    [use_ssl_3="true"])
-CPPFLAGS="$proj_temp_cppflags"
-
 else
     #assume we are using openssl < 3 if lib check is disabled
     use_ssl_3="false"

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2078,7 +2078,11 @@ static ACVP_RESULT acvp_build_login(ACVP_CTX *ctx, char **login, int *login_len,
         token = calloc(ACVP_TOTP_TOKEN_MAX + 1, sizeof(char));
         if (!token) return ACVP_MALLOC_FAIL;
 
-        ctx->totp_cb(&token, ACVP_TOTP_TOKEN_MAX);
+        rv = ctx->totp_cb(&token, ACVP_TOTP_TOKEN_MAX);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("Error occured in application callback while generating TOTP");
+            goto err;
+        }
         if (strnlen_s(token, ACVP_TOTP_TOKEN_MAX + 1) > ACVP_TOTP_TOKEN_MAX) {
             ACVP_LOG_ERR("totp cb generated a token that is too long");
             json_value_free(pw_val);


### PR DESCRIPTION
Tdes now uses new IV access API. Copies to a buffer instead of providing direct pointer access to CTX.

Updated HMAC/CMAC to stop strict cflags complaining about loss of const.

Updated configure so SSL version check now comes at beginning of library detection phase instead of end. This way we dont try to detect static libraries for SSL 3.0 when enable-offline is used.

Added error check to totp callback, so libacvp doesn't just hang if app returns non-success exit code to library.