### PR TITLE
RSA Siggen, sigver, and sigprim support for SSL 3.0 at fips runtime

### DIFF
--- a/app/app_cmac.c
+++ b/app/app_cmac.c
@@ -103,6 +103,10 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
         goto end;
     }
     aname = calloc(256, sizeof(char)); //avoid const removal warnings
+    if (!aname) {
+        printf("Error allocating memory for CMAC test\n");
+        goto end;
+    }
     strcpy_s(aname, 256, alg_name);
     params[0] = OSSL_PARAM_construct_utf8_string("cipher", aname, 0);
     params[1] = OSSL_PARAM_construct_end();

--- a/app/app_des.c
+++ b/app/app_des.c
@@ -125,6 +125,10 @@ int app_des_handler(ACVP_TEST_CASE *test_case) {
     if (tc->test_type == ACVP_SYM_TEST_TYPE_MCT) {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
         ctx_iv = calloc(8, sizeof(unsigned char));
+        if (!ctx_iv) {
+            printf("Error allocating memory for TDES test\n");
+            goto err;
+        }
 #else
         ctx_iv = EVP_CIPHER_CTX_iv(cipher_ctx);
 #endif

--- a/app/app_hmac.c
+++ b/app/app_hmac.c
@@ -102,6 +102,10 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     }
 
     mdname = calloc(256, sizeof(char)); //avoid const removal warnings
+    if (!mdname) {
+        printf("Error allocating memory for HMAC test\n");
+        goto end;
+    }
     strcpy_s(mdname, 256, md_name);
     params[0] = OSSL_PARAM_construct_utf8_string("digest", mdname, 0);
     params[1] = OSSL_PARAM_construct_end();

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -2233,21 +2233,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 4096, ACVP_SHA512, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
-#if 0
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 2048, ACVP_SHA512_224, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 2048, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 3072, ACVP_SHA512_224, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 3072, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 4096, ACVP_SHA512_224, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 4096, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-#endif
-
     // RSA w/ sigType: PKCS1v1.5
     rv = acvp_cap_rsa_siggen_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2275,21 +2260,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    
-#if 0
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_224, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_224, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_224, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-#endif
 
     // RSA w/ sigType: PKCS1PSS -- has salt
     rv = acvp_cap_rsa_siggen_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS);
@@ -2319,7 +2289,19 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
-#if 0
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_224, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_256, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_224, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_256, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_224, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_256, 0);
+    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512_256, 0);
@@ -2327,6 +2309,10 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA512_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA512_256, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512_224, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
@@ -2373,17 +2359,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 4096, ACVP_SHA512, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
-#if 0
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 2048, ACVP_SHA512_224, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 2048, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 3072, ACVP_SHA512_224, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 3072, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-#endif
-
     // RSA w/ sigType: PKCS1v1.5
     rv = acvp_cap_rsa_sigver_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2417,17 +2392,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-
-#if 0
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_224, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_224, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-#endif
 
     // RSA w/ sigType: PKCS1PSS -- has salt
     rv = acvp_cap_rsa_sigver_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS);
@@ -2463,12 +2427,32 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
-#if 0
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_224, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_256, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_224, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_256, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_224, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_256, 0);
+    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512_224, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512_256, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA512_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA512_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
-#endif
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512_224, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512_256, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+ #endif
 
 #ifdef OPENSSL_RSA_PRIMITIVE /* only enable as needed, decrypt can take a long time */
     /*
@@ -2480,7 +2464,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_DECPRIM, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-
+#endif
     /*
      * Enable Signature Primitive
      */
@@ -2496,7 +2480,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_prim_set_exponent(ctx, ACVP_RSA_PARM_FIXED_PUB_EXP_VAL, expo_str);
     CHECK_ENABLE_CAP_RV(rv);
-#endif
 end:
     if (expo_str) free(expo_str);
 

--- a/app/app_rsa.c
+++ b/app/app_rsa.c
@@ -11,32 +11,39 @@
 #include <openssl/evp.h>
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/param_build.h>
+#endif
+
 #include "app_lcl.h"
 #include "safe_lib.h"
 #ifdef ACVP_NO_RUNTIME
 #include "app_fips_lcl.h" /* All regular OpenSSL headers must come before here */
 #include <openssl/ossl_typ.h>
+#endif
 
-BIGNUM *group_n = NULL;
-RSA *group_rsa = NULL;
 int rsa_current_tg = 0;
+BIGNUM *group_n = NULL;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+EVP_PKEY *group_pkey = NULL;
+#else
+RSA *group_rsa = NULL;
+#endif
 
 void app_rsa_cleanup(void) {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    if (group_pkey) EVP_PKEY_free(group_pkey);
+    group_pkey = NULL;
+#else
     if (group_rsa) RSA_free(group_rsa);
     group_rsa = NULL;
+#endif
     if (group_n) BN_free(group_n);
     group_n = NULL;
 }
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L && defined ACVP_NO_RUNTIME
 int app_rsa_keygen_handler(ACVP_TEST_CASE *test_case) {
-    /*
-     * custom crypto module handler
-     * to be filled in -
-     * this handler assumes info gen by server
-     * and all the other params registered for
-     * in this example app.
-     */
-
     ACVP_RSA_KEYGEN_TC *tc = NULL;
     int rv = 1;
     RSA *rsa = NULL;
@@ -92,17 +99,33 @@ err:
     if (e) BN_free(e);
     return rv;
 }
-
+#else
+int app_rsa_keygen_handler(ACVP_TEST_CASE *test_case) {
+    if (!test_case) {
+        return -1;
+    }
+    return 1;
+}
+#endif
 
 int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    EVP_MD_CTX *md_ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *pkey_ctx = NULL;
+    OSSL_PARAM_BLD *pkey_pbld = NULL, *sig_pbld = NULL;
+    OSSL_PARAM *pkey_params = NULL, *sig_params = NULL;
+    const char *padding = NULL, *md = NULL;
+#else
     const EVP_MD *tc_md = NULL;
-    int siglen, pad_mode;
-    BIGNUM *bn_e = NULL, *e = NULL, *n = NULL;
     BIGNUM  *tmp_e = NULL, *tmp_n = NULL;
     const BIGNUM  *tmp_e1 = NULL, *tmp_n1 = NULL;
-    ACVP_RSA_SIG_TC    *tc;
     RSA *rsa = NULL;
+    int siglen = 0, pad_mode = 0;
+#endif
     int salt_len = -1;
+    BIGNUM *bn_e = NULL, *e = NULL, *n = NULL;
+    ACVP_RSA_SIG_TC *tc;
 
     int rv = 1;
 
@@ -118,16 +141,6 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
 
-    /*
-     * Make an RSA object and set a new BN exponent to use to generate a key
-     */
-
-    rsa = FIPS_rsa_new();
-    if (!rsa) {
-        printf("\nError: Issue with RSA obj in RSA Sig\n");
-        goto err;
-    }
-
     bn_e = BN_new();
     if (!bn_e || !BN_set_word(bn_e, 0x10001)) {
         printf("\nError: Issue with exponent in RSA Sig\n");
@@ -139,9 +152,60 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
 
-    /*
-     * Set the pad mode and generate a key given the respective sigType
-     */
+/* Set the padding mode and digest MD */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    switch (tc->sig_type) {
+    case ACVP_RSA_SIG_TYPE_X931:
+        padding = "x931";
+        break;
+    case ACVP_RSA_SIG_TYPE_PKCS1PSS:
+        salt_len = tc->salt_len;
+        padding = "pss";
+        break;
+    case ACVP_RSA_SIG_TYPE_PKCS1V15:
+        padding = "pkcs1";
+        break;
+    default:
+        printf("\nError: sigType not supported\n");
+        rv = ACVP_INVALID_ARG;
+        goto err;
+    }
+
+    switch (tc->hash_alg) {
+    case ACVP_SHA1:
+        md = "SHA-1";
+        break;
+    case ACVP_SHA224:
+        md = "SHA2-224";
+        break;
+    case ACVP_SHA256:
+        md = "SHA2-256";
+        break;
+    case ACVP_SHA384:
+        md = "SHA2-384";
+        break;
+    case ACVP_SHA512:
+        md = "SHA2-512";
+        break;
+    case ACVP_SHA512_224:
+        md = "SHA2-512/224";
+        break;
+    case ACVP_SHA512_256:
+        md = "SHA2-512/256";
+        break;
+    case ACVP_NO_SHA:
+    case ACVP_SHA3_224:
+    case ACVP_SHA3_256:
+    case ACVP_SHA3_384:
+    case ACVP_SHA3_512:
+    case ACVP_HASH_ALG_MAX:
+    default:
+        printf("\nError: hashAlg not supported for RSA SigGen\n");
+        goto err;
+    }
+
+#else
+
     switch (tc->sig_type) {
     case ACVP_RSA_SIG_TYPE_X931:
         pad_mode = RSA_X931_PADDING;
@@ -160,9 +224,6 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
 
-    /*
-     * Set the message digest to the appropriate sha
-     */
     switch (tc->hash_alg) {
     case ACVP_SHA1:
         tc_md = EVP_sha1();
@@ -195,6 +256,7 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
         printf("\nError: hashAlg not supported for RSA SigGen\n");
         goto err;
     }
+#endif
 
     /*
      * If we are verifying, set RSA to the given public key
@@ -215,72 +277,191 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
         }
         BN_bin2bn(tc->n, tc->n_len, n);
 
-        tmp_e = BN_dup(e);
-        tmp_n = BN_dup(n);
-        RSA_set0_key(rsa, tmp_n, tmp_e, NULL);
+        #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+            pkey_pbld = OSSL_PARAM_BLD_new();
+            OSSL_PARAM_BLD_push_BN(pkey_pbld, "n", n);
+            OSSL_PARAM_BLD_push_BN(pkey_pbld, "e", e);
+            pkey_params = OSSL_PARAM_BLD_to_param(pkey_pbld);
+            if (!pkey_params) {
+                printf("Error building pkey params in RSA sigver\n");
+                goto err;
+            }
 
-        tc->ver_disposition = FIPS_rsa_verify(rsa, tc->msg, tc->msg_len, tc_md, 
-                                              pad_mode, salt_len, NULL, tc->signature, 
-                                              tc->sig_len);
+            pkey_ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
+            if (!pkey_ctx) {
+                printf("Error initializing pkey ctx for RSA sigver\n");
+                goto err;
+            }
+            if (EVP_PKEY_fromdata_init(pkey_ctx) != 1) {
+                printf("Error initializing pkey in RSA ctx\n");
+                goto err;
+            }
+            if (EVP_PKEY_fromdata(pkey_ctx, &pkey, EVP_PKEY_KEYPAIR, pkey_params) != 1) {
+                printf("Error generating pkey in RSA context\n");
+                goto err;
+            }
+
+            //now we have the pkey, setup the digest ctx
+            sig_pbld = OSSL_PARAM_BLD_new();
+            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, "pad-mode", padding, 0);
+            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, "digest", md, 0);
+            sig_params = OSSL_PARAM_BLD_to_param(sig_pbld);
+            if (!sig_params) {
+                printf("Error building sig params in RSA sigver\n");
+                goto err;
+            }
+
+            md_ctx = EVP_MD_CTX_new();
+            if (!md_ctx) {
+                printf("Error creating MD CTX in RSA sigver\n");
+                goto err;
+            }
+            EVP_DigestVerifyInit_ex(md_ctx, NULL, md, NULL, NULL, pkey, sig_params);
+            if (EVP_DigestVerify(md_ctx, tc->signature, tc->sig_len, tc->msg, tc->msg_len) == 1) {
+                tc->ver_disposition = 1;
+            }
+        #else //if OPENSSL_VERSION_NUMBER is < 3
+            rsa = FIPS_rsa_new();
+            if (!rsa) {
+                printf("\nError: Issue with RSA obj in RSA Sig\n");
+                goto err;
+            }
+            tmp_e = BN_dup(e);
+            tmp_n = BN_dup(n);
+            RSA_set0_key(rsa, tmp_n, tmp_e, NULL);
+
+            tc->ver_disposition = FIPS_rsa_verify(rsa, tc->msg, tc->msg_len, tc_md, 
+                                                  pad_mode, salt_len, NULL, tc->signature, 
+                                                  tc->sig_len);
+        #endif
     } else {
-        if (rsa_current_tg != tc->tg_id) {
-            rsa_current_tg = tc->tg_id;
+        #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+            if (rsa_current_tg != tc->tg_id) {
+                rsa_current_tg = tc->tg_id;
 
-            /* Free the group objects before re-allocation */
-            if (group_rsa) RSA_free(group_rsa);
-            group_rsa = NULL;
-            if (group_n) BN_free(group_n);
-            group_n = NULL;
+                if (group_pkey) EVP_PKEY_free(group_pkey);
+                group_pkey = NULL;
+                if (group_n) BN_free(group_n);
+                group_n = NULL;
 
-            group_rsa = RSA_new();
+                pkey_ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
+                if (!pkey_ctx) {
+                    printf("Error initializing pkey ctx for RSA siggen\n");
+                    goto err;
+                }
+                if (EVP_PKEY_keygen_init(pkey_ctx) != 1) {
+                    printf("Error initializing pkey in RSA ctx\n");
+                    goto err;
+                }
+                EVP_PKEY_CTX_set_rsa_keygen_bits(pkey_ctx, tc->modulo);
 
-            if (!FIPS_rsa_x931_generate_key_ex(group_rsa, tc->modulo, bn_e, NULL)) {
-                printf("\nError: Issue with keygen during siggen handling\n");
+                if (EVP_PKEY_keygen(pkey_ctx, &group_pkey) != 1) {
+                    printf("Error generating pkey in RSA context\n");
+                    goto err;
+                }
+                if (EVP_PKEY_get_bn_param(group_pkey, "e", &e) != 1) {
+                    printf("Error retrieving e from generated pkey in RSA siggen\n");
+                    goto err;
+                }
+                if (EVP_PKEY_get_bn_param(group_pkey, "n", &n) != 1) {
+                    printf("Error retrieving n from generated pkey in RSA siggen\n");
+                    goto err;
+                }
+                group_n = BN_dup(n);
+            } else {
+                e = BN_dup(bn_e);
+                n = BN_dup(group_n);
+            }
+            tc->e_len = BN_bn2bin(e, tc->e);
+            tc->n_len = BN_bn2bin(n, tc->n);
+
+            sig_pbld = OSSL_PARAM_BLD_new();
+            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, "pad-mode", padding, 0);
+            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, "digest", md, 0);
+            if (tc->sig_type == ACVP_RSA_SIG_TYPE_PKCS1PSS) {
+                OSSL_PARAM_BLD_push_int(sig_pbld, "saltlen", salt_len);
+            }
+            sig_params = OSSL_PARAM_BLD_to_param(sig_pbld);
+            if (!sig_params) {
+                printf("Error building sig params in RSA siggen\n");
                 goto err;
             }
-            RSA_get0_key(group_rsa, &tmp_n1, &tmp_e1, NULL);
-            e = BN_dup(tmp_e1);
-            n = BN_dup(tmp_n1);
-            group_n = BN_dup(n);
-        } else {
-            e = BN_dup(bn_e);
-            n = BN_dup(group_n);
-        }
-        tc->e_len = BN_bn2bin(e, tc->e);
-        tc->n_len = BN_bn2bin(n, tc->n);
 
-        if (tc->msg && tc_md) {
-            siglen = RSA_size(group_rsa);
-
-            if (!FIPS_rsa_sign(group_rsa, tc->msg, tc->msg_len, tc_md, 
-                               pad_mode, salt_len, NULL,
-                               tc->signature, (unsigned int *)&siglen)) {
-                printf("\nError: RSA Signature Generation fail\n");
+            md_ctx = EVP_MD_CTX_new();
+            if (!md_ctx) {
+                printf("Error creating MD CTX in RSA sigver\n");
                 goto err;
             }
+            EVP_DigestSignInit_ex(md_ctx, NULL, md, NULL, NULL, group_pkey, sig_params);
+            if (EVP_DigestSign(md_ctx, tc->signature, (size_t *)&tc->sig_len, tc->msg, tc->msg_len) != 1) {
+                printf("Error while performing signature generation\n");
+                goto err;
+            }
+        #else  //if OPENSSL_VERSION_NUMBER is < 3
+            if (rsa_current_tg != tc->tg_id) {
+                rsa_current_tg = tc->tg_id;
 
-            tc->sig_len = siglen;
-        }
+                /* Free the group objects before re-allocation */
+                if (group_rsa) RSA_free(group_rsa);
+                group_rsa = NULL;
+                if (group_n) BN_free(group_n);
+                group_n = NULL;
+
+                group_rsa = RSA_new();
+
+                if (!FIPS_rsa_x931_generate_key_ex(group_rsa, tc->modulo, bn_e, NULL)) {
+                    printf("\nError: Issue with keygen during siggen handling\n");
+                    goto err;
+                }
+                RSA_get0_key(group_rsa, &tmp_n1, &tmp_e1, NULL);
+                e = BN_dup(tmp_e1);
+                n = BN_dup(tmp_n1);
+                group_n = BN_dup(n);
+            } else {
+                e = BN_dup(bn_e);
+                n = BN_dup(group_n);
+            }
+            tc->e_len = BN_bn2bin(e, tc->e);
+            tc->n_len = BN_bn2bin(n, tc->n);
+
+            if (tc->msg && tc_md) {
+                siglen = RSA_size(group_rsa);
+
+                if (!FIPS_rsa_sign(group_rsa, tc->msg, tc->msg_len, tc_md, 
+                                   pad_mode, salt_len, NULL,
+                                   tc->signature, (unsigned int *)&siglen)) {
+                    printf("\nError: RSA Signature Generation fail\n");
+                    goto err;
+                }
+
+                tc->sig_len = siglen;
+            }
+        #endif
     }
 
     /* Success */
     rv = 0;
 
 err:
-    if (bn_e) BN_free(bn_e);
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    if (md_ctx) EVP_MD_CTX_free(md_ctx);
+    if (pkey_ctx) EVP_PKEY_CTX_free(pkey_ctx);
+    if (pkey) EVP_PKEY_free(pkey);
+    if (pkey_pbld) OSSL_PARAM_BLD_free(pkey_pbld);
+    if (sig_pbld) OSSL_PARAM_BLD_free(sig_pbld);
+    if (pkey_params) OSSL_PARAM_free(pkey_params);
+    if (sig_params) OSSL_PARAM_free(sig_params);
+#else
     if (rsa) FIPS_rsa_free(rsa);
+#endif
+    if (bn_e) BN_free(bn_e);
     if (e) BN_free(e);
     if (n) BN_free(n);
 
     return rv;
 }
-#else
-int app_rsa_keygen_handler(ACVP_TEST_CASE *test_case) {
-    if (!test_case) {
-        return -1;
-    }
-    return 1;
-}
+
+#if 0 //todo: when could this be used? or just remove since 3.0 supports runtime.
 
 static const unsigned char sha1_bin[] = {
   0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a, 0x05,
@@ -611,9 +792,10 @@ err:
 
     return rv;
 }
-#endif // ACVP_NO_RUNTIME
+#endif
 
 int app_rsa_decprim_handler(ACVP_TEST_CASE *test_case) {
+#ifdef OPENSSL_RSA_PRIMITIVE
     BIGNUM *e = NULL, *n1 = NULL, *ct = NULL;
     const BIGNUM *n = NULL;
     ACVP_RSA_PRIM_TC    *tc;
@@ -681,13 +863,24 @@ err:
     if (n1) BN_free(n1);
     if (rsa) RSA_free(rsa);
     return rv;
+#else
+    return 1;
+#endif
 }
 
 int app_rsa_sigprim_handler(ACVP_TEST_CASE *test_case) {
     BIGNUM *e = NULL, *n = NULL, *d = NULL;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *pkey_ctx = NULL;
+    EVP_PKEY_CTX *sign_ctx = NULL;
+    OSSL_PARAM_BLD *pbld = NULL;
+    OSSL_PARAM *params = NULL;
+#else
     BIGNUM  *tmp_e = NULL, *tmp_n = NULL, *tmp_d = NULL;
-    ACVP_RSA_PRIM_TC    *tc;
     RSA *rsa = NULL;
+#endif
+    ACVP_RSA_PRIM_TC *tc;
     int rv = 1;
 
     tc = test_case->tc.rsa_prim;
@@ -702,7 +895,8 @@ int app_rsa_sigprim_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
 
-    rsa = RSA_new();
+    tc->disposition = 1;
+
     e = BN_bin2bn(tc->e, tc->e_len, NULL);
     if (!e) {
         printf("Failed to allocate BN for e\n");
@@ -719,24 +913,75 @@ int app_rsa_sigprim_handler(ACVP_TEST_CASE *test_case) {
         printf("Failed to allocate BN for d\n");
         goto err;
     }
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 
+    tc->sig_len = tc->modulo;
+
+    pbld = OSSL_PARAM_BLD_new();
+    OSSL_PARAM_BLD_push_BN(pbld, "d", d);
+    OSSL_PARAM_BLD_push_BN(pbld, "n", n);
+    OSSL_PARAM_BLD_push_BN(pbld, "e", e);
+    params = OSSL_PARAM_BLD_to_param(pbld);
+
+    pkey_ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
+    if (!pkey_ctx) {
+        printf("Error creating PKEY_CTX in RSA\n");
+        goto err;
+    }
+    if (EVP_PKEY_fromdata_init(pkey_ctx) != 1) {
+        printf("Error initializing pkey in RSA ctx\n");
+        goto err;
+    }
+    if (EVP_PKEY_fromdata(pkey_ctx, &pkey, EVP_PKEY_KEYPAIR, params) != 1) {
+        printf("Error generating pkey in RSA context\n");
+        goto err;
+    }
+    sign_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);
+    if (!sign_ctx) { 
+        printf("Error generating signing CTX from pkey in RSA\n");
+        goto err;
+    }
+
+    if (EVP_PKEY_sign_init(sign_ctx) != 1) {
+        printf("Error initializing signing function in RSA\n");
+        goto err;
+    }
+    if (EVP_PKEY_CTX_set_rsa_padding(sign_ctx, RSA_NO_PADDING) != 1) {
+        printf("Error setting padding in RSA context: %d\n", rv);
+        goto err;
+    }
+    if (EVP_PKEY_sign(sign_ctx, tc->signature, (size_t *)&tc->sig_len, tc->msg, tc->msg_len) != 1) {
+        tc->disposition = 0;
+    }
+
+#else
+    rsa = RSA_new();
     tmp_d = BN_dup(d);
     tmp_n = BN_dup(n);
     tmp_e = BN_dup(e);
     RSA_set0_key(rsa, tmp_n, tmp_e, tmp_d);
-    tc->disposition = 1;
+
     tc->sig_len = RSA_private_encrypt(tc->msg_len, tc->msg, tc->signature, rsa, RSA_NO_PADDING);
     if (tc->sig_len == -1) {
-        tc->disposition = 0;
+       tc->disposition = 0;
     }
+#endif
+
     rv = 0;
+
 err:
     if (e) BN_free(e);
     if (n) BN_free(n);
     if (d) BN_free(d);
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    if (pbld) OSSL_PARAM_BLD_free(pbld);
+    if (params) OSSL_PARAM_free(params);
+    if (sign_ctx) EVP_PKEY_CTX_free(sign_ctx);
+    if (pkey_ctx) EVP_PKEY_CTX_free(pkey_ctx);
+    if (pkey) EVP_PKEY_free(pkey);
+#else
     if (rsa) RSA_free(rsa);
+#endif
+
     return rv;
 }
-
-
-

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -1067,7 +1067,7 @@ ACVP_RESULT acvp_append_str_list(ACVP_STRING_LIST **list, const char *string) {
  */
 int acvp_lookup_str_list(ACVP_STRING_LIST **list, const char *string) {
     ACVP_STRING_LIST *tmp = NULL;
-    if (!list || *list == NULL) {
+    if (!list || *list == NULL || !string) {
         return 0;
     }
     tmp = *list;


### PR DESCRIPTION
This is a big PR for a Friday evening, so definitely feel free to let it sit :) 

RSA siggen, sigver, and sigprim now work on SSL 3.0 in runtime FIPS mode.

Some notes:
Some changes will need to be made to the registration to match the SSL cert, mainly around salt lens and PSS padding.
Will have some crashes on older 3.X versions due to https://github.com/openssl/openssl/issues/17075

There are some "still reachable" blocks in very odd places at the end of the session. I'll look at bit more into it.

Libacvp now shows mode of algorithm being tested in logs, or in failing algorithm list.
Also fixed some previously discussed calloc checks.

