### PR TITLE
RSA keyGen OpenSSL 3.0 support, library updates

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -2176,32 +2176,47 @@ static int enable_rsa(ACVP_CTX *ctx) {
     /*
      * Enable RSA keygen...
      */
-#ifdef NOT_SUPPORTED_BY_OPENSSL
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L || defined NOT_SUPPORTED_BY_OPENSSL
     rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_FIXED);
-    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_INFO_GEN_BY_SERVER, 1);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_KEY_FORMAT_CRT, 0);
     CHECK_ENABLE_CAP_RV(rv);
-
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_RANDOM);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_mode(ctx, ACVP_RSA_KEYGEN_B36);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_B36, 2048,
+                                        ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_TBLC2);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_B36, 3072,
+                                        ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_TBLC2);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_B36, 4096,
+                                        ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_TBLC2);
+    CHECK_ENABLE_CAP_RV(rv);
+#else
+    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_FIXED);
+    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_keygen_set_exponent(ctx, ACVP_RSA_PARM_FIXED_PUB_EXP_VAL, expo_str);
     CHECK_ENABLE_CAP_RV(rv);
-
     rv = acvp_cap_rsa_keygen_set_mode(ctx, ACVP_RSA_KEYGEN_B34);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_B34, 2048,
-                                        ACVP_RSA_PRIME_HASH_ALG, ACVP_SHA256);
+                                      ACVP_RSA_PRIME_HASH_ALG, ACVP_SHA256);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_B34, 3072,
                                         ACVP_RSA_PRIME_HASH_ALG, ACVP_SHA256);
     CHECK_ENABLE_CAP_RV(rv);
 #endif
+#endif
+
     /*
      * Enable siggen
      */

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -775,6 +775,13 @@ typedef enum acvp_kdf_tls13_param {
     ACVP_KDF_TLS13_RUNNING_MODE
 } ACVP_KDF_TLS13_PARM;
 
+/** @enum ACVP_RSA_TESTTYPE */
+typedef enum acvp_rsa_test_type {
+    ACVP_RSA_TESTTYPE_KAT = 1, /**< Known Answer Test */
+    ACVP_RSA_TESTTYPE_AFT,     /**< Algorithm Functional Test */
+    ACVP_RSA_TESTTYPE_GDT      /**< Generated Data Test */
+} ACVP_RSA_TESTTYPE;
+
 /** @enum ACVP_RSA_KEY_FORMAT */
 typedef enum acvp_rsa_key_format {
     ACVP_RSA_KEY_FORMAT_STANDARD = 1, /**< Standard */
@@ -1371,6 +1378,7 @@ typedef struct acvp_cmac_tc_t {
 typedef struct acvp_rsa_keygen_tc_t {
     unsigned int tc_id;    /**< Test case id */
     ACVP_HASH_ALG hash_alg;
+    ACVP_RSA_TESTTYPE test_type;
     ACVP_RSA_PRIME_TEST_TYPE prime_test;
     char *prime_result;
     char *pub_exp;
@@ -1379,8 +1387,8 @@ typedef struct acvp_rsa_keygen_tc_t {
     ACVP_RSA_PUB_EXP_MODE pub_exp_mode;
     ACVP_RSA_KEY_FORMAT key_format;
     int info_gen_by_server;
+    int test_disposition;
     unsigned int modulo;
-    int e_len;
 
     unsigned char *e;
     unsigned char *p_rand;
@@ -1410,6 +1418,7 @@ typedef struct acvp_rsa_keygen_tc_t {
     int bitlen3;
     int bitlen4;
 
+    int e_len;
     int n_len;
     int d_len;
     int p_len;

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -399,6 +399,11 @@
 #define ACVP_PREREQ_VAL_STR "valValue"
 #define ACVP_PREREQ_OBJ_STR "prereqVals"
 
+#define ACVP_TESTTYPE_STR_KAT "KAT"
+#define ACVP_TESTTYPE_STR_AFT "AFT"
+#define ACVP_TESTTYPE_STR_VOL "VOL"
+#define ACVP_TESTTYPE_STR_GDT "GDT"
+
 #define ACVP_DRBG_MODE_TDES          "TDES"
 #define ACVP_DRBG_MODE_AES_128       "AES-128"
 #define ACVP_DRBG_MODE_AES_192       "AES-192"


### PR DESCRIPTION
Improved support for handling different keygen modes (B.3.3, B.3.6) on the library end. There are probably still a few scratches in there to buff out between the different modes and whether the client or server is generating key info. Will revisit those later.

App side now supports OpenSSL 3.0 RSA keyGen, using B.3.6 testing. Thanks for all the help Barry.

