### PR TITLE
Support for SP800-56Cr2 (1.5.0)

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1831,6 +1831,8 @@ static int enable_kda(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_HKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_REVISION, ACVP_REVISION_SP800_56CR1, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_LITERAL, "0123456789ABCDEF");
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_UPARTYINFO, NULL);
@@ -1882,6 +1884,8 @@ static int enable_kda(ACVP_CTX *ctx) {
     rv = acvp_cap_kda_enable(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_HMAC, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_REVISION, ACVP_REVISION_SP800_56CR1, NULL);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_LITERAL, "0123456789ABCDEF");
     CHECK_ENABLE_CAP_RV(rv);

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -423,6 +423,7 @@ typedef enum acvp_conformance_t {
  */
 typedef enum acvp_revision_t {
     ACVP_REVISION_DEFAULT = 0,
+    ACVP_REVISION_SP800_56CR1,
     ACVP_REVISION_SP800_56AR3,
     ACVP_REVISION_MAX
 } ACVP_REVISION;
@@ -1880,6 +1881,7 @@ typedef enum acvp_kda_pattern_candidate {
     ACVP_KDA_PATTERN_ALGID,
     ACVP_KDA_PATTERN_LABEL,
     ACVP_KDA_PATTERN_L,
+    ACVP_KDA_PATTERN_T,
     ACVP_KDA_PATTERN_MAX
 } ACVP_KDA_PATTERN_CANDIDATE;
 
@@ -1902,6 +1904,7 @@ typedef enum acvp_kda_test_type {
 /** @enum ACVP_KDA_PARM */
 typedef enum acvp_kda_param {
     ACVP_KDA_PATTERN = 1,
+    ACVP_KDA_REVISION,
     ACVP_KDA_ENCODING_TYPE,
     ACVP_KDA_Z,
     ACVP_KDA_L,
@@ -1926,9 +1929,11 @@ typedef struct acvp_kda_onestep_tc_t {
     unsigned int tc_id;
     unsigned char *salt;
     unsigned char *z;
+    unsigned char *t;
     int l;
     int saltLen;
     int zLen;
+    int tLen;
     int uPartyIdLen;
     int uEphemeralLen;
     int vPartyIdLen;
@@ -1965,9 +1970,11 @@ typedef struct acvp_kda_hkdf_tc_t {
     unsigned int tc_id;
     unsigned char *salt;
     unsigned char *z;
+    unsigned char *t;
     int l;
     int saltLen;
     int zLen;
+    int tLen;
     int uPartyIdLen;
     int uEphemeralLen;
     int vPartyIdLen;

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -112,6 +112,7 @@
 #define ACVP_REV_STR_SP800_56AR3 "Sp800-56Ar3"
 #define ACVP_REV_STR_SP800_56BR2 "Sp800-56Br2"
 #define ACVP_REV_STR_SP800_56CR1 "Sp800-56Cr1"
+#define ACVP_REV_STR_SP800_56CR2 "Sp800-56Cr2"
 #define ACVP_REV_STR_RFC8446 "RFC8446"
 #define ACVP_REV_STR_RFC7627 "RFC7627"
 
@@ -210,8 +211,8 @@
 #define ACVP_REV_KAS_IFC_SSC         ACVP_REV_STR_SP800_56BR2
 
 /* KDA */
-#define ACVP_REV_KDA_ONESTEP         ACVP_REV_STR_SP800_56CR1
-#define ACVP_REV_KDA_HKDF            ACVP_REV_STR_SP800_56CR1
+#define ACVP_REV_KDA_ONESTEP         ACVP_REV_STR_SP800_56CR2
+#define ACVP_REV_KDA_HKDF            ACVP_REV_STR_SP800_56CR2
 
 /* KTS_IFC */
 #define ACVP_REV_KTS_IFC             ACVP_REV_STR_SP800_56BR2
@@ -827,12 +828,13 @@
 #define ACVP_KDA_PATTERN_ALGID_STR "algorithmId"
 #define ACVP_KDA_PATTERN_LABEL_STR "label"
 #define ACVP_KDA_PATTERN_LENGTH_STR "l"
+#define ACVP_KDA_PATTERN_T_STR "t"
 #define ACVP_KDA_PATTERN_LITERAL_STR_LEN_MAX 64 //arbitrary
 #define ACVP_KDA_PATTERN_LITERAL_BYTE_MAX (ACVP_KDA_PATTERN_LITERAL_STR_LEN_MAX >> 3)
 //arbitrary - leaving extra space in case spec adds more values later
 #define ACVP_KDA_PATTERN_REG_STR_MAX 256
 
-#define ACVP_KDA_DKM_BIT_MAX 4096 //arbitrary
+#define ACVP_KDA_DKM_BIT_MAX 8192 //arbitrary
 #define ACVP_KDA_DKM_STR_MAX (ACVP_KDA_DKM_BIT_MAX >> 2)
 #define ACVP_KDA_DKM_BYTE_MAX (ACVP_KDA_DKM_BIT_MAX >> 3)
 
@@ -1411,6 +1413,7 @@ typedef struct acvp_safe_primes_capability_t {
 
 typedef struct acvp_kda_onestep_capability_t {
     ACVP_CIPHER cipher;
+    ACVP_REVISION revision;
     ACVP_NAME_LIST *aux_functions;
     ACVP_NAME_LIST *mac_salt_methods;
     ACVP_PARAM_LIST *patterns;
@@ -1423,6 +1426,7 @@ typedef struct acvp_kda_onestep_capability_t {
 typedef struct acvp_kda_hkdf_t {
     ACVP_CIPHER cipher;
     ACVP_PARAM_LIST *patterns;
+    ACVP_REVISION revision;
     char *literal_pattern_candidate; //optional - only filled if "literal" pattern is used - hex only
     ACVP_PARAM_LIST *encodings;
     ACVP_NAME_LIST *hmac_algs;

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2898,7 +2898,9 @@ static ACVP_RESULT acvp_dispatch_vector_set(ACVP_CTX *ctx, JSON_Object *obj) {
 
     ACVP_LOG_STATUS("Processing vector set: %d", vs_id);
     ACVP_LOG_STATUS("Algorithm: %s", alg);
-
+    if (mode) {
+        ACVP_LOG_STATUS("Mode: %s", mode);
+    }
     for (i = 0; i < ACVP_ALG_MAX; i++) {
         strcmp_s(alg_tbl[i].name,
                  ACVP_ALG_NAME_MAX,

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -3425,7 +3425,11 @@ static ACVP_RESULT acvp_build_kda_onestep_register_cap(ACVP_CTX *ctx,
         goto err;
     }
     json_object_set_string(cap_obj, "mode", mode);
-    revision = acvp_lookup_cipher_revision(cap_entry->cipher);
+    if (cap_entry->cap.kda_onestep_cap->revision) {
+        revision = acvp_lookup_alt_revision_string(cap_entry->cap.kda_onestep_cap->revision);
+    } else {
+        revision = acvp_lookup_cipher_revision(cap_entry->cipher);
+    }
     if (!revision) {
         ACVP_LOG_ERR("Unable to find revision string for KDA-ONESTEP when building registration");
         rv = ACVP_INVALID_ARG;
@@ -3450,7 +3454,7 @@ static ACVP_RESULT acvp_build_kda_onestep_register_cap(ACVP_CTX *ctx,
             }
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_LITERAL_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_LITERAL_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_LITERAL_STR) - 1);
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1, "[", 1);
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       cap_entry->cap.kda_onestep_cap->literal_pattern_candidate,
@@ -3460,32 +3464,37 @@ static ACVP_RESULT acvp_build_kda_onestep_register_cap(ACVP_CTX *ctx,
         case ACVP_KDA_PATTERN_UPARTYINFO:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_UPARTYINFO_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_UPARTYINFO_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_UPARTYINFO_STR) - 1);
             break;
         case ACVP_KDA_PATTERN_VPARTYINFO:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_VPARTYINFO_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_VPARTYINFO_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_VPARTYINFO_STR) - 1);
             break;
         case ACVP_KDA_PATTERN_CONTEXT:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_CONTEXT_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_CONTEXT_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_CONTEXT_STR) - 1);
             break;
         case ACVP_KDA_PATTERN_ALGID:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_ALGID_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_ALGID_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_ALGID_STR) - 1);
             break;
         case ACVP_KDA_PATTERN_LABEL:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_LABEL_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_LABEL_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_LABEL_STR) - 1);
             break;
         case ACVP_KDA_PATTERN_L:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_LENGTH_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_LENGTH_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_LENGTH_STR) - 1);
+            break;
+        case ACVP_KDA_PATTERN_T:
+            strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
+                      ACVP_KDA_PATTERN_T_STR,
+                      sizeof(ACVP_KDA_PATTERN_T_STR) - 1);
             break;
         default:
             ACVP_LOG_ERR("Invalid pattern value in pattern list");
@@ -3580,7 +3589,11 @@ static ACVP_RESULT acvp_build_kda_hkdf_register_cap(ACVP_CTX *ctx,
         goto err;
     }
     json_object_set_string(cap_obj, "mode", mode);
-    revision = acvp_lookup_cipher_revision(cap_entry->cipher);
+    if (cap_entry->cap.kda_hkdf_cap->revision) {
+        revision = acvp_lookup_alt_revision_string(cap_entry->cap.kda_hkdf_cap->revision);
+    } else {
+        revision = acvp_lookup_cipher_revision(cap_entry->cipher);
+    }
     if (!revision) {
         ACVP_LOG_ERR("Unable to find revision string for KDA-HKDF when building registration");
         rv = ACVP_INVALID_ARG;
@@ -3605,7 +3618,7 @@ static ACVP_RESULT acvp_build_kda_hkdf_register_cap(ACVP_CTX *ctx,
             }
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_LITERAL_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_LITERAL_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_LITERAL_STR) - 1);
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1, "[", 1);
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       cap_entry->cap.kda_hkdf_cap->literal_pattern_candidate,
@@ -3615,32 +3628,37 @@ static ACVP_RESULT acvp_build_kda_hkdf_register_cap(ACVP_CTX *ctx,
         case ACVP_KDA_PATTERN_UPARTYINFO:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_UPARTYINFO_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_UPARTYINFO_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_UPARTYINFO_STR) - 1);
             break;
         case ACVP_KDA_PATTERN_VPARTYINFO:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_VPARTYINFO_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_VPARTYINFO_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_VPARTYINFO_STR) - 1);
             break;
         case ACVP_KDA_PATTERN_CONTEXT:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_CONTEXT_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_CONTEXT_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_CONTEXT_STR) - 1);
             break;
         case ACVP_KDA_PATTERN_ALGID:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_ALGID_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_ALGID_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_ALGID_STR) - 1);
             break;
         case ACVP_KDA_PATTERN_LABEL:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_LABEL_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_LABEL_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_LABEL_STR) - 1);
             break;
         case ACVP_KDA_PATTERN_L:
             strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
                       ACVP_KDA_PATTERN_LENGTH_STR,
-                      strnlen_s(ACVP_KDA_PATTERN_LENGTH_STR, 32));
+                      sizeof(ACVP_KDA_PATTERN_LENGTH_STR) - 1);
+            break;
+        case ACVP_KDA_PATTERN_T:
+            strncat_s(pattern_str, ACVP_KDA_PATTERN_REG_STR_MAX + 1,
+                      ACVP_KDA_PATTERN_T_STR,
+                      sizeof(ACVP_KDA_PATTERN_T_STR) - 1);
             break;
         default:
             ACVP_LOG_ERR("Invalid pattern value in pattern list");

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -7739,6 +7739,13 @@ ACVP_RESULT acvp_cap_kda_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KDA_PA
                 return ACVP_INVALID_ARG;
             }
             break;
+        case ACVP_KDA_REVISION:
+            if (value != ACVP_REVISION_SP800_56CR1) {
+                ACVP_LOG_ERR("Invalid revision for KDA specified.");
+                return ACVP_INVALID_ARG;
+            }
+            cap_list->cap.kda_onestep_cap->revision = value;
+            break;
         case ACVP_KDA_ENCODING_TYPE:
             if (value > ACVP_KDA_ENCODING_NONE && value < ACVP_KDA_ENCODING_MAX) {
                 plist = cap_list->cap.kda_onestep_cap->encodings;
@@ -7868,6 +7875,13 @@ ACVP_RESULT acvp_cap_kda_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KDA_PA
                 return ACVP_INVALID_ARG;
             }
             break;
+        case ACVP_KDA_REVISION:
+            if (value != ACVP_REVISION_SP800_56CR1) {
+                ACVP_LOG_ERR("Invalid revision for KDA specified.");
+                return ACVP_INVALID_ARG;
+            }
+            cap_list->cap.kda_hkdf_cap->revision = value;
+            break;
         case ACVP_KDA_ENCODING_TYPE:
             if (value > ACVP_KDA_ENCODING_NONE && value < ACVP_KDA_ENCODING_MAX) {
                 plist = cap_list->cap.kda_hkdf_cap->encodings;
@@ -7925,10 +7939,6 @@ ACVP_RESULT acvp_cap_kda_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KDA_PA
             }
             break;
         case ACVP_KDA_HKDF_HMAC_ALG:
-            if (value == ACVP_HMAC_ALG_SHA1) {
-                ACVP_LOG_ERR("SHA1 not supported in KDA HKDF");
-                return ACVP_INVALID_ARG;
-            }
             tmp = acvp_lookup_hmac_alg_str(value);
             if (!tmp) {
                 ACVP_LOG_ERR("Invalid value for hmac alg for KDA_HKDF");

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -168,7 +168,8 @@ const char *acvp_lookup_cipher_revision(ACVP_CIPHER alg) {
  * This table maintains a list of strings for revisions that can be registered as capabilities.
  */
 static struct acvp_alt_revision_info alt_revision_tbl[] = {
-    { ACVP_REVISION_SP800_56AR3, ACVP_REV_STR_SP800_56AR3 }
+    { ACVP_REVISION_SP800_56AR3, ACVP_REV_STR_SP800_56AR3 },
+    { ACVP_REVISION_SP800_56CR1, ACVP_REV_STR_SP800_56CR1 }
 };
 static int alt_revision_tbl_length =
     sizeof(alt_revision_tbl) / sizeof(struct acvp_alt_revision_info);


### PR DESCRIPTION
This adds initial support for SP800-56Cr2 to the next minor release. Support for Cr1 is still maintained provided you set that parameter.

Still in progress:

- Support for multi-expansion tests (for HKDF and twoStep)
- Support for KDA-twostep in general