### PR TITLE
Support for HKDF/Onestep KDA in 3.0

### DIFF
--- a/app/app_kda.c
+++ b/app/app_kda.c
@@ -9,23 +9,24 @@
 
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/kdf.h>
+#include <openssl/param_build.h>
+#endif
 #include "acvp/acvp.h"
 #include "app_lcl.h"
 #include "safe_lib.h"
 
-#ifdef ACVP_NO_RUNTIME
-#include "app_fips_lcl.h" /* All regular OpenSSL headers must come before here */
-#endif
-
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 int app_kda_hkdf_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KDA_HKDF_TC *stc = NULL;
-    const EVP_MD *md = NULL;
-    int rc = 1, i = 0, fixedInfoLen = 0, tmp = 0, reps = 0, resultLen = 0, resultIterator = 0;
-    unsigned int h_output_len = 0, lBits = 0;
+    int rc = 1, i = 0, tmp = 0, fixedInfoLen = 0, lBits = 0;
     unsigned char *fixedInfo = NULL;
-    unsigned char *extract_output = NULL, *expand_output = NULL;
-    unsigned char *result = NULL;
-    HMAC_CTX *hmac_ctx = NULL;
+    OSSL_PARAM_BLD *pbld = NULL;
+    OSSL_PARAM *params = NULL;
+    EVP_KDF *kdf = NULL;
+    EVP_KDF_CTX *kctx = NULL;
+    const char *md = NULL;
 
     if (!test_case) {
         printf("Missing HKDF test case\n");
@@ -37,14 +38,11 @@ int app_kda_hkdf_handler(ACVP_TEST_CASE *test_case) {
         return -1;
     }
 
-    hmac_ctx = HMAC_CTX_new();
-
-
     switch (stc->encoding) {
     case ACVP_KDA_ENCODING_CONCAT:
         //calculate the size of the buffer we need for fixed info, +4 incase L is included
         fixedInfoLen = stc->literalLen + stc->uPartyIdLen + stc->uEphemeralLen + stc->vPartyIdLen
-                     + stc->vEphemeralLen + stc->algIdLen + stc->labelLen + stc->contextLen;
+                     + stc->vEphemeralLen + stc->algIdLen + stc->labelLen + stc->contextLen + stc->tLen;
         //add 4 bytes for the int of lengths is used
         for (i = 0; i < ACVP_KDA_PATTERN_MAX; i++) {
             if (stc->fixedInfoPattern[i] == ACVP_KDA_PATTERN_L) {
@@ -121,6 +119,14 @@ int app_kda_hkdf_handler(ACVP_TEST_CASE *test_case) {
                 memcpy_s(fixedInfo + tmp, fixedInfoLen - tmp, (char *)&lBits, 4);
                 tmp += 4;
                 break;
+            case ACVP_KDA_PATTERN_T:
+                if (!stc->t) {
+                    printf("Test case missing t\n");
+                    goto end;
+                }
+                memcpy_s(fixedInfo + tmp, fixedInfoLen - tmp, stc->t, stc->tLen);
+                tmp += stc->tLen;
+                break;
             case ACVP_KDA_PATTERN_NONE:
             case ACVP_KDA_PATTERN_MAX:
             default:
@@ -136,195 +142,69 @@ int app_kda_hkdf_handler(ACVP_TEST_CASE *test_case) {
         goto end;
     }
 
-    switch (stc->hmacAlg) {
-    case ACVP_SHA224:
-        md = EVP_sha224();
-        h_output_len = 224;
-        break;
-    case ACVP_SHA256:
-        md = EVP_sha256();
-        h_output_len = 256;
-        break;
-    case ACVP_SHA384:
-        md = EVP_sha384();
-        h_output_len = 384;
-        break;
-    case ACVP_SHA512:
-        md = EVP_sha512();
-        h_output_len = 512;
-        break;
-    case ACVP_SHA512_224:
-        md = EVP_sha512_224();
-        h_output_len = 224;
-        break;
-    case ACVP_SHA512_256:
-        md = EVP_sha512_256();
-        h_output_len = 256;
-        break;
-    case ACVP_SHA3_224:
-        md = EVP_sha3_224();
-        h_output_len = 224;
-        break;
-    case ACVP_SHA3_256:
-        md = EVP_sha3_256();
-        h_output_len = 256;
-        break;
-    case ACVP_SHA3_384:
-        md = EVP_sha3_384();
-        h_output_len = 384;
-        break;
-    case ACVP_SHA3_512:
-        md = EVP_sha3_512();
-        h_output_len = 512;
-        break;
-    case ACVP_SHA1:
-    case ACVP_NO_SHA:
-    case ACVP_HASH_ALG_MAX:
-    default:
-        printf("Invalid hmac algorithm provided in test case\n");
-        goto end;
-        break;
-    }
-
-    //convert h_output_len to bytes for use with functions
-    h_output_len /= 8;
-
-    //buffer for first step, extract, output
-    extract_output = calloc(h_output_len, sizeof(unsigned char));
-    if (!extract_output) {
-        printf("Failed to allocate memory for test case\n");
+    md = get_md_string_for_hash_alg(stc->hmacAlg);
+    if (!md) {
+        printf("Invalid hmac alg in KDA-HKDF\n");
         goto end;
     }
-
-    //extract the pseudorandom key to be used in the creation of keying material in the second step
-    if (!HMAC_Init_ex(hmac_ctx, stc->salt, stc->saltLen, md, NULL)) {
-        printf("\nCrypto module error, HMAC_Init_ex failed\n");
+    kdf = EVP_KDF_fetch(NULL, "HKDF", NULL);
+    kctx = EVP_KDF_CTX_new(kdf);
+    if (!kctx) {
+        printf("Error creating KDF CTX in HKDF\n");
         goto end;
     }
-
-    if (!HMAC_Update(hmac_ctx, stc->z, stc->zLen)) {
-        printf("\nCrypto module error, HMAC_Update failed\n");
+    pbld = OSSL_PARAM_BLD_new();
+    OSSL_PARAM_BLD_push_utf8_string(pbld, "digest", md, 0);
+    OSSL_PARAM_BLD_push_octet_string(pbld, "key", stc->z, (size_t)stc->zLen);
+    OSSL_PARAM_BLD_push_octet_string(pbld, "info", fixedInfo, (size_t)fixedInfoLen);
+    OSSL_PARAM_BLD_push_octet_string(pbld, "salt", stc->salt, (size_t)stc->saltLen);
+    params = OSSL_PARAM_BLD_to_param(pbld);
+    if (!params) {
+        printf("Error generating params in HKDF\n");
         goto end;
     }
-    
-    if (!HMAC_Final(hmac_ctx, extract_output, &h_output_len)) {
-        printf("\nCrypto module error, HMAC_Final failed\n");
+    if (EVP_KDF_derive(kctx, stc->outputDkm, stc->l, params) != 1) {
+        printf("Failure deriving key material in KDA-HKDF\n");
         goto end;
     }
-
-    //the number of repetitions in step 2 (always round up)
-    //technically, this operation is defined to be done with bits, but using common denominators
-    reps = stc->l / h_output_len;
-    if (stc->l % h_output_len) {
-        reps++;
-    }
-
-    //buffer for second step, expand, output
-    expand_output = calloc(h_output_len, sizeof(unsigned char));
-    if (!expand_output) {
-        printf("Failed to allocate memory for test case\n");
-        goto end;
-    }
-
-    //the spec calls us to concatenate the previous loops result to the new one.
-    //this might be a big buffer.
-    resultLen = h_output_len * reps;
-    result = calloc(resultLen, sizeof(unsigned char));
-    if (!result) {
-        printf("Failed to allocate memory for test case\n");
-        goto end;
-    }
-
-    //hkdf as per RFC5869 calls to concatenate extract_output || fixedInfo || counter every iteration
-    for (i = 1; i <= reps; i++) {
-        unsigned int counter = i;
-        if (!check_is_little_endian()) { counter = swap_uint_endian(counter); }
-        if (i == 1) {
-            if (!HMAC_Init_ex(hmac_ctx, extract_output, h_output_len, md, NULL)) {
-                printf("\nCrypto module error, HMAC_Init_ex failed\n");
-                goto end;
-            }
-        } else {
-            if (!HMAC_Init_ex(hmac_ctx, NULL, 0, NULL, NULL)) {
-                printf("\nCrypto module error, HMAC_Init_ex failed\n");
-                goto end;
-            }
-
-            if (!HMAC_Update(hmac_ctx, expand_output, h_output_len)) {
-                printf("\nCrypto module error, HMAC_Update failed\n");
-                goto end;
-            }
-        }
-        if (!HMAC_Update(hmac_ctx, fixedInfo, fixedInfoLen)) {
-            printf("\nCrypto module error, HMAC_Update failed\n");
-            goto end;
-        }
-        if (!HMAC_Update(hmac_ctx, (unsigned char *)&counter, 1)) { //1 byte for hkdf, not 4
-            printf("\nCrypto module error, HMAC_Update failed\n");
-            goto end;
-        }
-
-        if (!HMAC_Final(hmac_ctx, expand_output, &h_output_len)) {
-            printf("\nCrypto module error, HMAC_Final failed\n");
-            goto end;
-        }
-        //concatenate to previous result
-        memcpy_s(result + resultIterator, resultLen - resultIterator, expand_output, h_output_len);
-        resultIterator += h_output_len;
-        if (resultIterator >= stc->l) {
-            break;
-        }
-    }
-    
-    memcpy_s(stc->outputDkm, stc->l, result, stc->l);
     rc = 0;
 end:
+    OSSL_PARAM_BLD_free(pbld);
+    OSSL_PARAM_free(params);
     if (fixedInfo) free(fixedInfo);
-    if (extract_output) free(extract_output);
-    if (expand_output) free(expand_output);
-    if (result) free(result);
-    if (hmac_ctx) HMAC_CTX_free(hmac_ctx);
+    if (kdf) EVP_KDF_free(kdf);
+    if (kctx) EVP_KDF_CTX_free(kctx);
     return rc;
 }
 
 
 int app_kda_onestep_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KDA_ONESTEP_TC *stc = NULL;
-    const EVP_MD *md = NULL;
-    int rc = 1, i = 0, fixedInfoLen = 0, tmp = 0, reps = 0, resultLen = 0, resultIterator = 0, isSha = 0;
-    unsigned int h_output_len = 0, lBits = 0;
+    int rc = 1, i = 0, tmp = 0, fixedInfoLen = 0, lBits = 0;
     unsigned char *fixedInfo = NULL;
-    unsigned char *h_output = NULL;
-    unsigned char *result = NULL;
-    HMAC_CTX *hmac_ctx = NULL;
-    EVP_MD_CTX *sha_ctx = NULL;
+    OSSL_PARAM_BLD *pbld = NULL;
+    OSSL_PARAM *params = NULL;
+    EVP_KDF *kdf = NULL;
+    EVP_KDF_CTX *kctx = NULL;
+    const char *md = NULL, *mac = NULL;
     ACVP_SUB_HASH hashalg;
     ACVP_SUB_HMAC hmacalg;
 
     if (!test_case) {
-        printf("Missing KDF onestep test case\n");
+        printf("Missing OneStep test case\n");
         return -1;
     }
     stc = test_case->tc.kda_onestep;
     if (!stc) {
-        printf("Missing KDF onestep test case\n");
+        printf("Missing OneStep test case\n");
         return -1;
     }
-
-    //if the test case has a salt, we are using HMAC, otherwise, SHA
-    if (stc->salt) {
-        hmac_ctx = HMAC_CTX_new();
-    } else {
-        sha_ctx = EVP_MD_CTX_create();
-        isSha = 1;
-    }
-
 
     switch (stc->encoding) {
     case ACVP_KDA_ENCODING_CONCAT:
         //calculate the size of the buffer we need for fixed info, +4 incase L is included
         fixedInfoLen = stc->literalLen + stc->uPartyIdLen + stc->uEphemeralLen + stc->vPartyIdLen
-                     + stc->vEphemeralLen + stc->algIdLen + stc->labelLen + stc->contextLen;
+                     + stc->vEphemeralLen + stc->algIdLen + stc->labelLen + stc->contextLen + stc->tLen;
         //add 4 bytes for the int of lengths is used
         for (i = 0; i < ACVP_KDA_PATTERN_MAX; i++) {
             if (stc->fixedInfoPattern[i] == ACVP_KDA_PATTERN_L) {
@@ -401,6 +281,14 @@ int app_kda_onestep_handler(ACVP_TEST_CASE *test_case) {
                 memcpy_s(fixedInfo + tmp, fixedInfoLen - tmp, (char *)&lBits, 4);
                 tmp += 4;
                 break;
+            case ACVP_KDA_PATTERN_T:
+                if (!stc->t) {
+                    printf("Test case missing t\n");
+                    goto end;
+                }
+                memcpy_s(fixedInfo + tmp, fixedInfoLen - tmp, stc->t, stc->tLen);
+                tmp += stc->tLen;
+                break;
             case ACVP_KDA_PATTERN_NONE:
             case ACVP_KDA_PATTERN_MAX:
             default:
@@ -416,214 +304,152 @@ int app_kda_onestep_handler(ACVP_TEST_CASE *test_case) {
         goto end;
     }
 
-  if (isSha) {
-    hashalg = acvp_get_hash_alg(stc->aux_function);
-    if (hashalg == 0) {
-        printf("Invalid cipher value");
-        goto end;
-    }
-
-    switch (hashalg) {
-    case ACVP_SUB_HASH_SHA2_224:
-        md = EVP_sha224();
-        h_output_len = 224;
-        break;
-    case ACVP_SUB_HASH_SHA2_256:
-        md = EVP_sha256();
-        h_output_len = 256;
-        break;
-    case ACVP_SUB_HASH_SHA2_384:
-        md = EVP_sha384();
-        h_output_len = 384;
-        break;
-    case ACVP_SUB_HASH_SHA2_512:
-        md = EVP_sha512();
-        h_output_len = 512;
-        break;
-    case ACVP_SUB_HASH_SHA2_512_224:
-        md = EVP_sha512_224();
-        h_output_len = 224;
-        break;
-    case ACVP_SUB_HASH_SHA2_512_256:
-        md = EVP_sha512_256();
-        h_output_len = 256;
-        break;
-    case ACVP_SUB_HASH_SHA3_224:
-        md = EVP_sha3_224();
-        h_output_len = 224;
-        break;
-    case ACVP_SUB_HASH_SHA3_256:
-        md = EVP_sha3_256();
-        h_output_len = 256;
-        break;
-    case ACVP_SUB_HASH_SHA3_384:
-        md = EVP_sha3_384();
-        h_output_len = 384;
-        break;
-    case ACVP_SUB_HASH_SHA3_512:
-        md = EVP_sha3_512();
-        h_output_len = 512;
-        break;
-    case ACVP_SUB_HASH_SHA1:
-    case ACVP_SUB_HASH_SHAKE_128:
-    case ACVP_SUB_HASH_SHAKE_256:
-    default:
-        printf("Invalid aux function provided in test case\n");
-        goto end;
-        break;
-    }
-
-  } else {
-    hmacalg = acvp_get_hmac_alg(stc->aux_function);
-    if (hmacalg == 0) {
-        printf("Invalid cipher value");
-        goto end;
-    }
-
-    switch (hmacalg) {
-    case ACVP_SUB_HMAC_SHA2_224:
-        md = EVP_sha224();
-        h_output_len = 224;
-        break;
-    case ACVP_SUB_HMAC_SHA2_256:
-        md = EVP_sha256();
-        h_output_len = 256;
-        break;
-    case ACVP_SUB_HMAC_SHA2_384:
-        md = EVP_sha384();
-        h_output_len = 384;
-        break;
-    case ACVP_SUB_HMAC_SHA2_512:
-        md = EVP_sha512();
-        h_output_len = 512;
-        break;
-    case ACVP_SUB_HMAC_SHA2_512_224:
-        md = EVP_sha512_224();
-        h_output_len = 224;
-        break;
-    case ACVP_SUB_HMAC_SHA2_512_256:
-        md = EVP_sha512_256();
-        h_output_len = 256;
-        break;
-    case ACVP_SUB_HMAC_SHA3_224:
-        md = EVP_sha3_224();
-        h_output_len = 224;
-        break;
-    case ACVP_SUB_HMAC_SHA3_256:
-        md = EVP_sha3_256();
-        h_output_len = 256;
-        break;
-    case ACVP_SUB_HMAC_SHA3_384:
-        md = EVP_sha3_384();
-        h_output_len = 384;
-        break;
-    case ACVP_SUB_HMAC_SHA3_512:
-        md = EVP_sha3_512();
-        h_output_len = 512;
-        break;
-    case ACVP_SUB_HMAC_SHA1:
-    default:
-        printf("Invalid aux function provided in test case\n");
-        goto end;
-        break;
-    }
-  }
-    //convert h_output_len to bytes for use with functions
-    h_output_len /= 8;
-
-    //the number of repetitions as defined by SP800-56Cr1 (always round up)
-    //technically, this operation is defined to be done with bits, but using common denominators
-    reps = stc->l * h_output_len;
-    if (stc->l % h_output_len) {
-        reps++;
-    }
-
-    //buffer for H function output
-    h_output = calloc(h_output_len, sizeof(unsigned char));
-    if (!h_output) {
-        printf("Failed to allocate memory for test case\n");
-        goto end;
-    }
-
-    //the spec calls us to concatenate the previous loops result to the new one.
-    //this might be a big buffer.
-    resultLen = h_output_len * reps;
-    result = calloc(resultLen, sizeof(unsigned char));
-    if (!result) {
-        printf("Failed to allocate memory for test case\n");
-        goto end;
-    }
-    //onestep as per NIST calls to concatenate counter || Z || FixedInfo every iteration
-    for (i = 1; i <= reps; i++) {
-        unsigned int counter = i;
-        if (check_is_little_endian()) { counter = swap_uint_endian(counter); } //nist doc specifically wants big endian byte string
-        if (isSha) {
-            if (!EVP_DigestInit_ex(sha_ctx, md, NULL)) {
-                printf("\nCrypto module error, EVP_DigestInit_ex failed\n");
-                goto end;
-            }
-
-            if (!EVP_DigestUpdate(sha_ctx, (unsigned char *)&counter, sizeof(int))) {
-                printf("\nCrypto module error, EVP_DigestUpdate failed\n");
-                goto end;
-            }
-
-            if (!EVP_DigestUpdate(sha_ctx, stc->z, stc->zLen)) {
-                printf("\nCrypto module error, EVP_DigestUpdate failed\n");
-                goto end;
-            }
-
-            if (!EVP_DigestUpdate(sha_ctx, fixedInfo, fixedInfoLen)) {
-                printf("\nCrypto module error, EVP_DigestUpdate failed\n");
-                goto end;
-            }
-
-            if (!EVP_DigestFinal(sha_ctx, h_output, &h_output_len)) {
-                printf("\nCrypto module error, EVP_DigestFinal failed\n");
-                goto end;
-            }
-        } else {
-            if (!HMAC_Init_ex(hmac_ctx, stc->salt, stc->saltLen, md, NULL)) {
-                printf("\nCrypto module error, HMAC_Init_ex failed\n");
-                goto end;
-            }
-
-            if (!HMAC_Update(hmac_ctx, (unsigned char *)&counter, sizeof(int))) {
-                printf("\nCrypto module error, HMAC_Update failed\n");
-                goto end;
-            }
-
-            if (!HMAC_Update(hmac_ctx, stc->z, stc->zLen)) {
-                printf("\nCrypto module error, HMAC_Update failed\n");
-                goto end;
-            }
-            if (!HMAC_Update(hmac_ctx, fixedInfo, fixedInfoLen)) {
-                printf("\nCrypto module error, HMAC_Update failed\n");
-                goto end;
-            }
-
-            if (!HMAC_Final(hmac_ctx, h_output, &h_output_len)) {
-                printf("\nCrypto module error, HMAC_Final failed\n");
-                goto end;
-            }
+    if (!stc->salt) {
+        hashalg = acvp_get_hash_alg(stc->aux_function);
+        if (hashalg == 0) {
+            printf("Invalid cipher value");
+            goto end;
         }
-        //concatenate to previous result
-        memcpy_s(result + resultIterator, resultLen - resultIterator, h_output, h_output_len);
-        resultIterator += h_output_len;
-
-        memzero_s(h_output, h_output_len);
-        if (resultIterator >= stc->l) {
+        switch (hashalg) {
+        case ACVP_SUB_HASH_SHA1:
+            md = "SHA-1";
             break;
+        case ACVP_SUB_HASH_SHA2_224:
+            md = "SHA2-224";
+            break;
+        case ACVP_SUB_HASH_SHA2_256:
+            md = "SHA2-256";
+            break;
+        case ACVP_SUB_HASH_SHA2_384:
+            md = "SHA2-384";
+            break;
+        case ACVP_SUB_HASH_SHA2_512:
+            md = "SHA2-512";
+            break;
+        case ACVP_SUB_HASH_SHA2_512_224:
+            md = "SHA2-512/224";
+            break;
+        case ACVP_SUB_HASH_SHA2_512_256:
+            md = "SHA2-512/256";
+            break;
+        case ACVP_SUB_HASH_SHA3_224:
+            md = "SHA3-224";
+            break;
+        case ACVP_SUB_HASH_SHA3_256:
+            md = "SHA3-256";
+            break;
+        case ACVP_SUB_HASH_SHA3_384:
+            md = "SHA3-384";
+            break;
+        case ACVP_SUB_HASH_SHA3_512:
+            md = "SHA3-512";
+            break;
+        case ACVP_SUB_HASH_SHAKE_128:
+        case ACVP_SUB_HASH_SHAKE_256:
+        default:
+            printf("Invalid aux function provided in test case\n");
+            goto end;
+        }
+    } else {
+        hmacalg = acvp_get_hmac_alg(stc->aux_function);
+        if (hmacalg == 0) {
+            printf("Invalid cipher value");
+            goto end;
+        }
+        mac = "HMAC";
+        switch (hmacalg) {
+        case ACVP_SUB_HMAC_SHA1:
+            md = "SHA-1";
+            break;
+        case ACVP_SUB_HMAC_SHA2_224:
+            md = "SHA2-224";
+            break;
+        case ACVP_SUB_HMAC_SHA2_256:
+            md = "SHA2-256";
+            break;
+        case ACVP_SUB_HMAC_SHA2_384:
+            md = "SHA2-384";
+            break;
+        case ACVP_SUB_HMAC_SHA2_512:
+            md = "SHA2-512";
+            break;
+        case ACVP_SUB_HMAC_SHA2_512_224:
+            md = "SHA2-512/224";
+            break;
+        case ACVP_SUB_HMAC_SHA2_512_256:
+            md = "SHA2-512/256";
+            break;
+        case ACVP_SUB_HMAC_SHA3_224:
+            md = "SHA3-224";
+            break;
+        case ACVP_SUB_HMAC_SHA3_256:
+            md = "SHA3-256";
+            break;
+        case ACVP_SUB_HMAC_SHA3_384:
+            md = "SHA3-384";
+            break;
+        case ACVP_SUB_HMAC_SHA3_512:
+            md = "SHA3-512";
+            break;
+        default:
+            printf("Invalid aux function provided in test case\n");
+            goto end;
         }
     }
-    
-    memcpy_s(stc->outputDkm, stc->l, result, stc->l);
+    if (!md) {
+        printf("Invalid hmac alg in KDA-OneStep\n");
+        goto end;
+    }
+
+    kdf = EVP_KDF_fetch(NULL, "SSKDF", NULL);
+    kctx = EVP_KDF_CTX_new(kdf);
+    if (!kctx) {
+        printf("Error creating KDF CTX in KDA Onestep\n");
+        goto end;
+    }
+    pbld = OSSL_PARAM_BLD_new();
+    if (stc->salt) {
+        OSSL_PARAM_BLD_push_utf8_string(pbld, "mac", mac, 0);
+        OSSL_PARAM_BLD_push_octet_string(pbld, "salt", stc->salt, (size_t)stc->saltLen);
+    }
+    OSSL_PARAM_BLD_push_utf8_string(pbld, "digest", md, 0);
+    OSSL_PARAM_BLD_push_octet_string(pbld, "key", stc->z, (size_t)stc->zLen);
+    OSSL_PARAM_BLD_push_octet_string(pbld, "info", fixedInfo, (size_t)fixedInfoLen);
+    params = OSSL_PARAM_BLD_to_param(pbld);
+    if (!params) {
+        printf("Error generating params in KDA Onestep\n");
+        goto end;
+    }
+    if (EVP_KDF_derive(kctx, stc->outputDkm, stc->l, params) != 1) {
+        printf("Failure deriving key material in KDA-OneStep\n");
+        goto end;
+    }
     rc = 0;
 end:
+    OSSL_PARAM_BLD_free(pbld);
+    OSSL_PARAM_free(params);
     if (fixedInfo) free(fixedInfo);
-    if (h_output) free(h_output);
-    if (result) free(result);
-    if (hmac_ctx) HMAC_CTX_free(hmac_ctx);
-    if (sha_ctx) EVP_MD_CTX_destroy(sha_ctx);
+    if (kdf) EVP_KDF_free(kdf);
+    if (kctx) EVP_KDF_CTX_free(kctx);
     return rc;
 }
+
+#else //SSL < 3.0
+
+int app_kda_hkdf_handler(ACVP_TEST_CASE *test_case) {
+    if (!test_case) {
+        return -1;
+    }
+    printf("No application support\n");
+    return 1;
+}
+
+int app_kda_onestep_handler(ACVP_TEST_CASE *test_case) {
+    if (!test_case) {
+        return -1;
+    }
+    printf("No application support\n");
+    return 1;
+}
+
+#endif

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1882,6 +1882,22 @@ static int enable_kda(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_HKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_ALGID, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_T, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_L, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_UPARTYINFO, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_VPARTYINFO, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_HKDF_HMAC_ALG, ACVP_HMAC_ALG_SHA1, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_domain(ctx, ACVP_KDA_HKDF, ACVP_KDA_Z, 224, 8192, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+#else
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_REVISION, ACVP_REVISION_SP800_56CR1, NULL);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_LITERAL, "0123456789ABCDEF");
@@ -1898,6 +1914,9 @@ static int enable_kda(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_L, NULL);
     CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_domain(ctx, ACVP_KDA_HKDF, ACVP_KDA_Z, 224, 1024, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+#endif
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_ENCODING_TYPE, ACVP_KDA_ENCODING_CONCAT, NULL);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_HKDF_HMAC_ALG, ACVP_HMAC_ALG_SHA224, NULL);
@@ -1926,14 +1945,34 @@ static int enable_kda(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_L, 2048, NULL);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_kda_set_domain(ctx, ACVP_KDA_HKDF, ACVP_KDA_Z, 224, 1024, 8);
-    CHECK_ENABLE_CAP_RV(rv);
 
     // kdf onestep
     rv = acvp_cap_kda_enable(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_ALGID, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_L, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_UPARTYINFO, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_T, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_VPARTYINFO, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA512, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA2_224, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+#if 0 /* Not yet implemented */
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_KMAC_128, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
+#endif
+    rv = acvp_cap_kda_set_domain(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_Z, 224, 8192, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+#else
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_REVISION, ACVP_REVISION_SP800_56CR1, NULL);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_LITERAL, "0123456789ABCDEF");
@@ -1949,8 +1988,6 @@ static int enable_kda(ACVP_CTX *ctx) {
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_LABEL, NULL);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_L, NULL);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ENCODING_TYPE, ACVP_KDA_ENCODING_CONCAT, NULL);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA224, NULL);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1992,13 +2029,16 @@ static int enable_kda(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA3_512, NULL);
     CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kda_set_domain(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_Z, 224, 1024, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+#endif
+    rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ENCODING_TYPE, ACVP_KDA_ENCODING_CONCAT, NULL);
+    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_MAC_SALT, ACVP_KDA_MAC_SALT_METHOD_DEFAULT, NULL);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_MAC_SALT, ACVP_KDA_MAC_SALT_METHOD_RANDOM, NULL);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_L, 2048, NULL);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_kda_set_domain(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_Z, 224, 1024, 8);
     CHECK_ENABLE_CAP_RV(rv);
 end:
    return rv;


### PR DESCRIPTION
The fixed info still has to all be combined in advance before the API can consume it. This seems fine. 

