### PR TITLE
Cleanup acvp_capabilities list code (1.5.0)

### DIFF
--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1904,6 +1904,9 @@ ACVP_RESULT acvp_kv_list_append(ACVP_KV_LIST **kv_list,
 void acvp_kv_list_free(ACVP_KV_LIST *kv_list);
 
 void acvp_free_str_list(ACVP_STRING_LIST **list);
+ACVP_RESULT acvp_append_param_list(ACVP_PARAM_LIST **list, int param);
+ACVP_RESULT acvp_append_name_list(ACVP_NAME_LIST **list, const char *string);
+int acvp_is_in_name_list(ACVP_NAME_LIST *list, const char *string);
 ACVP_RESULT acvp_append_str_list(ACVP_STRING_LIST **list, const char *string);
 int acvp_lookup_str_list(ACVP_STRING_LIST **list, const char *string);
 int acvp_lookup_param_list(ACVP_PARAM_LIST *list, int value);


### PR DESCRIPTION
As I was adding twostep code (waiting to get some info back), it was clear that code related to iterating through PARAM_LISTs and NAME_LISTs was getting pretty messy. This was being done on a case-by-case basis in acvp_capabilities.c. This adds iterator functions to acvp_utils, and cleans up all those calls in acvp_capabilities, saving us a few hundred lines of code. 