### PR TITLE
DRBG support on 3.0

### DIFF
--- a/app/app_drbg.c
+++ b/app/app_drbg.c
@@ -11,334 +11,174 @@
 
 #include <stdlib.h>
 #include <openssl/rand.h>
-#include <openssl/err.h>
 #include "app_fips_lcl.h" /* All regular OpenSSL headers must come before here */
 #include "app_lcl.h"
 #include "safe_mem_lib.h"
-#ifdef ACVP_NO_RUNTIME
 
-typedef struct {
-    unsigned char *ent;
-    size_t entlen;
-    unsigned char *nonce;
-    size_t noncelen;
-} DRBG_TEST_ENT;
-
-static size_t drbg_test_entropy(DRBG_CTX *dctx,
-                                unsigned char **pout,
-                                int entropy,
-                                size_t min_len,
-                                size_t max_len) {
-    if (!dctx || !pout || !entropy) return 0;
-
-    DRBG_TEST_ENT *t = (DRBG_TEST_ENT *)FIPS_drbg_get_app_data(dctx);
-    if (!t) return 0;
-
-    if (t->entlen < min_len) printf("entropy data len %zu < min_len: %zu\n", t->entlen, min_len);
-    if (t->entlen > max_len) printf("entropy data len %zu > max_len: %zu\n", t->entlen, max_len);
-    *pout = (unsigned char *)t->ent;
-    return t->entlen;
-}
-
-static size_t drbg_test_nonce(DRBG_CTX *dctx,
-                              unsigned char **pout,
-                              int entropy,
-                              size_t min_len,
-                              size_t max_len) {
-    if (!dctx || !pout || !entropy) return 0;
-
-    DRBG_TEST_ENT *t = (DRBG_TEST_ENT *)FIPS_drbg_get_app_data(dctx);
-
-    if (t->noncelen < min_len) printf("nonce data len %zu < min_len: %zu\n", t->noncelen, min_len);
-    if (t->noncelen > max_len) printf("nonce data len %zu > max_len: %zu\n", t->noncelen, max_len);
-    *pout = (unsigned char *)t->nonce;
-    return t->noncelen;
-}
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 
 int app_drbg_handler(ACVP_TEST_CASE *test_case) {
-    int result = 1;
-    ACVP_DRBG_TC    *tc;
-    unsigned int nid;
-    int der_func = 0;
-    unsigned int drbg_entropy_len;
-    int fips_rc;
+    int rv = 1;
+    ACVP_DRBG_TC *tc;
     ACVP_SUB_DRBG alg;
-
-    unsigned char   *nonce = NULL;
+    EVP_RAND *rand = NULL;
+    EVP_RAND_CTX *rctx = NULL, *test = NULL;
+    OSSL_PARAM params[10] = { 0 };
+    const char *alg_name = NULL, *alg_str = NULL, *param_str = NULL;
+    char *tmp = NULL;
+    unsigned int strength = 512;
 
     if (!test_case) {
-        return result;
+        return rv;
     }
 
     tc = test_case->tc.drbg;
-    /*
-     * Init entropy length
-     */
-    drbg_entropy_len = tc->entropy_len;
 
     alg = acvp_get_drbg_alg(tc->cipher);
-    if (alg == 0) {
-        printf("Invalid cipher value\n");
-        return 1;
-    }
 
     switch (alg) {
     case ACVP_SUB_DRBG_HASH:
-        nonce = tc->nonce;
-        switch (tc->mode) {
-        case ACVP_DRBG_SHA_1:
-            nid = NID_sha1;
-            break;
-        case ACVP_DRBG_SHA_224:
-            nid = NID_sha224;
-            break;
-        case ACVP_DRBG_SHA_256:
-            nid = NID_sha256;
-            break;
-        case ACVP_DRBG_SHA_384:
-            nid = NID_sha384;
-            break;
-        case ACVP_DRBG_SHA_512:
-            nid = NID_sha512;
-            break;
-        case ACVP_DRBG_SHA_512_224:
-            nid = NID_sha512_224;
-            break;
-        case ACVP_DRBG_SHA_512_256:
-            nid = NID_sha512_256;
-            break;
-        case ACVP_DRBG_TDES:
-        case ACVP_DRBG_AES_128:
-        case ACVP_DRBG_AES_192:
-        case ACVP_DRBG_AES_256:
-        default:
-            printf("%s: Unsupported algorithm/mode %d/%d (tc_id=%d)\n", __FUNCTION__, tc->tc_id,
-                   tc->cipher, tc->mode);
-            return result;
-
-            break;
-        }
+        alg_name = "HASH-DRBG";
+        param_str = "digest";
         break;
-
     case ACVP_SUB_DRBG_HMAC:
-        nonce = tc->nonce;
-        switch (tc->mode) {
-        case ACVP_DRBG_SHA_1:
-            nid =   NID_hmacWithSHA1;
-            break;
-        case ACVP_DRBG_SHA_224:
-            nid =   NID_hmacWithSHA224;
-            break;
-        case ACVP_DRBG_SHA_256:
-            nid =   NID_hmacWithSHA256;
-            break;
-        case ACVP_DRBG_SHA_384:
-            nid =   NID_hmacWithSHA384;
-            break;
-        case ACVP_DRBG_SHA_512:
-            nid =   NID_hmacWithSHA512;
-            break;
-        case ACVP_DRBG_SHA_512_224:
-            nid =   NID_hmacWithSHA512_224;
-            break;
-        case ACVP_DRBG_SHA_512_256:
-            nid =   NID_hmacWithSHA512_256;
-            break;
-        case ACVP_DRBG_TDES:
-        case ACVP_DRBG_AES_128:
-        case ACVP_DRBG_AES_192:
-        case ACVP_DRBG_AES_256:
-        default:
-            printf("%s: Unsupported algorithm/mode %d/%d (tc_id=%d)\n", __FUNCTION__, tc->tc_id,
-                   tc->cipher, tc->mode);
-            return result;
-
-            break;
-        }
+        alg_name = "HMAC-DRBG";
+        param_str = "digest";
         break;
-
     case ACVP_SUB_DRBG_CTR:
-        /*
-         * DR function Only valid in CTR mode
-         * if not set nonce is ignored
-         */
-        if (tc->der_func_enabled) {
-            der_func = DRBG_FLAG_CTR_USE_DF;
-            nonce = tc->nonce;
-        } else {
-            /**
-             * Note 5: All DRBGs are tested at their maximum supported security
-             * strength so this is the minimum bit length of the entropy input that
-             * ACVP will accept.  The maximum supported security strength is also
-             * the default value for this input.  Longer entropy inputs are
-             * permitted, with the following exception: for ctrDRBG with no df, the
-             * bit length must equal the seed length.
-             *
-             * This will be enforced at registration time by the server. Also, with
-             * this mode, no nonce is used.
-             **/
-        }
-
-        switch (tc->mode) {
-        case ACVP_DRBG_AES_128:
-            nid = NID_aes_128_ctr;
-            break;
-        case ACVP_DRBG_AES_192:
-            nid = NID_aes_192_ctr;
-            break;
-        case ACVP_DRBG_AES_256:
-            nid = NID_aes_256_ctr;
-            break;
-        case ACVP_DRBG_TDES:
-        case ACVP_DRBG_SHA_1:
-        case ACVP_DRBG_SHA_224:
-        case ACVP_DRBG_SHA_256:
-        case ACVP_DRBG_SHA_384:
-        case ACVP_DRBG_SHA_512:
-        case ACVP_DRBG_SHA_512_224:
-        case ACVP_DRBG_SHA_512_256:
-        default:
-            printf("%s: Unsupported algorithm/mode %d/%d (tc_id=%d)\n", __FUNCTION__, tc->tc_id,
-                   tc->cipher, tc->mode);
-            return result;
-
-            break;
-        }
+        alg_name = "CTR-DRBG";
+        param_str = "cipher";
         break;
     default:
-        printf("%s: Unsupported algorithm %d (tc_id=%d)\n", __FUNCTION__, tc->tc_id,
-               tc->cipher);
-        return result;
+        printf("Invalid DRBG cipher value\n");
+        goto err;
+    }
 
+    switch (tc->mode) {
+    case ACVP_DRBG_SHA_1:
+        alg_str = "SHA-1";
         break;
+    case ACVP_DRBG_SHA_224:
+        alg_str = "SHA2-224";
+        break;
+    case ACVP_DRBG_SHA_256:
+        alg_str = "SHA2-256";
+        break;
+    case ACVP_DRBG_SHA_384:
+        alg_str = "SHA2-384";
+        break;
+    case ACVP_DRBG_SHA_512:
+        alg_str = "SHA2-512";
+        break;
+    case ACVP_DRBG_SHA_512_224:
+        alg_str = "SHA2-512/224";
+        break;
+    case ACVP_DRBG_SHA_512_256:
+        alg_str = "SHA2-512/256";
+        break;
+    case ACVP_DRBG_AES_128:
+        alg_str = "AES-128-CTR";
+        break;
+    case ACVP_DRBG_AES_192:
+        alg_str = "AES-192-CTR";
+        break;
+    case ACVP_DRBG_AES_256:
+        alg_str = "AES-256-CTR";
+        break;
+    case ACVP_DRBG_TDES:
+    default:
+        printf("Invalid mode given for DRBG\n");
+        goto err;
     }
 
-    if (!tc->pred_resist_enabled && tc->reseed && !tc->entropy_input_pr_0) {
-        printf("Missing entropy input needed for reseed\n");
-        return 1;
-    }
-    if (!drbg_entropy_len || !tc->pr1_len || !tc->pr2_len ||
-        !tc->entropy || !tc->entropy_input_pr_1 || !tc->entropy_input_pr_2) {
-        printf("Insufficient entropy for testing DRBG\n");
-        return 1;
-    }
-    if (!tc->drb) {
-        printf("Invalid output buffer for DRBG test\n");
-        return 1;
-    }
-    if (!tc->perso_string) {
-        printf("Missing persoString for DRBG test\n");
-        return 1;
+    tmp = remove_str_const(alg_str);
+    if (!tmp) {
+        printf ("Unexpected error copying string in DRBG\n");
+        goto err;
     }
 
-    DRBG_CTX *drbg_ctx = NULL;
-    DRBG_TEST_ENT entropy_nonce;
-    memzero_s(&entropy_nonce, sizeof(DRBG_TEST_ENT));
-    drbg_ctx = FIPS_drbg_new(nid, der_func | DRBG_FLAG_TEST);
-    if (!drbg_ctx) {
-        printf("ERROR: failed to create DRBG Context.\n");
-        return result;
+    /* NOTE ABOUT DRBG in 3.X:
+    * TEST-RAND is an "unapproved" algorithm that exists inside the FIPS module. It cannot be used with
+    * the property "fips=yes", which we use in the default library context. It has to be used with
+    * fips=no in order to run it. Do NOT run this outside of the context of testing in any situation.
+    */
+    rand = EVP_RAND_fetch(NULL, "TEST-RAND", "fips=no");
+
+    test = EVP_RAND_CTX_new(rand, NULL);
+    if (rand) EVP_RAND_free(rand);
+    if (!test) {
+        printf("Error creating test CTX in DRBG\n");
+        goto err;
     }
 
-    /*
-     * Set entropy and nonce
-     */
-    entropy_nonce.ent = tc->entropy;
-    entropy_nonce.entlen = drbg_entropy_len;
-
-    entropy_nonce.nonce = nonce;
-    entropy_nonce.noncelen = tc->nonce_len;
-
-    FIPS_drbg_set_app_data(drbg_ctx, &entropy_nonce);
-
-    fips_rc = FIPS_drbg_set_callbacks(drbg_ctx,
-                                      drbg_test_entropy,
-                                      0, 0,
-                                      drbg_test_nonce,
-                                      0);
-    if (!fips_rc) {
-        printf("ERROR: failed to Set callback DRBG ctx\n");
-        long l = 9;
-        char buf[2048]  = { 0 };
-        while ((l = ERR_get_error())) {
-            printf("ERROR:%s\n", ERR_error_string(l, buf));
-        }
-        goto end;
+    params[0] = OSSL_PARAM_construct_uint("strength", &strength);
+    params[1] = OSSL_PARAM_construct_end();
+    params[2] = OSSL_PARAM_construct_end(); //for hmac
+    if (EVP_RAND_CTX_set_params(test, params) != 1) {
+        printf("Error setting test ctx params in DRBG\n");
+        goto err;
     }
 
-    fips_rc = FIPS_drbg_instantiate(drbg_ctx, (const unsigned char *)tc->perso_string,
-                                    (size_t)tc->perso_string_len);
-    if (!fips_rc) {
-        printf("ERROR: failed to instantiate DRBG ctx\n");
-        long l = 9;
-        char buf[2048]  = { 0 };
-        while ((l = ERR_get_error())) {
-            printf("ERROR:%s\n", ERR_error_string(l, buf));
-        }
-        goto end;
+    rand = EVP_RAND_fetch(NULL, alg_name, NULL);
+    rctx = EVP_RAND_CTX_new(rand, test);
+    if (!rctx) {
+        printf("Error creating DRBG ctx\n");
+        goto err;
+    }
+    strength = EVP_RAND_get_strength(rctx);
+
+    params[0] = OSSL_PARAM_construct_utf8_string(param_str, tmp, 0);
+    params[1] = OSSL_PARAM_construct_utf8_string("mac", "HMAC", 0); //ignored if irrelevant
+    if (EVP_RAND_CTX_set_params(rctx, params) != 1) {
+        printf("Error setting algorithm for DRBG\n");
+        goto err;
     }
 
-    /*
-     * Process predictive resistance flag
-     */
-    if (!tc->pred_resist_enabled && tc->reseed) {
-
-        entropy_nonce.ent = tc->entropy_input_pr_0;
-        entropy_nonce.entlen = drbg_entropy_len;
-
-        fips_rc =  FIPS_drbg_reseed(drbg_ctx, (const unsigned char *)tc->additional_input_0,
-                                      (size_t)(tc->additional_input_len));
-        if (!fips_rc) {
-            printf("ERROR: failed to generate drbg reseed\n");
-            long l;
-            while ((l = ERR_get_error())) {
-                printf("ERROR:%s\n", ERR_error_string(l, NULL));
-            }
-            goto end;
-        }
+    params[0] = OSSL_PARAM_construct_octet_string("test_entropy", tc->entropy, tc->entropy_len);
+    params[1] = OSSL_PARAM_construct_octet_string("test_nonce", tc->nonce, tc->nonce_len);
+    if (EVP_RAND_CTX_set_params(test, params) != 1) {
+        printf("Error setting initial entropy/nonce for DRBG\n");
+        goto err;
+    }
+    if (EVP_RAND_instantiate(rctx, strength, tc->pred_resist_enabled, tc->perso_string,
+                              tc->perso_string_len, NULL) != 1) {
+        printf("Error performing RAND instantiate\n");
+        goto err;
     }
 
-    entropy_nonce.ent = tc->entropy_input_pr_1;
-    entropy_nonce.entlen = tc->pr1_len;
-
-    fips_rc =  FIPS_drbg_generate(drbg_ctx, (unsigned char *)tc->drb,
-                                  (size_t)(tc->drb_len),
-                                  (int)tc->pred_resist_enabled,
-                                  (const unsigned char *)tc->additional_input_1,
-                                  (size_t)(tc->additional_input_len));
-    if (!fips_rc) {
-        printf("ERROR: failed to generate drbg gen1\n");
-        long l;
-        while ((l = ERR_get_error())) {
-            printf("ERROR:%s\n", ERR_error_string(l, NULL));
-        }
-        goto end;
+    params[0] = OSSL_PARAM_construct_octet_string("test_entropy", tc->entropy_input_pr_1, tc->entropy_len);
+    if (EVP_RAND_CTX_set_params(test, params) != 1) {
+        printf("Error setting params for DRBG (1)\n");
+        goto err;
     }
 
-    entropy_nonce.ent = tc->entropy_input_pr_2;
-    entropy_nonce.entlen = tc->pr2_len;
+    if (EVP_RAND_generate(rctx, tc->drb, tc->drb_len, strength,
+                           tc->pred_resist_enabled,
+                           tc->additional_input_1, tc->additional_input_len) != 1) {
+        printf("Error performing rand generate (1)\n");
+        goto err;
+     }
 
-    fips_rc =  FIPS_drbg_generate(drbg_ctx, (unsigned char *)tc->drb,
-                                  (size_t)(tc->drb_len),
-                                  (int)tc->pred_resist_enabled,
-                                  (const unsigned char *)tc->additional_input_2,
-                                  (size_t)(tc->additional_input_len));
-    if (!fips_rc) {
-        printf("ERROR: failed to generate drbg gen2\n");
-        long l;
-        while ((l = ERR_get_error())) {
-            printf("ERROR:%s\n", ERR_error_string(l, NULL));
-        }
-        goto end;
+    params[0] = OSSL_PARAM_construct_octet_string("test_entropy", tc->entropy_input_pr_2, tc->entropy_len);
+    if (EVP_RAND_CTX_set_params(test, params) != 1) {
+        printf("Error setting params for DRBG (2)\n");
+        goto err;
     }
 
-    result = 0;
+    if (EVP_RAND_generate(rctx, tc->drb, tc->drb_len, strength,
+                           tc->pred_resist_enabled,
+                           tc->additional_input_2, tc->additional_input_len) != 1) {
+        printf("Error performing rand generate (2)\n");
+        goto err;
+     }
 
-end:
-    FIPS_drbg_uninstantiate(drbg_ctx);
-    FIPS_drbg_free(drbg_ctx);
-
-    return result;
+    rv = 0;
+err:
+    if (test) EVP_RAND_CTX_free(test);
+    if (rctx) EVP_RAND_CTX_free(rctx);
+    if (rand) EVP_RAND_free(rand);
+    if (tmp) free (tmp);
+    return rv;
 }
 #else
 int app_drbg_handler(ACVP_TEST_CASE *test_case) {
@@ -348,5 +188,5 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
     return 1;
 }
 
-#endif // ACVP_NO_RUNTIME
+#endif
 

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -2914,598 +2914,228 @@ end:
 static int enable_drbg(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    /*
-     * Register DRBG
-     */
+    /* Register DRBG */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
     //ACVP_HASHDRBG
     rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_set_prereq(ctx, ACVP_HASHDRBG,
-                                  ACVP_PREREQ_SHA, value);
+    rv = acvp_cap_set_prereq(ctx, ACVP_HASHDRBG, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_RESEED_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_ENTROPY_LEN, 128, 64, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_NONCE_LEN, 96, 32, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_PERSO_LEN, 0, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_RET_BITS_LEN, 160);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_RESEED_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_ENTROPY_LEN, 192, 64, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_PERSO_LEN, 0, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_RET_BITS_LEN, 224);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_RESEED_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_ENTROPY_LEN, 256, 64, 320);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_PERSO_LEN, 0, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_RET_BITS_LEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)128, (int)64, (int)256);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_RESEED_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_ENTROPY_LEN, 256, 64, 320);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_PERSO_LEN, 0, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_RET_BITS_LEN, 384);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1,
-                                  ACVP_DRBG_NONCE_LEN, (int)96, (int)32, (int)128);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_RESEED_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_ENTROPY_LEN, 256, 64, 320);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1,
-                                ACVP_DRBG_RET_BITS_LEN, 160);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_PERSO_LEN, 0, 128, 256);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_RET_BITS_LEN, 512);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)192, (int)64, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224,
-                                  ACVP_DRBG_NONCE_LEN, (int)128, (int)32, (int)160);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_224,
-                                ACVP_DRBG_RET_BITS_LEN, 224);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)256, (int)64, (int)320);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256,
-                                  ACVP_DRBG_NONCE_LEN, (int)128, (int)32, (int)160);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256,
-                                ACVP_DRBG_RET_BITS_LEN, 256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)256, (int)64, (int)320);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384,
-                                  ACVP_DRBG_NONCE_LEN, (int)128, (int)32, (int)160);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_384,
-                                ACVP_DRBG_RET_BITS_LEN, 384);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)256, (int)64, (int)320);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512,
-                                  ACVP_DRBG_NONCE_LEN, (int)128, (int)32, (int)160);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512,
-                                ACVP_DRBG_RET_BITS_LEN, 512);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    /* set same params for hashDRBG with SHA_512_224 and SHA_512_256 */
-    #if 0
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_224,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_224,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_224,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_224,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)192, (int)64, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_224,
-                                  ACVP_DRBG_NONCE_LEN, (int)128, (int)32, (int)160);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_224,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_224,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_224,
-                                ACVP_DRBG_RET_BITS_LEN, 224);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_256,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_256,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_256,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_256,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)256, (int)64, (int)320);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_256,
-                                  ACVP_DRBG_NONCE_LEN, (int)128, (int)32, (int)160);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_256,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_256,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512_256,
-                                ACVP_DRBG_RET_BITS_LEN, 256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    #endif
 
     //ACVP_HMACDRBG
     rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, 
-                                  ACVP_PREREQ_SHA, value);
+    rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, 
-                                  ACVP_PREREQ_HMAC, value);
+    rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG,ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_RESEED_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_RET_BITS_LEN, 160);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1,
-                                ACVP_DRBG_RET_BITS_LEN, 160);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_ENTROPY_LEN, 160, 32, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_NONCE_LEN, 0, 0, 64);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_PERSO_LEN, 0, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    //Add length range
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)160, (int)32, (int)256);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_RESEED_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_RET_BITS_LEN, 224);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_ENTROPY_LEN, 192, 64, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_NONCE_LEN, 0, 0, 96);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_PERSO_LEN, 0, 64, 192);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, ACVP_DRBG_ADD_IN_LEN, 0, 0, 192);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1,
-                                  ACVP_DRBG_NONCE_LEN, (int)0, (int)0, (int)64);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_RESEED_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_RET_BITS_LEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_ENTROPY_LEN, 256, 64, 512);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_NONCE_LEN, 0, 0, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_PERSO_LEN, 0, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_RESEED_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_RET_BITS_LEN, 384);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_ENTROPY_LEN, 384, 64, 512);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_NONCE_LEN, 0, 0, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_PERSO_LEN, 0, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_RESEED_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_RET_BITS_LEN, 512);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_ENTROPY_LEN, 512, 64, 1024);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224,
-                                ACVP_DRBG_RET_BITS_LEN, 224);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_NONCE_LEN, 0, 0, 128);
     CHECK_ENABLE_CAP_RV(rv);
-
-    //Add length range
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)192, (int)64, (int)256);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_PERSO_LEN, 0, 128, 256);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224,
-                                  ACVP_DRBG_NONCE_LEN, (int)0, (int)0, (int)96);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)64, (int)192);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)0, (int)192);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256,
-                                ACVP_DRBG_RET_BITS_LEN, 256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    //Add length range
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)256, (int)64, (int)512);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256,
-                                  ACVP_DRBG_NONCE_LEN, (int)0, (int)0, (int)128);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384,
-                                ACVP_DRBG_RET_BITS_LEN, 384);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    //Add length range
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)384, (int)64, (int)512);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384,
-                                  ACVP_DRBG_NONCE_LEN, (int)0, (int)0, (int)128);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_384,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512,
-                                ACVP_DRBG_RET_BITS_LEN, 512);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    //Add length range
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)512, (int)64, (int)1024);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512,
-                                  ACVP_DRBG_NONCE_LEN, (int)0, (int)0, (int)128);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    /* set same params for hmacDRBG with SHA_512_224 and SHA_512_256 */
-    #if 0
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_224,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_224,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_224,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_224,
-                                ACVP_DRBG_RET_BITS_LEN, 224);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    //Add length range
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_224,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)192, (int)64, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_224,
-                                  ACVP_DRBG_NONCE_LEN, (int)0, (int)0, (int)128);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_224,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_224,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_256,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_256,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_256,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_256,
-                                ACVP_DRBG_RET_BITS_LEN, 256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    //Add length range
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_256,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)256, (int)64, (int)512);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_256,
-                                  ACVP_DRBG_NONCE_LEN, (int)0, (int)0, (int)128);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_256,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512_256,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)128, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-    #endif
 
     // ACVP_CTRDRBG
     rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_set_prereq(ctx, ACVP_CTRDRBG, 
-                                  ACVP_PREREQ_AES, value);
+    rv = acvp_cap_set_prereq(ctx, ACVP_CTRDRBG, ACVP_PREREQ_AES, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, ACVP_DRBG_DER_FUNC_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, ACVP_DRBG_RESEED_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, ACVP_DRBG_RET_BITS_LEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, ACVP_DRBG_ENTROPY_LEN, 128, 128, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, ACVP_DRBG_NONCE_LEN, 0, 0, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, ACVP_DRBG_PERSO_LEN, 0, 256, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, ACVP_DRBG_ADD_IN_LEN, 0, 256, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, ACVP_DRBG_DER_FUNC_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, ACVP_DRBG_RESEED_ENABLED, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, ACVP_DRBG_RET_BITS_LEN, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, ACVP_DRBG_ENTROPY_LEN, 256, 128, 512);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, ACVP_DRBG_NONCE_LEN, 0, 0, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, ACVP_DRBG_PERSO_LEN, 0, 256, 256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, ACVP_DRBG_ADD_IN_LEN, 0, 256, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, ACVP_DRBG_DER_FUNC_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128,
-                                ACVP_DRBG_RET_BITS_LEN, 256);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, ACVP_DRBG_RESEED_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
-
-    //Add length range
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)128, (int)128, (int)256);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, ACVP_DRBG_RET_BITS_LEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128,
-                                  ACVP_DRBG_NONCE_LEN, (int)0, (int)0, (int)128);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, ACVP_DRBG_ENTROPY_LEN, 256, 128, 512);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)256, (int)256);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, ACVP_DRBG_NONCE_LEN, 0, 0, 128);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)256, (int)256);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, ACVP_DRBG_PERSO_LEN, 0, 256, 256);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 1);
+    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, ACVP_DRBG_ADD_IN_LEN, 0, 256, 256);
     CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192,
-                                ACVP_DRBG_RET_BITS_LEN, 256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    //Add length range
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)256, (int)128, (int)512);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192,
-                                  ACVP_DRBG_NONCE_LEN, (int)0, (int)0, (int)128);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)256, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)256, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256,
-                                ACVP_DRBG_DER_FUNC_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256,
-                                ACVP_DRBG_PRED_RESIST_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256,
-                                ACVP_DRBG_RESEED_ENABLED, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256,
-                                ACVP_DRBG_RET_BITS_LEN, 256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    //Add length range
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256,
-                                  ACVP_DRBG_ENTROPY_LEN, (int)256, (int)128, (int)512);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256,
-                                  ACVP_DRBG_NONCE_LEN, (int)0, (int)0, (int)128);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256,
-                                  ACVP_DRBG_PERSO_LEN, (int)0, (int)256, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256,
-                                  ACVP_DRBG_ADD_IN_LEN, (int)0, (int)256, (int)256);
-    CHECK_ENABLE_CAP_RV(rv);
-
+#endif
 end:
 
     return rv;


### PR DESCRIPTION
Works with most of the registration of OpenSSL 3.0. Todo: library adjustments to be able to test counter DRBG with derivation function and without in the same test session. Putting that on the backburner for time being. 