### PR TITLE
ECDSA component test support, more registration updates

### DIFF
--- a/app/app_ecdsa.c
+++ b/app/app_ecdsa.c
@@ -58,7 +58,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
     ACVP_SUB_ECDSA alg;
     ACVP_ECDSA_TC *tc = NULL;
     EVP_MD_CTX *sig_ctx = NULL;
-    EVP_PKEY_CTX *pkey_ctx = NULL;
+    EVP_PKEY_CTX *pkey_ctx = NULL, *comp_ctx = NULL;
     EVP_PKEY *pkey = NULL;
     OSSL_PARAM_BLD *pkey_pbld = NULL;
     OSSL_PARAM *params = NULL;
@@ -94,7 +94,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
 
-    if (mode == ACVP_ECDSA_SIGGEN || mode == ACVP_ECDSA_SIGVER) {
+    if ((mode == ACVP_ECDSA_SIGGEN || mode == ACVP_ECDSA_SIGVER) && !tc->is_component) {
         md = get_md_string_for_hash_alg(tc->hash_alg, NULL);
         if (!md) {
             printf("Error getting hash alg from test case for ECDSA\n");
@@ -201,31 +201,49 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
             }
         }
         /* Then, for each test case, generate a signature */
-        sig_ctx = EVP_MD_CTX_new();
-        if (!sig_ctx) {
-            printf("Error initializing sign CTX for ECDSA siggen\n");
-            goto err;
+        if (!tc->is_component) {
+            sig_ctx = EVP_MD_CTX_new();
+            if (!sig_ctx) {
+                printf("Error initializing sign CTX for ECDSA siggen\n");
+                goto err;
+            }
+            if (EVP_DigestSignInit_ex(sig_ctx, NULL, md, NULL, NULL, group_pkey, NULL) != 1) {
+                printf("Error initializing signing for ECDSA siggen\n");
+                goto err;
+            }
+            EVP_DigestSign(sig_ctx, NULL, &sig_len, tc->message, tc->msg_len);
+            sig = calloc(sig_len, sizeof(char));
+            if (!sig) {
+                printf("Error allocating memory in ECDSA siggen\n");
+                goto err;
+            }
+            sig_iter = sig; /* since d2i_ECDSA_SIG alters the pointer, we need to keep the original one for freeing */
+            if (EVP_DigestSign(sig_ctx, sig, &sig_len, tc->message, tc->msg_len) != 1) {
+                printf("Error generating signature in ECDSA siggen\n");
+                goto err;
+            }
+        } else {
+            comp_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, group_pkey, NULL);
+            if (!comp_ctx) {
+                printf("Error initializing sign CTX for ECDSA component siggen\n");
+                goto err;
+            }
+            if (EVP_PKEY_sign_init(comp_ctx) != 1) {
+                printf("Error initializing signing for ECDSA component siggen\n");
+                goto err;
+            }
+            EVP_PKEY_sign(comp_ctx, NULL, &sig_len, tc->message, tc->msg_len);
+            sig = calloc(sig_len, sizeof(char));
+            if (!sig) {
+                printf("Error allocating memory in ECDSA siggen\n");
+                goto err;
+            }
+            sig_iter = sig; /* since d2i_ECDSA_SIG alters the pointer, we need to keep the original one for freeing */
+            if (EVP_PKEY_sign(comp_ctx, sig, &sig_len, tc->message, tc->msg_len) != 1) {
+                printf("Error generating signature in ECDSA component siggen\n");
+                goto err;
+            }
         }
-        if (EVP_DigestSignInit_ex(sig_ctx, NULL, md, NULL, NULL, group_pkey, NULL) != 1) {
-            printf("Error initializing signing for ECDSA siggen\n");
-            goto err;
-        }
-        EVP_DigestSign(sig_ctx, NULL, &sig_len, tc->message, tc->msg_len);
-        sig = calloc(sig_len, sizeof(char));
-        if (!sig) {
-            printf("Error allocating memory in ECDSA siggen\n");
-            goto err;
-        }
-        sig_iter = sig; /* since d2i_ECDSA_SIG alters the pointer, we need to keep the original one for freeing */
-        if (!sig) {
-            printf("Error allocating memory for signature in ECDSA siggen\n");
-            goto err;
-        }
-        if (EVP_DigestSign(sig_ctx, sig, &sig_len, tc->message, tc->msg_len) != 1) {
-            printf("Error generating signature in ECDSA siggen\n");
-            goto err;
-        }
-
         /* Finally, extract R and S from signature */
         sig_obj = d2i_ECDSA_SIG(NULL, (const unsigned char **)&sig_iter, (long)sig_len);
         if (!sig_obj) {
@@ -296,18 +314,34 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
         }
 
         sig_len = (size_t)i2d_ECDSA_SIG(sig_obj, &sig);
-        sig_ctx = EVP_MD_CTX_new();
-        if (!sig_ctx) {
-            printf("Error initializing sign CTX for ECDSA sigver\n");
-            goto err;
-        }            
 
-        if (EVP_DigestVerifyInit_ex(sig_ctx, NULL, md, NULL, NULL, pkey, NULL) != 1) {
-            printf("Error initializing signing for ECDSA sigver\n");
-            goto err;
-        }
-        if (EVP_DigestVerify(sig_ctx, sig, sig_len, tc->message, tc->msg_len) == 1) {
-            tc->ver_disposition = 1;
+        if (!tc->is_component) {
+            sig_ctx = EVP_MD_CTX_new();
+            if (!sig_ctx) {
+                printf("Error initializing sign CTX for ECDSA sigver\n");
+                goto err;
+            }
+
+            if (EVP_DigestVerifyInit_ex(sig_ctx, NULL, md, NULL, NULL, pkey, NULL) != 1) {
+                printf("Error initializing signing for ECDSA sigver\n");
+                goto err;
+            }
+            if (EVP_DigestVerify(sig_ctx, sig, sig_len, tc->message, tc->msg_len) == 1) {
+                tc->ver_disposition = 1;
+            }
+        } else {
+            comp_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);
+            if (!comp_ctx) {
+                printf("Error initializing sign CTX for ECDSA component siggen\n");
+                goto err;
+            }
+            if (EVP_PKEY_verify_init(comp_ctx) != 1) {
+                printf("Error initializing signing for ECDSA component siggen\n");
+                goto err;
+            }
+            if (EVP_PKEY_verify(comp_ctx, sig, sig_len, tc->message, tc->msg_len) == 1) {
+                tc->ver_disposition = 1;
+            }
         }
         break;
     default:
@@ -327,6 +361,7 @@ err:
     if (pkey) EVP_PKEY_free(pkey);
     if (sig_ctx) EVP_MD_CTX_free(sig_ctx);
     if (pkey_ctx) EVP_PKEY_CTX_free(pkey_ctx);
+    if (comp_ctx) EVP_PKEY_CTX_free(comp_ctx);
     return rv;
 }
 

--- a/app/app_ecdsa.c
+++ b/app/app_ecdsa.c
@@ -235,7 +235,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
             EVP_PKEY_sign(comp_ctx, NULL, &sig_len, tc->message, tc->msg_len);
             sig = calloc(sig_len, sizeof(char));
             if (!sig) {
-                printf("Error allocating memory in ECDSA siggen\n");
+                printf("Error allocating memory in ECDSA component siggen\n");
                 goto err;
             }
             sig_iter = sig; /* since d2i_ECDSA_SIG alters the pointer, we need to keep the original one for freeing */
@@ -332,11 +332,11 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
         } else {
             comp_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);
             if (!comp_ctx) {
-                printf("Error initializing sign CTX for ECDSA component siggen\n");
+                printf("Error initializing sign CTX for ECDSA component sigver\n");
                 goto err;
             }
             if (EVP_PKEY_verify_init(comp_ctx) != 1) {
-                printf("Error initializing signing for ECDSA component siggen\n");
+                printf("Error initializing signing for ECDSA component sigver\n");
                 goto err;
             }
             if (EVP_PKEY_verify(comp_ctx, sig, sig_len, tc->message, tc->msg_len) == 1) {

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -777,6 +777,8 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_KW_MODE, ACVP_SYM_KW_CIPHER);
     CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_KW_MODE, ACVP_SYM_KW_INVERSE);
+    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_KEYLEN, 128);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_KEYLEN, 192);
@@ -871,7 +873,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_PARM_KO, ACVP_SYM_CIPH_KO_NA);
     CHECK_ENABLE_CAP_RV(rv);
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_EXT);
+    rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_EITHER);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_TAGLEN, 32);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2682,6 +2684,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#if 0 //Do we want this?
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_256, 0);
@@ -2694,6 +2697,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_256, 0);
     CHECK_ENABLE_CAP_RV(rv);
+#endif
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512_256, 0);
@@ -3004,6 +3008,8 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_COMPONENT_TEST, ACVP_ECDSA_COMPONENT_MODE_BOTH);
+    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P224);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P256);
@@ -3051,6 +3057,8 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_DRBG, value);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_COMPONENT_TEST, ACVP_ECDSA_COMPONENT_MODE_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P224);
     CHECK_ENABLE_CAP_RV(rv);

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -676,7 +676,8 @@ typedef enum acvp_rsa_prime_param {
 typedef enum acvp_ecdsa_param {
     ACVP_ECDSA_CURVE,
     ACVP_ECDSA_SECRET_GEN,
-    ACVP_ECDSA_HASH_ALG
+    ACVP_ECDSA_HASH_ALG,
+    ACVP_ECDSA_COMPONENT_TEST
 } ACVP_ECDSA_PARM;
 
 /** @enum ACVP_ECDSA_SECRET_GEN_MODE */
@@ -705,6 +706,13 @@ typedef enum acvp_ec_curve {
     ACVP_EC_CURVE_K571,
     ACVP_EC_CURVE_END
 } ACVP_EC_CURVE;
+
+/** @enum ACVP_ECDSA_COMPONENT_MODE */
+typedef enum acvp_ecdsa_component_mode {
+    ACVP_ECDSA_COMPONENT_MODE_NO,
+    ACVP_ECDSA_COMPONENT_MODE_YES,
+    ACVP_ECDSA_COMPONENT_MODE_BOTH
+} ACVP_ECDSA_COMPONENT_MODE;
 
 /** @enum ACVP_KDF135_IKEV2_PARM */
 typedef enum acvp_kdf135_ikev2_param {
@@ -1548,6 +1556,7 @@ typedef struct acvp_rsa_keygen_tc_t {
 typedef struct acvp_ecdsa_tc_t {
     unsigned int tc_id;    /**< Test case id */
     int tg_id;
+    int is_component;
     ACVP_HASH_ALG hash_alg;
 
     ACVP_CIPHER cipher;

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1348,6 +1348,7 @@ typedef struct acvp_ecdsa_capability_t {
     ACVP_NAME_LIST *secret_gen_modes;
     //For backwards compatibility, this contains hash algs that will be used with ALL registered curves (HASH_ALG = array index)
     int hash_algs[ACVP_HASH_ALG_MAX + 1];
+    ACVP_ECDSA_COMPONENT_MODE component;
 } ACVP_ECDSA_CAP;
 
 typedef struct acvp_rsa_sig_capability_t {

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -4938,6 +4938,19 @@ ACVP_RESULT acvp_cap_ecdsa_set_parm(ACVP_CTX *ctx,
 
         cap->hash_algs[value] = 1;
         break;
+    case ACVP_ECDSA_COMPONENT_TEST:
+        if (cipher == ACVP_ECDSA_SIGGEN || cipher == ACVP_ECDSA_SIGVER) {
+            if (value >= ACVP_ECDSA_COMPONENT_MODE_NO && value <= ACVP_ECDSA_COMPONENT_MODE_BOTH) {
+                cap->component = value;
+            } else {
+                ACVP_LOG_ERR("Invalid value given for ECDSA component test mode");
+                return ACVP_INVALID_ARG;
+            }
+        } else {
+            ACVP_LOG_ERR("ECDSA Component Tests only apply to siggen and sigver");
+            return ACVP_INVALID_ARG;
+        }
+        break;
     default:
         return ACVP_INVALID_ARG;
         break;

--- a/src/acvp_ecdsa.c
+++ b/src/acvp_ecdsa.c
@@ -102,6 +102,7 @@ static ACVP_RESULT acvp_ecdsa_release_tc(ACVP_ECDSA_TC *stc) {
 
 static ACVP_RESULT acvp_ecdsa_init_tc(ACVP_CTX *ctx,
                                       ACVP_CIPHER cipher,
+                                      int is_component,
                                       ACVP_ECDSA_TC *stc,
                                       int tg_id,
                                       unsigned int tc_id,
@@ -123,6 +124,7 @@ static ACVP_RESULT acvp_ecdsa_init_tc(ACVP_CTX *ctx,
     stc->hash_alg = hash_alg;
     stc->curve = curve;
     stc->secret_gen_mode = secret_gen_mode;
+    stc->is_component = is_component;
 
     stc->qx = calloc(ACVP_RSA_EXP_LEN_MAX, sizeof(char));
     if (!stc->qx) { goto err; }
@@ -312,7 +314,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
     g_cnt = json_array_get_count(groups);
 
     for (i = 0; i < g_cnt; i++) {
-        int tgId = 0;
+        int tgId = 0, is_component = 0;
         ACVP_HASH_ALG hash_alg = 0;
         ACVP_EC_CURVE curve = 0;
         ACVP_ECDSA_SECRET_GEN_MODE secret_gen_mode = 0;
@@ -383,6 +385,8 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
                 rv = ACVP_INVALID_ARG;
                 goto err;
             }
+
+            is_component = json_object_get_boolean(groupobj, "componentTest");
         }
 
         ACVP_LOG_VERBOSE("           Test group: %d", i);
@@ -459,7 +463,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
 
             json_object_set_number(r_tobj, "tcId", tc_id);
 
-            rv = acvp_ecdsa_init_tc(ctx, alg_id, &stc, tgId, tc_id, curve, secret_gen_mode, hash_alg, qx, qy, message, r, s);
+            rv = acvp_ecdsa_init_tc(ctx, alg_id, is_component, &stc, tgId, tc_id, curve, secret_gen_mode, hash_alg, qx, qy, message, r, s);
 
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {


### PR DESCRIPTION
More registration updates to match 3.0 cert, small fix for DRBG registration building, and support for ECDSA siggen/sigver component test.

Note that component test support requires an entire other vector set, instead of supporting both types of test in one vector set like usual.