### PR TITLE
Update domain functionality to support list of values, registration updates

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1218,6 +1218,7 @@ static int enable_cmac(ACVP_CTX *ctx) {
     rv = acvp_cap_cmac_set_parm(ctx, ACVP_CMAC_AES, ACVP_CMAC_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
     rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_TDES, &app_cmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_TDES, ACVP_CMAC_MSGLEN, 0, 65536, 8);
@@ -1232,7 +1233,7 @@ static int enable_cmac(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_CMAC_TDES, ACVP_PREREQ_TDES, value);
     CHECK_ENABLE_CAP_RV(rv);
-
+#endif
 end:
 
     return rv;
@@ -1578,14 +1579,22 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_SHARED_INFO_LEN, 1024);
     CHECK_ENABLE_CAP_RV(rv);
 
-    /*
-     * KDF108 Counter Mode
-     */
+    /* KDF108 Counter Mode */
     rv = acvp_cap_kdf108_enable(ctx, &app_kdf108_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 8, 4096, 8);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 72);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 776);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 3456);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 4096);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_CMAC_AES128);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1607,7 +1616,18 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_FIXED_DATA_ORDER, ACVP_KDF108_FIXED_DATA_ORDER_BEFORE);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 8, 4096, 8);
+    /* KDF108 Feedback Mode */
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 72);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 776);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 3456);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 4096);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_CMAC_AES128);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2291,7 +2311,7 @@ static int enable_kda(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_TWOSTEP_REQUIRES_EMPTY_IV, 1, ACVP_KDF108_MODE_FEEDBACK, NULL);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_kda_twostep_set_domain(ctx, ACVP_KDA_TWOSTEP_SUPPORTED_LEN, 2048, 2048, 0, ACVP_KDF108_MODE_FEEDBACK);
+    rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_TWOSTEP_SUPPORTED_LEN, 2048, ACVP_KDF108_MODE_FEEDBACK, NULL);
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1097,7 +1097,7 @@ typedef struct acvp_json_domain_obj_t {
     int min;
     int max;
     int increment;
-    int value; // for single values
+    struct acvp_sl_list_t *values;
 } ACVP_JSON_DOMAIN_OBJ;
 
 typedef struct acvp_prereq_alg_val {

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -50,6 +50,8 @@ static void acvp_cap_free_nl(ACVP_NAME_LIST *list);
 
 static void acvp_cap_free_pl(ACVP_PARAM_LIST *list);
 
+static void acvp_cap_free_domain(ACVP_JSON_DOMAIN_OBJ *domain);
+
 static void acvp_cap_free_hash_pairs(ACVP_RSA_HASH_PAIR_LIST *list);
 
 static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url);
@@ -530,6 +532,7 @@ static void acvp_cap_free_kdf108(ACVP_KDF108_CAP *cap) {
             if (mode_obj->counter_lens) {
                 acvp_cap_free_sl(mode_obj->counter_lens);
             }
+            acvp_cap_free_domain(&mode_obj->supported_lens);
         }
 
         if (cap->feedback_mode.kdf_mode) {
@@ -543,6 +546,7 @@ static void acvp_cap_free_kdf108(ACVP_KDF108_CAP *cap) {
             if (mode_obj->counter_lens) {
                 acvp_cap_free_sl(mode_obj->counter_lens);
             }
+            acvp_cap_free_domain(&mode_obj->supported_lens);
         }
 
         if (cap->dpi_mode.kdf_mode) {
@@ -556,6 +560,7 @@ static void acvp_cap_free_kdf108(ACVP_KDF108_CAP *cap) {
             if (mode_obj->counter_lens) {
                 acvp_cap_free_sl(mode_obj->counter_lens);
             }
+            acvp_cap_free_domain(&mode_obj->supported_lens);
         }
 
         cap = NULL;
@@ -647,14 +652,21 @@ ACVP_RESULT acvp_free_test_session(ACVP_CTX *ctx) {
                 acvp_free_drbg_struct(cap_entry);
                 break;
             case ACVP_HMAC_TYPE:
+                acvp_cap_free_domain(&cap_entry->cap.hmac_cap->key_len);
+                acvp_cap_free_domain(&cap_entry->cap.hmac_cap->mac_len);
                 free(cap_entry->cap.hmac_cap);
                 break;
             case ACVP_CMAC_TYPE:
                 acvp_cap_free_sl(cap_entry->cap.cmac_cap->key_len);
                 acvp_cap_free_sl(cap_entry->cap.cmac_cap->keying_option);
+                acvp_cap_free_domain(&cap_entry->cap.cmac_cap->msg_len);
+                acvp_cap_free_domain(&cap_entry->cap.cmac_cap->mac_len);
                 free(cap_entry->cap.cmac_cap);
                 break;
             case ACVP_KMAC_TYPE:
+                acvp_cap_free_domain(&cap_entry->cap.kmac_cap->key_len);
+                acvp_cap_free_domain(&cap_entry->cap.kmac_cap->msg_len);
+                acvp_cap_free_domain(&cap_entry->cap.kmac_cap->mac_len);
                 free(cap_entry->cap.kmac_cap);
                 break;
             case ACVP_DSA_TYPE:
@@ -770,6 +782,10 @@ ACVP_RESULT acvp_free_test_session(ACVP_CTX *ctx) {
                 break;
             case ACVP_KDF135_IKEV2_TYPE:
                 acvp_cap_free_nl(cap_entry->cap.kdf135_ikev2_cap->hash_algs);
+                acvp_cap_free_domain(&cap_entry->cap.kdf135_ikev2_cap->init_nonce_len_domain);
+                acvp_cap_free_domain(&cap_entry->cap.kdf135_ikev2_cap->respond_nonce_len_domain);
+                acvp_cap_free_domain(&cap_entry->cap.kdf135_ikev2_cap->dh_secret_len);
+                acvp_cap_free_domain(&cap_entry->cap.kdf135_ikev2_cap->key_material_len);
                 free(cap_entry->cap.kdf135_ikev2_cap);
                 break;
             case ACVP_KDF135_IKEV1_TYPE:
@@ -878,6 +894,14 @@ static void acvp_cap_free_nl(ACVP_NAME_LIST *list) {
         top = top->next;
         free(tmp);
     }
+}
+
+static void acvp_cap_free_domain(ACVP_JSON_DOMAIN_OBJ *domain) {
+    if (!domain) {
+        return;
+    }
+    acvp_cap_free_sl(domain->values);
+    return;
 }
 
 static void acvp_cap_free_hash_pairs(ACVP_RSA_HASH_PAIR_LIST *list) {


### PR DESCRIPTION
Domains in the acvp protocol are defined as a given range, AND/OR a list of specific values. We have had very limited support for giving specific values in libacvp; a single value could be provided in some cases and the code often made you chose between a single value or a range.

Now, a domain object consists of a range and a dynamically allocated list of values, so we have alot more control over that. This was needed to update the KDF108 registration. The only downside is we have to specifically free domains in any capability objects that support setting single values. For now, this has only been updated where needed, but is easy to update moving forward. 

Now, when building registrations, libacvp checks if a range exists (increment != 0), adds that, then iterates through the value list if it exists. 