### PR TITLE
Replace string literals with OSSL definitions, cmac/hmac updates

### DIFF
--- a/app/app_drbg.c
+++ b/app/app_drbg.c
@@ -43,15 +43,15 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
     switch (alg) {
     case ACVP_SUB_DRBG_HASH:
         alg_name = "HASH-DRBG";
-        param_str = "digest";
+        param_str = OSSL_DRBG_PARAM_DIGEST;
         break;
     case ACVP_SUB_DRBG_HMAC:
         alg_name = "HMAC-DRBG";
-        param_str = "digest";
+        param_str = OSSL_DRBG_PARAM_DIGEST;
         break;
     case ACVP_SUB_DRBG_CTR:
         alg_name = "CTR-DRBG";
-        param_str = "cipher";
+        param_str = OSSL_DRBG_PARAM_CIPHER;
         break;
     default:
         printf("Invalid DRBG cipher value\n");
@@ -116,7 +116,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
 
-    params[0] = OSSL_PARAM_construct_uint("strength", &strength);
+    params[0] = OSSL_PARAM_construct_uint(OSSL_RAND_PARAM_STRENGTH, &strength);
     params[1] = OSSL_PARAM_construct_end(); /* HMAC */
     params[2] = OSSL_PARAM_construct_end(); /* der func */
     params[3] = OSSL_PARAM_construct_end();
@@ -135,15 +135,15 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
     strength = EVP_RAND_get_strength(rctx);
     mac_name = remove_str_const("HMAC");
     params[0] = OSSL_PARAM_construct_utf8_string(param_str, tmp, 0);
-    params[1] = OSSL_PARAM_construct_utf8_string("mac", mac_name, 0); //ignored if irrelevant
+    params[1] = OSSL_PARAM_construct_utf8_string(OSSL_DRBG_PARAM_MAC, mac_name, 0); //ignored if irrelevant
     params[2] = OSSL_PARAM_construct_int(OSSL_DRBG_PARAM_USE_DF, &der_func);
     if (EVP_RAND_CTX_set_params(rctx, params) != 1) {
         printf("Error setting algorithm for DRBG\n");
         goto err;
     }
 
-    params[0] = OSSL_PARAM_construct_octet_string("test_entropy", tc->entropy, tc->entropy_len);
-    params[1] = OSSL_PARAM_construct_octet_string("test_nonce", tc->nonce, tc->nonce_len);
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY, tc->entropy, tc->entropy_len);
+    params[1] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_NONCE, tc->nonce, tc->nonce_len);
     if (EVP_RAND_CTX_set_params(test, params) != 1) {
         printf("Error setting initial entropy/nonce for DRBG\n");
         goto err;
@@ -154,7 +154,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
 
-    params[0] = OSSL_PARAM_construct_octet_string("test_entropy", tc->entropy_input_pr_1, tc->entropy_len);
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY, tc->entropy_input_pr_1, tc->entropy_len);
     if (EVP_RAND_CTX_set_params(test, params) != 1) {
         printf("Error setting params for DRBG (1)\n");
         goto err;
@@ -167,7 +167,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
         goto err;
      }
 
-    params[0] = OSSL_PARAM_construct_octet_string("test_entropy", tc->entropy_input_pr_2, tc->entropy_len);
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY, tc->entropy_input_pr_2, tc->entropy_len);
     if (EVP_RAND_CTX_set_params(test, params) != 1) {
         printf("Error setting params for DRBG (2)\n");
         goto err;

--- a/app/app_ecdsa.c
+++ b/app/app_ecdsa.c
@@ -14,6 +14,7 @@
 #include <openssl/ecdsa.h>
 #include <openssl/ec.h>
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/core_names.h>
 #include <openssl/param_build.h>
 #endif
 
@@ -156,8 +157,8 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
             printf("Error creating param_bld in ECDSA keyver\n");
             goto err;
         }
-        OSSL_PARAM_BLD_push_utf8_string(pkey_pbld, "group", curve, 0);
-        OSSL_PARAM_BLD_push_octet_string(pkey_pbld, "pub", pub_key, key_size);
+        OSSL_PARAM_BLD_push_utf8_string(pkey_pbld, OSSL_PKEY_PARAM_GROUP_NAME, curve, 0);
+        OSSL_PARAM_BLD_push_octet_string(pkey_pbld, OSSL_PKEY_PARAM_PUB_KEY, pub_key, key_size);
         params = OSSL_PARAM_BLD_to_param(pkey_pbld);
         if (!params) {
             printf("Error generating parameters for pkey generation in RSA keygen\n");
@@ -276,8 +277,8 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
             printf("Error creating param_bld in ECDSA sigver\n");
             goto err;
         }
-        OSSL_PARAM_BLD_push_utf8_string(pkey_pbld, "group", curve, 0);
-        OSSL_PARAM_BLD_push_octet_string(pkey_pbld, "pub", pub_key, key_size);
+        OSSL_PARAM_BLD_push_utf8_string(pkey_pbld, OSSL_PKEY_PARAM_GROUP_NAME, curve, 0);
+        OSSL_PARAM_BLD_push_octet_string(pkey_pbld, OSSL_PKEY_PARAM_PUB_KEY, pub_key, key_size);
         params = OSSL_PARAM_BLD_to_param(pkey_pbld);
         if (!params) {
             printf("Error generating parameters for pkey generation in RSA sigver\n");

--- a/app/app_kas.c
+++ b/app/app_kas.c
@@ -65,9 +65,9 @@ int app_kas_ecc_handler(ACVP_TEST_CASE *test_case) {
         printf("Error creating param_bld in KAS-ECC\n");
         goto err;
     }
-    OSSL_PARAM_BLD_push_utf8_string(serv_pbld, "group", curve, 0);
-    OSSL_PARAM_BLD_push_octet_string(serv_pbld, "pub", s_pub_key, s_key_size);
-    OSSL_PARAM_BLD_push_int(serv_pbld, "use-cofactor-flag", 1);
+    OSSL_PARAM_BLD_push_utf8_string(serv_pbld, OSSL_PKEY_PARAM_GROUP_NAME, curve, 0);
+    OSSL_PARAM_BLD_push_octet_string(serv_pbld, OSSL_PKEY_PARAM_PUB_KEY, s_pub_key, s_key_size);
+    OSSL_PARAM_BLD_push_int(serv_pbld, OSSL_PKEY_PARAM_USE_COFACTOR_ECDH, 1);
     serv_params = OSSL_PARAM_BLD_to_param(serv_pbld);
     if (!serv_params) {
         printf("Error generating params in KAS-ECC\n");
@@ -93,17 +93,17 @@ int app_kas_ecc_handler(ACVP_TEST_CASE *test_case) {
         printf("Error creating param_bld in KAS-ECC\n");
         goto err;
     }
-    OSSL_PARAM_BLD_push_utf8_string(iut_pbld, "group", curve, 0);
-    OSSL_PARAM_BLD_push_int(iut_pbld, "use-cofactor-flag", 1);
+    OSSL_PARAM_BLD_push_utf8_string(iut_pbld, OSSL_PKEY_PARAM_GROUP_NAME, curve, 0);
+    OSSL_PARAM_BLD_push_int(iut_pbld, OSSL_PKEY_PARAM_USE_COFACTOR_ECDH, 1);
     if (tc->test_type == ACVP_KAS_ECC_TT_VAL) {
         i_pub_key = ec_point_to_pub_key(tc->pix, tc->pixlen, tc->piy, tc->piylen, &i_key_size);
         if (!i_pub_key) {
             printf("Error generating IUT pub key in KAS-ECC\n");
             goto err;
         }
-        OSSL_PARAM_BLD_push_octet_string(iut_pbld, "pub", i_pub_key, i_key_size);
+        OSSL_PARAM_BLD_push_octet_string(iut_pbld, OSSL_PKEY_PARAM_PUB_KEY, i_pub_key, i_key_size);
         ik = BN_bin2bn(tc->d, tc->dlen, NULL);
-        OSSL_PARAM_BLD_push_BN(iut_pbld, "priv", ik);
+        OSSL_PARAM_BLD_push_BN(iut_pbld, OSSL_PKEY_PARAM_PRIV_KEY, ik);
     }
     iut_params = OSSL_PARAM_BLD_to_param(iut_pbld);
     if (!iut_params) {
@@ -289,13 +289,13 @@ int app_kas_ffc_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
     if (!use_pqg) {
-        OSSL_PARAM_BLD_push_utf8_string(serv_pbld, "group", group, 0);
+        OSSL_PARAM_BLD_push_utf8_string(serv_pbld, OSSL_PKEY_PARAM_GROUP_NAME, group, 0);
     } else {
-        OSSL_PARAM_BLD_push_BN(serv_pbld, "p", p);
-        OSSL_PARAM_BLD_push_BN(serv_pbld, "q", q);
-        OSSL_PARAM_BLD_push_BN(serv_pbld, "g", g);
+        OSSL_PARAM_BLD_push_BN(serv_pbld, OSSL_PKEY_PARAM_FFC_P, p);
+        OSSL_PARAM_BLD_push_BN(serv_pbld, OSSL_PKEY_PARAM_FFC_Q, q);
+        OSSL_PARAM_BLD_push_BN(serv_pbld, OSSL_PKEY_PARAM_FFC_G, g);
     }
-    OSSL_PARAM_BLD_push_BN(serv_pbld, "pub", spub);
+    OSSL_PARAM_BLD_push_BN(serv_pbld, OSSL_PKEY_PARAM_PUB_KEY, spub);
     serv_params = OSSL_PARAM_BLD_to_param(serv_pbld);
     if (!serv_params) {
         printf("Error generating params in KAS-FFC\n");
@@ -322,15 +322,15 @@ int app_kas_ffc_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
     if (!use_pqg) {
-        OSSL_PARAM_BLD_push_utf8_string(iut_pbld, "group", group, 0);
+        OSSL_PARAM_BLD_push_utf8_string(iut_pbld, OSSL_PKEY_PARAM_GROUP_NAME, group, 0);
     } else {
-        OSSL_PARAM_BLD_push_BN(iut_pbld, "p", p);
-        OSSL_PARAM_BLD_push_BN(iut_pbld, "q", q);
-        OSSL_PARAM_BLD_push_BN(iut_pbld, "g", g);
+        OSSL_PARAM_BLD_push_BN(iut_pbld, OSSL_PKEY_PARAM_FFC_P, p);
+        OSSL_PARAM_BLD_push_BN(iut_pbld, OSSL_PKEY_PARAM_FFC_Q, q);
+        OSSL_PARAM_BLD_push_BN(iut_pbld, OSSL_PKEY_PARAM_FFC_G, g);
     }
     if (tc->test_type == ACVP_KAS_FFC_TT_VAL) {
-        OSSL_PARAM_BLD_push_BN(iut_pbld, "pub", ipub);
-        OSSL_PARAM_BLD_push_BN(iut_pbld, "priv", ipriv);
+        OSSL_PARAM_BLD_push_BN(iut_pbld, OSSL_PKEY_PARAM_PUB_KEY, ipub);
+        OSSL_PARAM_BLD_push_BN(iut_pbld, OSSL_PKEY_PARAM_PRIV_KEY, ipriv);
     }
     iut_params = OSSL_PARAM_BLD_to_param(iut_pbld);
     if (!iut_params) {
@@ -372,7 +372,7 @@ int app_kas_ffc_handler(ACVP_TEST_CASE *test_case) {
     }
 
     if (tc->test_type == ACVP_KAS_FFC_TT_AFT) {
-        EVP_PKEY_get_bn_param(iut_pkey, "pub", &ipub);
+        EVP_PKEY_get_bn_param(iut_pkey, OSSL_PKEY_PARAM_PUB_KEY, &ipub);
         if (!ipub) {
             printf("Error getting key values from IUT pkey in KAS-FFC\n");
             goto err;
@@ -387,7 +387,7 @@ int app_kas_ffc_handler(ACVP_TEST_CASE *test_case) {
         printf("Error creating param_bld in KAS-FFC\n");
         goto err;
     }
-    OSSL_PARAM_BLD_push_uint(der_pbld, "pad", 1);
+    OSSL_PARAM_BLD_push_uint(der_pbld, OSSL_EXCHANGE_PARAM_PAD, 1);
     der_params = OSSL_PARAM_BLD_to_param(der_pbld);
     if (!der_params) {
         printf("Error generating params in KAS-FFC\n");
@@ -514,9 +514,9 @@ int app_kas_ifc_handler(ACVP_TEST_CASE *test_case) {
         printf("Error creating param_bld in KAS-IFC\n");
         goto err;
     }
-    OSSL_PARAM_BLD_push_BN(serv_pbld, "n", server_n);
-    OSSL_PARAM_BLD_push_BN(serv_pbld, "e", server_e);
-    OSSL_PARAM_BLD_push_uint(serv_pbld, "bits", tc->modulo);
+    OSSL_PARAM_BLD_push_BN(serv_pbld, OSSL_PKEY_PARAM_RSA_N, server_n);
+    OSSL_PARAM_BLD_push_BN(serv_pbld, OSSL_PKEY_PARAM_RSA_E, server_e);
+    OSSL_PARAM_BLD_push_uint(serv_pbld, OSSL_PKEY_PARAM_RSA_BITS, tc->modulo);
     serv_params = OSSL_PARAM_BLD_to_param(serv_pbld);
     if (!serv_params) {
         printf("Error generating parameters for pkey generation in KAS-IFC\n");
@@ -552,16 +552,16 @@ int app_kas_ifc_handler(ACVP_TEST_CASE *test_case) {
 
         /* Note: rsakpg-prime-factor schemes should use P and Q as private key storage.
          * OpenSSL claims support, but is unclear. Here we represent with our given (?) n value */
-        OSSL_PARAM_BLD_push_BN(pbld, "n", n);
-        OSSL_PARAM_BLD_push_BN(pbld, "e", e);
-        OSSL_PARAM_BLD_push_BN(pbld, "d", d);
-        OSSL_PARAM_BLD_push_uint(pbld, "bits", tc->modulo);
+        OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_N, n);
+        OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_E, e);
+        OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_D, d);
+        OSSL_PARAM_BLD_push_uint(pbld, OSSL_PKEY_PARAM_RSA_BITS, tc->modulo);
         if (tc->key_gen == ACVP_KAS_IFC_RSAKPG1_CRT || tc->key_gen == ACVP_KAS_IFC_RSAKPG2_CRT) {
-            OSSL_PARAM_BLD_push_BN(pbld, "rsa-factor1", p);
-            OSSL_PARAM_BLD_push_BN(pbld, "rsa-factor2", q);
-            OSSL_PARAM_BLD_push_BN(pbld, "rsa-exponent1", dmp1);
-            OSSL_PARAM_BLD_push_BN(pbld, "rsa-exponent2", dmq1);
-            OSSL_PARAM_BLD_push_BN(pbld, "rsa-coefficient1", iqmp);
+            OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_FACTOR1, p);
+            OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_FACTOR2, q);
+            OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_EXPONENT1, dmp1);
+            OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_EXPONENT2, dmq1);
+            OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, iqmp);
         }
 
         params = OSSL_PARAM_BLD_to_param(pbld);
@@ -852,17 +852,16 @@ int app_kts_ifc_handler(ACVP_TEST_CASE *test_case) {
 
     /* Note: rsakpg-prime-factor schemes should use P and Q as private key storage.
      * OpenSSL claims support, but is unclear. Here we represent with our given (?) n value */
-    OSSL_PARAM_BLD_push_BN(pbld, "n", n);
-    OSSL_PARAM_BLD_push_BN(pbld, "e", e);
-    OSSL_PARAM_BLD_push_uint(pbld, "bits", tc->modulo);
+    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_N, n);
+    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_E, e);
+    OSSL_PARAM_BLD_push_uint(pbld, OSSL_PKEY_PARAM_RSA_BITS, tc->modulo);
     if (tc->kts_role == ACVP_KTS_IFC_RESPONDER) {
-        OSSL_PARAM_BLD_push_BN(pbld, "d", d);
+        OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_D, d);
         if (tc->key_gen == ACVP_KTS_IFC_RSAKPG1_CRT || tc->key_gen == ACVP_KTS_IFC_RSAKPG2_CRT) {
-            OSSL_PARAM_BLD_push_BN(pbld, "rsa-factor1", p);
-            OSSL_PARAM_BLD_push_BN(pbld, "rsa-factor2", q);
-            OSSL_PARAM_BLD_push_BN(pbld, "rsa-exponent1", dmp1);
-            OSSL_PARAM_BLD_push_BN(pbld, "rsa-exponent2", dmq1);
-            OSSL_PARAM_BLD_push_BN(pbld, "rsa-coefficient1", iqmp);
+            OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_FACTOR1, p);
+            OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_FACTOR2, q);
+            OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_EXPONENT1, dmp1);
+            OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, iqmp);
         }
     }
     params = OSSL_PARAM_BLD_to_param(pbld);

--- a/app/app_kda.c
+++ b/app/app_kda.c
@@ -11,6 +11,7 @@
 #include <openssl/hmac.h>
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/kdf.h>
+#include <openssl/core_names.h>
 #include <openssl/param_build.h>
 #endif
 #include "acvp/acvp.h"
@@ -202,10 +203,10 @@ int app_kda_hkdf_handler(ACVP_TEST_CASE *test_case) {
         printf("Error creating param_bld in HKDF\n");
         goto end;
     }
-    OSSL_PARAM_BLD_push_utf8_string(pbld, "digest", md, 0);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "key", stc->z, (size_t)stc->zLen);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "info", fixedInfo, (size_t)fixedInfoLen);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "salt", stc->salt, (size_t)stc->saltLen);
+    OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_DIGEST, md, 0);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_KEY, stc->z, (size_t)stc->zLen);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_INFO, fixedInfo, (size_t)fixedInfoLen);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_SALT, stc->salt, (size_t)stc->saltLen);
     params = OSSL_PARAM_BLD_to_param(pbld);
     if (!params) {
         printf("Error generating params in HKDF\n");
@@ -367,14 +368,14 @@ int app_kda_onestep_handler(ACVP_TEST_CASE *test_case) {
         goto end;
     }
     if (stc->salt) {
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "mac", mac, 0);
-        OSSL_PARAM_BLD_push_octet_string(pbld, "salt", stc->salt, (size_t)stc->saltLen);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_MAC, mac, 0);
+        OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_SALT, stc->salt, (size_t)stc->saltLen);
     }
     if (md) {
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "digest", md, 0);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_DIGEST, md, 0);
     }
-    OSSL_PARAM_BLD_push_octet_string(pbld, "key", stc->z, (size_t)stc->zLen);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "info", fixedInfo, (size_t)fixedInfoLen);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_KEY, stc->z, (size_t)stc->zLen);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_INFO, fixedInfo, (size_t)fixedInfoLen);
     params = OSSL_PARAM_BLD_to_param(pbld);
     if (!params) {
         printf("Error generating params in KDA Onestep\n");
@@ -517,9 +518,9 @@ int app_kda_twostep_handler(ACVP_TEST_CASE *test_case) {
          goto end;
     }
     if (isHmac) {
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "digest", aname, 0);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_MAC_PARAM_DIGEST, aname, 0);
     } else {
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "cipher", aname, 0);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_MAC_PARAM_CIPHER, aname, 0);
     }
     params = OSSL_PARAM_BLD_to_param(pbld);
 
@@ -561,24 +562,24 @@ int app_kda_twostep_handler(ACVP_TEST_CASE *test_case) {
         printf("Error creating param_bld in KDA Twostep\n");
         goto end;
     }
-    OSSL_PARAM_BLD_push_utf8_string(pbld, "mac", mac, 0);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "key", extraction, ext_len);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "seed", stc->iv, stc->ivLen);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "info", fixedInfo, fixedInfoLen);
-    OSSL_PARAM_BLD_push_int(pbld, "use-separator", 0);
-    OSSL_PARAM_BLD_push_int(pbld, "use-l", 0);
+    OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_MAC, mac, 0);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_KEY, extraction, ext_len);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_SEED, stc->iv, stc->ivLen);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_INFO, fixedInfo, fixedInfoLen);
+    OSSL_PARAM_BLD_push_int(pbld, OSSL_KDF_PARAM_KBKDF_USE_SEPARATOR, 0);
+    OSSL_PARAM_BLD_push_int(pbld, OSSL_KDF_PARAM_KBKDF_USE_L, 0);
 
     if (isHmac) {
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "digest", alg, 0);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_DIGEST, alg, 0);
     } else {
         /* For this step, any CMAC length uses 128, as per SP800-56C */
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "cipher", "AES128", 0);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_CIPHER, "AES128", 0);
     }
 
     if (stc->kdfMode == ACVP_KDF108_MODE_COUNTER) {
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "mode", "COUNTER", 0);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_MODE, "COUNTER", 0);
     } else if (stc->kdfMode == ACVP_KDF108_MODE_FEEDBACK) {
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "mode", "FEEDBACK", 0);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_MODE, "FEEDBACK", 0);
     } else {
         printf("Unsupported KDF108 mode given for KDA Twostep\n");
         goto end;

--- a/app/app_kdf.c
+++ b/app/app_kdf.c
@@ -239,9 +239,9 @@ int app_kdf135_x963_handler(ACVP_TEST_CASE *test_case) {
         printf("Error creating param_bld in KDF X963\n");
         goto end;
     }
-    OSSL_PARAM_BLD_push_octet_string(pbld, "key", stc->z, stc->z_len);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "info", stc->shared_info, stc->shared_info_len);
-    OSSL_PARAM_BLD_push_utf8_string(pbld, "digest", aname, 0);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_KEY, stc->z, stc->z_len);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_INFO, stc->shared_info, stc->shared_info_len);
+    OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_DIGEST, aname, 0);
     params = OSSL_PARAM_BLD_to_param(pbld);
     if (!params) {
         printf("Error generating params in KDF X963\n");
@@ -385,23 +385,23 @@ int app_kdf108_handler(ACVP_TEST_CASE *test_case) {
         printf("Error creating param_bld in kdf108\n");
         goto end;
     }
-    OSSL_PARAM_BLD_push_utf8_string(pbld, "mac", mac, 0);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "key", stc->key_in, stc->key_in_len);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "seed", stc->iv, stc->iv_len);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "info", fixed, fixed_len);
-    OSSL_PARAM_BLD_push_int(pbld, "use-separator", 0);
-    OSSL_PARAM_BLD_push_int(pbld, "use-l", 0);
+    OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_MAC, mac, 0);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_KEY, stc->key_in, stc->key_in_len);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_SEED, stc->iv, stc->iv_len);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_INFO, fixed, fixed_len);
+    OSSL_PARAM_BLD_push_int(pbld, OSSL_KDF_PARAM_KBKDF_USE_SEPARATOR, 0);
+    OSSL_PARAM_BLD_push_int(pbld, OSSL_KDF_PARAM_KBKDF_USE_L, 0);
 
     if (isHmac) {
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "digest", aname, 0);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_DIGEST, aname, 0);
     } else {
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "cipher", aname, 0);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_CIPHER, aname, 0);
     }
 
     if (stc->mode == ACVP_KDF108_MODE_COUNTER) {
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "mode", "COUNTER", 0);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_MODE, "COUNTER", 0);
     } else if (stc->mode == ACVP_KDF108_MODE_FEEDBACK) {
-        OSSL_PARAM_BLD_push_utf8_string(pbld, "mode", "FEEDBACK", 0);
+        OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_MODE, "FEEDBACK", 0);
     } else {
         printf("Unsupported KDF108 mode given for kdf108\n");
         goto end;
@@ -583,11 +583,11 @@ int app_pbkdf_handler(ACVP_TEST_CASE *test_case) {
         printf("Error creating param_bld in PBKDF\n");
         goto end;
     }
-    OSSL_PARAM_BLD_push_octet_string(pbld, "pass", stc->password, stc->pw_len);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "salt", stc->salt, stc->salt_len);
-    OSSL_PARAM_BLD_push_utf8_string(pbld, "digest", aname, 0);
-    OSSL_PARAM_BLD_push_uint(pbld, "iter", stc->iterationCount);
-    OSSL_PARAM_BLD_push_int(pbld, "pkcs5", 1); /* disables compliance checks, dont want limit checks for ACVP tests */
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_PASSWORD, stc->password, stc->pw_len);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_SALT, stc->salt, stc->salt_len);
+    OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_DIGEST, aname, 0);
+    OSSL_PARAM_BLD_push_uint(pbld, OSSL_KDF_PARAM_ITER, stc->iterationCount);
+    OSSL_PARAM_BLD_push_int(pbld, OSSL_KDF_PARAM_PKCS5, 1); /* disables compliance checks, dont want limit checks for ACVP tests */
     params = OSSL_PARAM_BLD_to_param(pbld);
     if (!params) {
         printf("Error generating params in PBKDF\n");
@@ -668,9 +668,9 @@ int app_kdf_tls12_handler(ACVP_TEST_CASE *test_case) {
     memcpy_s(seed + TLS_EXT_MASTER_SECRET_CONST_SIZE, TLS12_SEED_BUF_MAX - TLS_EXT_MASTER_SECRET_CONST_SIZE,
              tc->session_hash, tc->session_hash_len);
 
-    OSSL_PARAM_BLD_push_utf8_string(pbld, "digest", alg, 0);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "secret", tc->pm_secret, tc->pm_len);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "seed", seed, seed_len);
+    OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_DIGEST, alg, 0);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_SECRET, tc->pm_secret, tc->pm_len);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_SEED, seed, seed_len);
     params = OSSL_PARAM_BLD_to_param(pbld);
     if (!params) {
         printf("Error generating params in TLS1.2 KDF (1)\n");
@@ -703,9 +703,9 @@ int app_kdf_tls12_handler(ACVP_TEST_CASE *test_case) {
              TLS12_SEED_BUF_MAX - TLS_KEY_EXPAND_CONST_SIZE - tc->s_rnd_len,
              tc->c_rnd, tc->c_rnd_len);
 
-    OSSL_PARAM_BLD_push_utf8_string(pbld, "digest", alg, 0);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "secret", tc->msecret, tc->pm_len);
-    OSSL_PARAM_BLD_push_octet_string(pbld, "seed", seed, seed_len);
+    OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_KDF_PARAM_DIGEST, alg, 0);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_SECRET, tc->msecret, tc->pm_len);
+    OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_KDF_PARAM_SEED, seed, seed_len);
     params = OSSL_PARAM_BLD_to_param(pbld);
     if (!params) {
         printf("Error generating params in TLS1.2 KDF (2)\n");

--- a/app/app_kmac.c
+++ b/app/app_kmac.c
@@ -10,6 +10,7 @@
 
 #include <openssl/evp.h>
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/core_names.h>
 #include <openssl/param_build.h>
 #endif
 #include "acvp/acvp.h"
@@ -75,13 +76,12 @@ int app_kmac_handler(ACVP_TEST_CASE *test_case) {
         printf("error creating param_bld in KMAC\n");
         goto end;
     }
-    OSSL_PARAM_BLD_push_utf8_string(pbld, "cipher", alg_name, 0);
-    OSSL_PARAM_BLD_push_int(pbld, "xof", tc->xof);
-    OSSL_PARAM_BLD_push_uint(pbld, "size", (unsigned int)tc->mac_len);
+    OSSL_PARAM_BLD_push_int(pbld, OSSL_MAC_PARAM_XOF, tc->xof);
+    OSSL_PARAM_BLD_push_uint(pbld, OSSL_MAC_PARAM_SIZE, (unsigned int)tc->mac_len);
     if (tc->hex_customization) {
-        OSSL_PARAM_BLD_push_octet_string(pbld, "custom", tc->custom_hex, tc->custom_len);
+        OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_MAC_PARAM_CUSTOM, tc->custom_hex, tc->custom_len);
     } else {
-        OSSL_PARAM_BLD_push_octet_string(pbld, "custom", tc->custom, tc->custom_len);
+        OSSL_PARAM_BLD_push_octet_string(pbld, OSSL_MAC_PARAM_CUSTOM, tc->custom, tc->custom_len);
     }
     params = OSSL_PARAM_BLD_to_param(pbld);
 #define KMAC_BUF_MAX 8192

--- a/app/app_rsa.c
+++ b/app/app_rsa.c
@@ -136,14 +136,14 @@ int app_rsa_keygen_handler(ACVP_TEST_CASE *test_case) {
         printf("Error creating param_bld in RSA keygen\n");
         goto err;
     }
-    OSSL_PARAM_BLD_push_BN(pkey_pbld, "e", e);
-    OSSL_PARAM_BLD_push_uint(pkey_pbld, "bits", tc->modulo);
-    OSSL_PARAM_BLD_push_BN(pkey_pbld, "xp", xp);
-    OSSL_PARAM_BLD_push_BN(pkey_pbld, "xp1", xp1);
-    OSSL_PARAM_BLD_push_BN(pkey_pbld, "xp2", xp2);
-    OSSL_PARAM_BLD_push_BN(pkey_pbld, "xq", xq);
-    OSSL_PARAM_BLD_push_BN(pkey_pbld, "xq1", xq1); 
-    OSSL_PARAM_BLD_push_BN(pkey_pbld, "xq2", xq2);
+    OSSL_PARAM_BLD_push_BN(pkey_pbld, OSSL_PKEY_PARAM_RSA_E, e);
+    OSSL_PARAM_BLD_push_uint(pkey_pbld, OSSL_PKEY_PARAM_RSA_BITS, tc->modulo);
+    OSSL_PARAM_BLD_push_BN(pkey_pbld, OSSL_PKEY_PARAM_RSA_TEST_XP, xp);
+    OSSL_PARAM_BLD_push_BN(pkey_pbld, OSSL_PKEY_PARAM_RSA_TEST_XP1, xp1);
+    OSSL_PARAM_BLD_push_BN(pkey_pbld, OSSL_PKEY_PARAM_RSA_TEST_XP2, xp2);
+    OSSL_PARAM_BLD_push_BN(pkey_pbld, OSSL_PKEY_PARAM_RSA_TEST_XQ, xq);
+    OSSL_PARAM_BLD_push_BN(pkey_pbld, OSSL_PKEY_PARAM_RSA_TEST_XQ1, xq1); 
+    OSSL_PARAM_BLD_push_BN(pkey_pbld, OSSL_PKEY_PARAM_RSA_TEST_XQ2, xq2);
     params = OSSL_PARAM_BLD_to_param(pkey_pbld);
     if (!params) {
         printf("Error generating parameters for pkey generation in RSA keygen\n");
@@ -395,8 +395,8 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
                 printf("Error creating param_bld in RSA sigver\n");
                 goto err;
             }
-            OSSL_PARAM_BLD_push_BN(pkey_pbld, "n", n);
-            OSSL_PARAM_BLD_push_BN(pkey_pbld, "e", e);
+            OSSL_PARAM_BLD_push_BN(pkey_pbld, OSSL_PKEY_PARAM_RSA_N, n);
+            OSSL_PARAM_BLD_push_BN(pkey_pbld, OSSL_PKEY_PARAM_RSA_E, e);
             pkey_params = OSSL_PARAM_BLD_to_param(pkey_pbld);
             if (!pkey_params) {
                 printf("Error building pkey params in RSA sigver\n");
@@ -423,8 +423,8 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
                 printf("Error creating param_bld in RSA sigver\n");
                 goto err;
             }
-            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, "pad-mode", padding, 0);
-            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, "digest", md, 0);
+            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, OSSL_SIGNATURE_PARAM_PAD_MODE, padding, 0);
+            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, OSSL_SIGNATURE_PARAM_DIGEST, md, 0);
             sig_params = OSSL_PARAM_BLD_to_param(sig_pbld);
             if (!sig_params) {
                 printf("Error building sig params in RSA sigver\n");
@@ -500,10 +500,10 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
                 printf("Error creating param_bld in RSA siggen\n");
                 goto err;
             }
-            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, "pad-mode", padding, 0);
-            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, "digest", md, 0);
+            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, OSSL_SIGNATURE_PARAM_PAD_MODE, padding, 0);
+            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, OSSL_SIGNATURE_PARAM_DIGEST, md, 0);
             if (tc->sig_type == ACVP_RSA_SIG_TYPE_PKCS1PSS) {
-                OSSL_PARAM_BLD_push_int(sig_pbld, "saltlen", salt_len);
+                OSSL_PARAM_BLD_push_int(sig_pbld, OSSL_SIGNATURE_PARAM_PSS_SALTLEN, salt_len);
             }
             sig_params = OSSL_PARAM_BLD_to_param(sig_pbld);
             if (!sig_params) {

--- a/src/acvp_kas_ifc.c
+++ b/src/acvp_kas_ifc.c
@@ -760,7 +760,9 @@ static ACVP_RESULT acvp_kas_ifc_ssc(ACVP_CTX *ctx,
                     rv = ACVP_INVALID_ARG;
                     goto err;
                 }
+            }
 
+            if (scheme == ACVP_KAS_IFC_KAS2) {
                 server_n = json_object_get_string(testobj, "serverN");
                 if (!server_n) {
                     ACVP_LOG_ERR("Server JSON missing 'serverN'");


### PR DESCRIPTION
CMAC and HMAC now use OSSL_PARAM_BLD instead of PARAM constructors. 

A bugfix for KAS-IFC.

The rest of the changes are just replacing string literals with the openssl definitions from core_names.h.