### PR TITLE
Move FIPS mode decision to runtime from build time

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -160,6 +160,11 @@ static void print_usage(int code) {
     printf("      --save_to <file>\n");
     printf("      -s <file>\n");
     printf("\n");
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    printf("To disable FIPS mode for this run (Note, a warning will be issued):\n");
+    printf("      -disable_fips\n");
+    printf("\n");
+#endif
     printf("In addition some options are passed to acvp_app using\n");
     printf("environment variables.  The following variables can be set:\n\n");
     printf("    ACV_SERVER (when not set, defaults to %s)\n", DEFAULT_SERVER);
@@ -266,6 +271,9 @@ static ko_longopt_t longopts[] = {
     { "save_to", ko_required_argument, 413 },
     { "delete", ko_required_argument, 414 },
     { "cancel_session", ko_required_argument, 415 },
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    { "disable_fips", ko_no_argument, 500 },
+#endif
     { NULL, 0, 0 }
 };
 
@@ -590,6 +598,11 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
             strcpy_s(cfg->session_file, JSON_FILENAME_LENGTH + 1, opt.arg);
             break;
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+        case 500:
+            cfg->disable_fips = 1;
+            break;
+#endif
         case '?':
             printf(ANSI_COLOR_RED "unknown option: %s\n"ANSI_COLOR_RESET, *(argv + opt.ind - !(opt.pos > 0)));
             printf("%s\n", ACVP_APP_HELP_MSG);

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -47,6 +47,9 @@ typedef struct app_config {
     int fips_validation;
     int get_expected;
     int save_to;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    int disable_fips;
+#endif
     char reg_file[JSON_FILENAME_LENGTH + 1];
     char vector_req_file[JSON_FILENAME_LENGTH + 1];
     char vector_rsp_file[JSON_FILENAME_LENGTH + 1];
@@ -135,6 +138,7 @@ int app_safe_primes_handler(ACVP_TEST_CASE *test_case);
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 int app_aes_handler_gmac(ACVP_TEST_CASE *test_case);
+ACVP_RESULT fips_sanity_check(void);
 const char *get_string_from_oid(unsigned char *oid, int oid_len);
 #endif
 

--- a/configure
+++ b/configure
@@ -790,8 +790,6 @@ CRITERION_CFLAGS
 CLEANFILES
 LIBACVP_CFLAGS
 LIBACVP_LDFLAGS
-USE_FIPS_PROVIDER_FALSE
-USE_FIPS_PROVIDER_TRUE
 USE_FOM_OBJ_FALSE
 USE_FOM_OBJ_TRUE
 FOM_LDFLAGS
@@ -936,8 +934,6 @@ enable_lib
 with_libacvp_dir
 with_ssl_dir
 with_fom_dir
-enable_fips
-enable_runtime_fips
 enable_offline
 with_libcurl_dir
 with_libmurl_dir
@@ -1593,10 +1589,6 @@ Optional Features:
   --disable-libtool-lock  avoid locking (might break parallel builds)
   --disable-app           To build library only and not app code
   --disable-lib           To build acvp_app only without library
-  --enable-fips           Use FIPS mode with a build of SSL that supports
-                          testing all algorithms
-  --enable-runtime-fips   Use FIPS mode with a regular FIPS build of SSL, only
-                          supports some algorithms
   --enable-offline        Flag to indicate use of offline mode
   --enable-cflags         Flag to indicate use of enhanced CFLAGS
   --disable-kdf           For use if using a FOM with no KDF support, such as
@@ -4961,13 +4953,13 @@ if ${lt_cv_nm_interface+:} false; then :
 else
   lt_cv_nm_interface="BSD nm"
   echo "int some_variable = 0;" > conftest.$ac_ext
-  (eval echo "\"\$as_me:4964: $ac_compile\"" >&5)
+  (eval echo "\"\$as_me:4956: $ac_compile\"" >&5)
   (eval "$ac_compile" 2>conftest.err)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4967: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
+  (eval echo "\"\$as_me:4959: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
   (eval "$NM \"conftest.$ac_objext\"" 2>conftest.err > conftest.out)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4970: output\"" >&5)
+  (eval echo "\"\$as_me:4962: output\"" >&5)
   cat conftest.out >&5
   if $GREP 'External.*some_variable' conftest.out > /dev/null; then
     lt_cv_nm_interface="MS dumpbin"
@@ -6172,7 +6164,7 @@ ia64-*-hpux*)
   ;;
 *-*-irix6*)
   # Find out which ABI we are using.
-  echo '#line 6175 "configure"' > conftest.$ac_ext
+  echo '#line 6167 "configure"' > conftest.$ac_ext
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
@@ -7701,11 +7693,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7704: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7696: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7708: \$? = $ac_status" >&5
+   echo "$as_me:7700: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8040,11 +8032,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8043: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8035: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:8047: \$? = $ac_status" >&5
+   echo "$as_me:8039: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8145,11 +8137,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8148: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8140: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8152: \$? = $ac_status" >&5
+   echo "$as_me:8144: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -8200,11 +8192,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8203: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8195: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8207: \$? = $ac_status" >&5
+   echo "$as_me:8199: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -10570,7 +10562,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10573 "configure"
+#line 10565 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -10666,7 +10658,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10669 "configure"
+#line 10661 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -10986,22 +10978,7 @@ else
   with_fomdir=no
 fi
 
-    # If using SSL >= 3.0.0, just enable fips, no path needed
-    # Check whether --enable-fips was given.
-if test "${enable_fips+set}" = set; then :
-  enableval=$enable_fips; use_dev_fips="yes"
-else
-  use_dev_fips="no"
-fi
-
-    #Only supports subset of algorithms due to needed intermediate values
-    # Check whether --enable-runtime-fips was given.
-if test "${enable_runtime_fips+set}" = set; then :
-  enableval=$enable_runtime_fips; use_runtime_fips="yes"
-else
-  use_runtime_fips="no"
-fi
-
+    # If using SSL >= 3.0.0, FIPS is mananged at runtime
 fi
 
 # Offline mode
@@ -11594,20 +11571,6 @@ as_fn_error $? "--with-fom-dir should not be provided with versions of SSL great
                     use --enable-fips or --enable-runtime-fips instead
 See \`config.log' for more details" "$LINENO" 5; }
 fi
-if test "x$use_ssl_3" = "xtrue" && test "x$use_dev_fips" != "xno" && test "x$use_runtime_fips" != "xno" ; then
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "Either --enable-fips or --enable-runtime-fips can be used, but not both. See the README
-                    for more information.
-See \`config.log' for more details" "$LINENO" 5; }
-fi
-if test "x$use_ssl_3" != "xtrue" && (test "x$use_dev_fips" != "xno"|| test "x$use_runtime_fips" != "xno") ; then
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "For versions of SSL under 3.0.0, use --with-fom-dir=<path> to use FIPS, not --enable-fips or
-                    --enable-runtime-fips
-See \`config.log' for more details" "$LINENO" 5; }
-fi
 
 if test "x$disable_app" = "xno" ; then
     SSL_CFLAGS="-I$ssldir/include"
@@ -11647,12 +11610,6 @@ if test "x$with_fomdir" != "xno" ; then
 
     FOM_OBJ_DIR="$fomdir/lib"
 
-elif test "x$use_dev_fips" != "xno" ; then
-    FOM_CFLAGS="-DACVP_NO_RUNTIME"
-
-elif test "x$use_runtime_fips" != "xno" ; then
-    FOM_CFLAGS="-DACVP_FIPS_RUNTIME"
-
 fi
  if test "x$with_fomdir" != "xno"; then
   USE_FOM_OBJ_TRUE=
@@ -11660,14 +11617,6 @@ fi
 else
   USE_FOM_OBJ_TRUE='#'
   USE_FOM_OBJ_FALSE=
-fi
-
- if test "x$use_dev_fips" != "xno" || test "x$use_runtime_fips" != "xno"; then
-  USE_FIPS_PROVIDER_TRUE=
-  USE_FIPS_PROVIDER_FALSE='#'
-else
-  USE_FIPS_PROVIDER_TRUE='#'
-  USE_FIPS_PROVIDER_FALSE=
 fi
 
 
@@ -11960,10 +11909,6 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${USE_FOM_OBJ_TRUE}" && test -z "${USE_FOM_OBJ_FALSE}"; then
   as_fn_error $? "conditional \"USE_FOM_OBJ\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${USE_FIPS_PROVIDER_TRUE}" && test -z "${USE_FIPS_PROVIDER_FALSE}"; then
-  as_fn_error $? "conditional \"USE_FIPS_PROVIDER\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${UNIT_TEST_SUPPORTED_TRUE}" && test -z "${UNIT_TEST_SUPPORTED_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -101,16 +101,7 @@ if test "x$disable_app" = "xno" ; then
         [Path to FOM install directory])],
         [fomdir="$withval"],
         [with_fomdir=no])
-    # If using SSL >= 3.0.0, just enable fips, no path needed
-    AC_ARG_ENABLE([fips],
-    [AS_HELP_STRING([--enable-fips], [Use FIPS mode with a build of SSL that supports testing all algorithms])],
-    [use_dev_fips="yes"],
-    [use_dev_fips="no"])
-    #Only supports subset of algorithms due to needed intermediate values
-    AC_ARG_ENABLE([runtime-fips],
-    [AS_HELP_STRING([--enable-runtime-fips], [Use FIPS mode with a regular FIPS build of SSL, only supports some algorithms])],
-    [use_runtime_fips="yes"],
-    [use_runtime_fips="no"])
+    # If using SSL >= 3.0.0, FIPS is mananged at runtime
 fi
 
 # Offline mode
@@ -282,14 +273,6 @@ if test "x$use_ssl_3" = "xtrue" && test "x$with_fomdir" != "xno" ; then
     AC_MSG_FAILURE([--with-fom-dir should not be provided with versions of SSL greater than 1.1.1;
                     use --enable-fips or --enable-runtime-fips instead])
 fi
-if test "x$use_ssl_3" = "xtrue" && test "x$use_dev_fips" != "xno" && test "x$use_runtime_fips" != "xno" ; then
-    AC_MSG_FAILURE([Either --enable-fips or --enable-runtime-fips can be used, but not both. See the README
-                    for more information.])
-fi
-if test "x$use_ssl_3" != "xtrue" && (test "x$use_dev_fips" != "xno"|| test "x$use_runtime_fips" != "xno") ; then
-    AC_MSG_FAILURE([For versions of SSL under 3.0.0, use --with-fom-dir=<path> to use FIPS, not --enable-fips or
-                    --enable-runtime-fips])
-fi
 
 if test "x$disable_app" = "xno" ; then
     AC_SUBST([SSL_CFLAGS], "-I$ssldir/include")
@@ -319,13 +302,8 @@ if test "x$with_fomdir" != "xno" ; then
     AC_SUBST([FOM_CFLAGS], "-DACVP_NO_RUNTIME -DOPENSSL_FIPS -I$fomdir/include")
     AC_SUBST([FOM_LDFLAGS], "-L$fomdir/lib")
     AC_SUBST([FOM_OBJ_DIR], "$fomdir/lib")
-elif test "x$use_dev_fips" != "xno" ; then
-    AC_SUBST([FOM_CFLAGS], "-DACVP_NO_RUNTIME")
-elif test "x$use_runtime_fips" != "xno" ; then
-    AC_SUBST([FOM_CFLAGS], "-DACVP_FIPS_RUNTIME")
 fi
 AM_CONDITIONAL([USE_FOM_OBJ], [test "x$with_fomdir" != "xno"])
-AM_CONDITIONAL([USE_FIPS_PROVIDER], [test "x$use_dev_fips" != "xno" || test "x$use_runtime_fips" != "xno"])
 
 #Conditionally included algorithms should be added to cond_alg_cflags here
 if test "x$disable_kdf" != "xfalse" || test "x$use_ssl_3" = "xtrue"; then


### PR DESCRIPTION
Because all ACVP testing can be done using public APIs in 3.X, we don't need to indicate FIPS mode at build time; we can just assume it is FIPS mode and give the user a run time argument they can use to disable fips (--disable_fips) if they need for some reason.

If FIPS is disabled, a warning is printed + 5 seconds of sleep just to emphasize.

If FIPS is enabled, we do a quick digest to sanity check  of crypto operations (EVP_Q_digest) on the FIPS provider. Otherwise, if something is wrong loading the FIPS provider, we will get a vague error doing something else down the road (usually, generating the TOTP).