### PR TITLE
Update KDA implementation to match ACVP updates (1.5.0)

### DIFF
--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -1909,6 +1909,7 @@ typedef enum acvp_kda_param {
     ACVP_KDA_Z,
     ACVP_KDA_L,
     ACVP_KDA_MAC_SALT,
+    ACVP_KDA_USE_HYBRID_SECRET,
     ACVP_KDA_HKDF_HMAC_ALG,
     ACVP_KDA_ONESTEP_AUX_FUNCTION
 } ACVP_KDA_PARM;
@@ -1971,6 +1972,7 @@ typedef struct acvp_kda_hkdf_tc_t {
     unsigned char *salt;
     unsigned char *z;
     unsigned char *t;
+    int uses_hybrid_secret;
     int l;
     int saltLen;
     int zLen;

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1433,6 +1433,8 @@ typedef struct acvp_kda_hkdf_t {
     ACVP_NAME_LIST *mac_salt_methods;
     ACVP_JSON_DOMAIN_OBJ z;
     int l;
+    int use_hybrid_shared_secret; /* 56Cr2 only */
+    ACVP_JSON_DOMAIN_OBJ aux_secret_len; /* 56Cr2 only */
 } ACVP_KDA_HKDF_CAP;
 
 typedef struct acvp_kts_ifc_macs_t {

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -3720,6 +3720,31 @@ static ACVP_RESULT acvp_build_kda_hkdf_register_cap(ACVP_CTX *ctx,
     json_object_set_number(tmp_obj, "max", cap_entry->cap.kda_hkdf_cap->z.max);
     json_object_set_number(tmp_obj, "increment", cap_entry->cap.kda_hkdf_cap->z.increment);
     json_array_append_value(temp_arr, tmp_val);
+
+    /* Append the "usesHybridShareSecret" value and "auxSharedSecretLen" value if enabled */
+    if (cap_entry->cap.kda_hkdf_cap->use_hybrid_shared_secret) {
+        json_object_set_boolean(cap_obj, "usesHybridSharedSecret", 1);
+        json_object_set_value(cap_obj, "auxSharedSecretLen", json_value_init_array());
+        temp_arr = json_object_get_array(cap_obj, "auxSharedSecretLen");
+
+        if (cap_entry->cap.kda_hkdf_cap->aux_secret_len.min != 0 ||
+                cap_entry->cap.kda_hkdf_cap->aux_secret_len.max != 0 ||
+                cap_entry->cap.kda_hkdf_cap->aux_secret_len.increment != 0) {
+            tmp_val = json_value_init_object();
+            tmp_obj = json_value_get_object(tmp_val);
+            json_object_set_number(tmp_obj, "min", cap_entry->cap.kda_hkdf_cap->aux_secret_len.min);
+            json_object_set_number(tmp_obj, "max", cap_entry->cap.kda_hkdf_cap->aux_secret_len.max);
+            json_object_set_number(tmp_obj, "increment", cap_entry->cap.kda_hkdf_cap->aux_secret_len.increment);
+            json_array_append_value(temp_arr, tmp_val);
+        }
+
+        if (cap_entry->cap.kda_hkdf_cap->aux_secret_len.value) {
+            json_array_append_number(temp_arr, cap_entry->cap.kda_hkdf_cap->aux_secret_len.value);
+        }
+    } else if (!cap_entry->cap.kda_hkdf_cap->revision) {
+        /* Only applies if using default revision */
+        json_object_set_boolean(cap_obj, "usesHybridSharedSecret", 0);
+    }
 err:
     if (pattern_str) free(pattern_str);
     return rv;

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -7430,6 +7430,7 @@ ACVP_RESULT acvp_cap_kda_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KDA_PA
             result = acvp_append_name_list(&cap_list->cap.kda_onestep_cap->aux_functions, tmp);
             break;
         case ACVP_KDA_Z:
+        case ACVP_KDA_USE_HYBRID_SECRET:
         default:
             ACVP_LOG_ERR("Invalid parameter specified");
             return ACVP_INVALID_ARG;
@@ -7463,6 +7464,10 @@ ACVP_RESULT acvp_cap_kda_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KDA_PA
                 }
                 strncpy_s(cap_list->cap.kda_hkdf_cap->literal_pattern_candidate, 
                           ACVP_KDA_PATTERN_LITERAL_STR_LEN_MAX, string, len);
+            }
+            if (value == ACVP_KDA_PATTERN_T) {
+                ACVP_LOG_ERR("T is only a valid pattern for KDA onestep");
+                return ACVP_INVALID_ARG;
             }
             if (value > ACVP_KDA_PATTERN_NONE && value < ACVP_KDA_PATTERN_MAX) {
                 result = acvp_append_param_list(&cap_list->cap.kda_hkdf_cap->patterns, value);
@@ -7508,6 +7513,15 @@ ACVP_RESULT acvp_cap_kda_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KDA_PA
                 ACVP_LOG_ERR("Invalid value for ACVK_KDA_MAC_SALT");
                 return ACVP_INVALID_ARG;
             }
+            break;
+        case ACVP_KDA_USE_HYBRID_SECRET:
+            /* revision is only set for non-default revisions */
+            if (cap_list->cap.kda_hkdf_cap->revision) {
+                ACVP_LOG_ERR("Hybrid secrets for HKDF can only be set for revision SP800-56Cr2");
+                return ACVP_INVALID_ARG;
+            }
+            cap_list->cap.kda_hkdf_cap->aux_secret_len.value = value;
+            cap_list->cap.kda_hkdf_cap->use_hybrid_shared_secret = 1;
             break;
         case ACVP_KDA_HKDF_HMAC_ALG:
             tmp = acvp_lookup_hmac_alg_str(value);
@@ -7563,12 +7577,8 @@ ACVP_RESULT acvp_cap_kda_set_domain(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KDA_
         ACVP_LOG_ERR("Cap entry not found.");
         return ACVP_NO_CAP;
     }
-    if (param != ACVP_KDA_Z) {
-        ACVP_LOG_ERR("Invalid parameter provided");
-        return ACVP_INVALID_ARG;
-    }
 
-    if (min < 0 || increment % 8 != 0 || max < min || max - min < 8) {
+    if (min < 0 || max < min || max - min < 8) {
         ACVP_LOG_ERR("Invalid domain given");
     }
 
@@ -7584,18 +7594,73 @@ ACVP_RESULT acvp_cap_kda_set_domain(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KDA_
             ACVP_LOG_ERR("KDA onestep cap entry not found.");
             return ACVP_NO_CAP;
         }
-        cap_list->cap.kda_onestep_cap->z.min = min;
-        cap_list->cap.kda_onestep_cap->z.max = max;
-        cap_list->cap.kda_onestep_cap->z.increment = increment;
+
+        switch(param) {
+        case ACVP_KDA_Z:
+            if (min < 224 || max > 65536 || increment % 8 != 0) {
+                ACVP_LOG_ERR("Invalid Z domain provided for KDA onestep");
+                return ACVP_INVALID_ARG;
+            }
+            cap_list->cap.kda_onestep_cap->z.min = min;
+            cap_list->cap.kda_onestep_cap->z.max = max;
+            cap_list->cap.kda_onestep_cap->z.increment = increment;
+            break;
+        case ACVP_KDA_USE_HYBRID_SECRET:
+            ACVP_LOG_ERR("Hybrid secret only applies to HKDF, not onestep");
+            return ACVP_INVALID_ARG;
+        case ACVP_KDA_PATTERN:
+        case ACVP_KDA_REVISION:
+        case ACVP_KDA_ENCODING_TYPE:
+        case ACVP_KDA_L:
+        case ACVP_KDA_MAC_SALT:
+        case ACVP_KDA_HKDF_HMAC_ALG:
+        case ACVP_KDA_ONESTEP_AUX_FUNCTION:
+        default:
+            ACVP_LOG_ERR("Invalid domain param provided for KDA");
+            return ACVP_INVALID_ARG;
+        }
         break;
     case ACVP_SUB_KDA_HKDF:
         if (!cap_list->cap.kda_hkdf_cap) {
             ACVP_LOG_ERR("KDA-HKDF entry not found.");
             return ACVP_NO_CAP;
         }
-        cap_list->cap.kda_hkdf_cap->z.min = min;
-        cap_list->cap.kda_hkdf_cap->z.max = max;
-        cap_list->cap.kda_hkdf_cap->z.increment = increment;
+
+        switch(param) {
+        case ACVP_KDA_Z:
+            if (min < 224 || max > 65536 || increment % 8 != 0) {
+                ACVP_LOG_ERR("Invalid Z domain provided for HKDF");
+                return ACVP_INVALID_ARG;
+            }
+            cap_list->cap.kda_hkdf_cap->z.min = min;
+            cap_list->cap.kda_hkdf_cap->z.max = max;
+            cap_list->cap.kda_hkdf_cap->z.increment = increment;
+            break;
+        case ACVP_KDA_USE_HYBRID_SECRET:
+            if (cap_list->cap.kda_hkdf_cap->revision) {
+                ACVP_LOG_ERR("Hybrid secrets for HKDF can only be set for revision SP800-56Cr2");
+                return ACVP_INVALID_ARG;
+            }
+            if (min < 112 || max > 65536 || increment % 8 != 0) {
+                ACVP_LOG_ERR("Invalid aux secret len domain provided for HKDF");
+                return ACVP_INVALID_ARG;
+            }
+            cap_list->cap.kda_hkdf_cap->aux_secret_len.min = min;
+            cap_list->cap.kda_hkdf_cap->aux_secret_len.max = max;
+            cap_list->cap.kda_hkdf_cap->aux_secret_len.increment = increment;
+            cap_list->cap.kda_hkdf_cap->use_hybrid_shared_secret = 1;
+            break;
+        case ACVP_KDA_PATTERN:
+        case ACVP_KDA_REVISION:
+        case ACVP_KDA_ENCODING_TYPE:
+        case ACVP_KDA_L:
+        case ACVP_KDA_MAC_SALT:
+        case ACVP_KDA_HKDF_HMAC_ALG:
+        case ACVP_KDA_ONESTEP_AUX_FUNCTION:
+        default:
+            ACVP_LOG_ERR("Invalid domain param provided for KDA");
+            return ACVP_INVALID_ARG;
+        }
         break;
     case ACVP_SUB_KAS_ECC_CDH:
     case ACVP_SUB_KAS_ECC_COMP:

--- a/src/acvp_kda.c
+++ b/src/acvp_kda.c
@@ -254,6 +254,7 @@ static ACVP_RESULT acvp_kda_hkdf_init_tc(ACVP_CTX *ctx,
                                              ACVP_KDA_HKDF_TC *stc,
                                              const int tc_id,
                                              ACVP_HASH_ALG hmac_alg,
+                                             int hybrid_secret,
                                              const char *salt,
                                              const char *z,
                                              const char *t,
@@ -279,6 +280,7 @@ static ACVP_RESULT acvp_kda_hkdf_init_tc(ACVP_CTX *ctx,
     stc->l = l / 8;
     stc->encoding = encoding;
     stc->saltMethod = saltMethod;
+    stc->uses_hybrid_secret = hybrid_secret;
 
     if (memcpy_s(stc->fixedInfoPattern, ACVP_KDA_PATTERN_MAX * sizeof(int), fixedArr, ACVP_KDA_PATTERN_MAX * sizeof(int))) {
         ACVP_LOG_ERR("Error copying array of fixedInfoPattern candidates into test case structure");
@@ -675,7 +677,7 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
                *salt_method_str = NULL;
     ACVP_HASH_ALG hmac_alg = 0;
     unsigned int i = 0, g_cnt = 0;
-    int j = 0, k = 0, t_cnt = 0, tc_id = 0, saltLen = 0, l = 0, tmp = 0;
+    int j = 0, k = 0, t_cnt = 0, tc_id = 0, saltLen = 0, l = 0, tmp = 0, hybrid_secret = 0;
     ACVP_RESULT rv;
     const char *test_type_str = NULL;
     ACVP_KDA_TEST_TYPE test_type;
@@ -829,6 +831,9 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
                 goto err;
             }
         }
+
+        /* in case of value not existing or being false, we have the same outcome */
+        hybrid_secret = json_object_get_boolean(paramobj, "usesHybridSharedSecret");
 
         json_object_set_value(r_gobj, "tests", json_value_init_array());
         r_tarr = json_object_get_array(r_gobj, "tests");
@@ -997,6 +1002,15 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
                 }
             }
 
+            if (!t && json_object_has_value(paramobj, "t") && hybrid_secret) {
+                t = json_object_get_string(paramobj, "t");
+                if (!t) {
+                    ACVP_LOG_ERR("Server JSON missing 't'");
+                    rv = ACVP_MALFORMED_JSON;
+                    goto err;
+                }
+            }
+
             if (test_type == ACVP_KDA_TT_VAL) {
                 /*
                  * Validate
@@ -1052,7 +1066,7 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
              * the crypto module.
              */
             if (cipher == ACVP_KDA_HKDF) {
-                rv = acvp_kda_hkdf_init_tc(ctx, tc->tc.kda_hkdf, tc_id, hmac_alg, salt, z, t, uparty, uephemeral,
+                rv = acvp_kda_hkdf_init_tc(ctx, tc->tc.kda_hkdf, tc_id, hmac_alg, hybrid_secret, salt, z, t, uparty, uephemeral,
                                             vparty, vephemeral, algid, context, label, dkm, l, saltLen,
                                             salt_method, encoding, arr, test_type);
             } else {


### PR DESCRIPTION
Note: this fix requires more work for the TBD branch as it supports twostep (this branch does not) and has some structural differences inside the library. That PR will be later (this week).

Previously for HKDF, aux shared secrets were considered to be part of the fixedInfo. This works for onestep, but not for hkdf or twostep. Server now has aux shared secret (t) as a separate entity. In libacvp, registering any value for the hybrid secret param enables it, and sets that value as a length.