### PR TITLE
Added vs count functionality, fixed ms build

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -251,6 +251,7 @@ static ko_longopt_t longopts[] = {
     { "save_to", ko_required_argument, 413 },
     { "delete", ko_required_argument, 414 },
     { "cancel_session", ko_required_argument, 415 },
+    { "cost", ko_no_argument, 416 },
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     { "disable_fips", ko_no_argument, 500 },
 #endif
@@ -567,6 +568,10 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
                 return 1;
             }
             strcpy_s(cfg->session_file, JSON_FILENAME_LENGTH + 1, opt.arg);
+            break;
+
+        case 416:
+            cfg->get_cost = 1;
             break;
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -47,6 +47,7 @@ typedef struct app_config {
     int fips_validation;
     int get_expected;
     int save_to;
+    int get_cost;
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     int disable_fips;
 #endif

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -354,6 +354,16 @@ int main(int argc, char **argv) {
 #endif
     }
 
+    if (cfg.get_cost) {
+        diff = acvp_get_vector_set_count(ctx);
+        if (diff < 0) {
+            printf("Unable to get expected vector set count with given test session context.\n\n");
+        } else {
+            printf("The given test session context is expected to generate %d vector sets.\n\n", diff);
+        }
+        goto end;
+    }
+
     if (cfg.kat) {
        rv = acvp_load_kat_filename(ctx, cfg.kat_file);
        goto end;

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -4147,6 +4147,16 @@ ACVP_RESULT acvp_mark_as_delete_only(ACVP_CTX *ctx, char *request_url);
  */
 ACVP_RESULT acvp_mark_as_put_after_test(ACVP_CTX *ctx, char *filename);
 
+/**
+ * @brief acvp_get_vector_set_count will return the number of vector sets that are expected based on the current
+ * registration. This should be seen as a close estimate not an exact number, as different ACVP servers could
+ * possibly have different behaviors.
+ *
+ * @param ctx Pointer to ACVP_CTX with registered algorithms
+ *
+ * @return Count of expected vector sets
+ */
+int acvp_get_vector_set_count(ACVP_CTX *ctx);
 
 /**
  * @brief Performs the ACVP testing procedures.

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1787,6 +1787,8 @@ struct acvp_ctx_t {
 
     /* crypto module capabilities list */
     ACVP_CAPS_LIST *caps_list;
+    /* Maintain a count of the number of registered vector sets so we can evaluate cost. This can be >= caps_list size */
+    int vs_count;
 
     /* application callbacks */
     ACVP_RESULT (*test_progress_cb) (char *msg);

--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -53,11 +53,13 @@ EXPORTS
   acvp_cap_kdf135_srtp_enable
   acvp_cap_kdf135_ikev2_enable
   acvp_cap_kdf135_ikev1_enable
+  acvp_cap_kdf135_x942_enable
   acvp_cap_kdf135_x963_enable
   acvp_cap_kdf108_enable
   acvp_cap_kdf135_ssh_set_parm
   acvp_cap_kdf135_srtp_set_parm
   acvp_cap_kdf108_set_parm
+  acvp_cap_kdf135_x942_set_parm
   acvp_cap_kdf135_x963_set_parm
   acvp_cap_kdf135_snmp_set_parm
   acvp_cap_kdf135_snmp_set_engid
@@ -67,6 +69,7 @@ EXPORTS
   acvp_cap_kdf135_ikev2_set_domain
   acvp_cap_kdf135_ikev1_set_domain
   acvp_cap_kdf108_set_domain
+  acvp_cap_kdf135_x942_set_domain
   acvp_cap_pbkdf_enable
   acvp_cap_pbkdf_set_domain
   acvp_cap_pbkdf_set_parm

--- a/ms/resources/libacvp.vcxproj
+++ b/ms/resources/libacvp.vcxproj
@@ -411,6 +411,7 @@
     <ClCompile Include="..\..\src\acvp_kdf135_snmp.c" />
     <ClCompile Include="..\..\src\acvp_kdf135_srtp.c" />
     <ClCompile Include="..\..\src\acvp_kdf135_ssh.c" />
+    <ClCompile Include="..\..\src\acvp_kdf135_x942.c" />
     <ClCompile Include="..\..\src\acvp_kdf135_x963.c" />
     <ClCompile Include="..\..\src\acvp_operating_env.c" />
     <ClCompile Include="..\..\src\acvp_rsa_keygen.c" />

--- a/ms/resources/libacvp.vcxproj.filters
+++ b/ms/resources/libacvp.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClCompile Include="..\..\src\acvp_kdf135_ssh.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\acvp_kdf135_x942.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\acvp_kdf135_x963.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2095,6 +2095,13 @@ ACVP_RESULT acvp_mark_as_delete_only(ACVP_CTX *ctx, char *request_url) {
     return ACVP_SUCCESS;
 }
 
+int acvp_get_vector_set_count(ACVP_CTX *ctx) {
+    if (!ctx) {
+        return -1;
+    }
+    return ctx->vs_count;
+}
+
 /*
  * This function builds the JSON login message that
  * will be sent to the ACVP server. If enabled,

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -636,6 +636,8 @@ static ACVP_RESULT acvp_cap_list_append(ACVP_CTX *ctx,
         cap_e2->next = cap_entry;
     }
 
+    /* Assume here one cap = one vector set; for special cases we will handle those as the parameter is set */
+    ctx->vs_count++;
     return ACVP_SUCCESS;
 
 err:
@@ -2560,6 +2562,10 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
 
     case ACVP_SYM_CIPH_PARM_IVGEN_SRC:
         if (value > 0 && value < ACVP_SYM_CIPH_IVGEN_SRC_MAX) {
+            if (value == ACVP_SYM_CIPH_IVGEN_SRC_EITHER) {
+                /* This will generate two vector sets, one for internal ivgen and one for external */
+                ctx->vs_count++;
+            }
             cap->cap.sym_cap->ivgen_source = value;
             return ACVP_SUCCESS;
         } else {
@@ -4958,6 +4964,10 @@ ACVP_RESULT acvp_cap_ecdsa_set_parm(ACVP_CTX *ctx,
     case ACVP_ECDSA_COMPONENT_TEST:
         if (cipher == ACVP_ECDSA_SIGGEN || cipher == ACVP_ECDSA_SIGVER) {
             if (value >= ACVP_ECDSA_COMPONENT_MODE_NO && value <= ACVP_ECDSA_COMPONENT_MODE_BOTH) {
+                if (value == ACVP_ECDSA_COMPONENT_MODE_BOTH) {
+                    /* This will generate two vector sets, one for and one not for component mode */
+                    ctx->vs_count++;
+                }
                 cap->component = value;
             } else {
                 ACVP_LOG_ERR("Invalid value given for ECDSA component test mode");

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -837,6 +837,20 @@ Test(PROCESS_TESTS, mark_as_delete_only, .init = setup_full_ctx, .fini = teardow
 }
 
 /*
+ * Test acvp_get_vector_set_count
+ */
+Test(PROCESS_TESTS, get_vector_set_count, .init = setup_full_ctx, .fini = teardown) {
+    int count = 0;
+    count = acvp_get_vector_set_count(NULL);
+    cr_assert(count < 0);
+
+    count = acvp_get_vector_set_count(ctx);
+    cr_assert(count > 0);
+    cr_assert(count < 10000); /* An arbitrarily large number that should never be reached */
+
+}
+
+/*
  * Test acvp_mark_as_put_after_test
  */
 Test(PROCESS_TESTS, mark_as_put_after_test, .init = setup_full_ctx, .fini = teardown) {


### PR DESCRIPTION
Added API and app behavior for giving the expected number of vector sets from the current test session registration. This could be useful if a user has a limited number of vector sets available for use with the ACVP server and wants to know in advance what to expect.

Also fixed an MS build error from missing x942 KDF references.