### PR TITLE
Fix empty inputs on entropyInput for ctrdrbg

### DIFF
--- a/app/app_drbg.c
+++ b/app/app_drbg.c
@@ -229,8 +229,8 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
         printf("Missing entropy input needed for reseed\n");
         return 1;
     }
-    if (!drbg_entropy_len || !tc->pr1_len || !tc->pr2_len ||
-        !tc->entropy || !tc->entropy_input_pr_1 || !tc->entropy_input_pr_2) {
+    if (!drbg_entropy_len || !tc->entropy || !tc->entropy_input_pr_1 ||
+	!tc->entropy_input_pr_2) {
         printf("Insufficient entropy for testing DRBG\n");
         return 1;
     }


### PR DESCRIPTION
From https://github.com/cisco/libacvp/pull/753

There were some ACVP test vectors we were trying to parse, which had empty inputs for `entropyInput` in the `otherInput` vectors. The field exists, but the string length is `0`. 
I assume `!tc->pr1_len || !tc->pr2_len` are helping to check if the field exists, but because the length is `0`, this causes DRBG ACVP parsing to fail prematurely.

I found an example of such case here: https://pages.nist.gov/ACVP/draft-vassilev-acvp-drbg.html#section-13-7. Although the example is for `ACVP_DRBG_SHA_256`, such cases do exists for `ACVP_DRBG_AES_128/192/256` as well.

Tested with OpenSSL 1.0.2.
