### PR TITLE
Change to logging structure, updates to logs in a few places

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -17,9 +17,6 @@
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
 
-#define ANSI_COLOR_RED "\x1b[31m"
-#define ANSI_COLOR_YELLOW "\x1b[33m"
-#define ANSI_COLOR_RESET "\x1b[0m"
 #define ACVP_APP_HELP_MSG "Use acvp_app --help for more information."
 
 static void print_usage(int code) {
@@ -252,6 +249,7 @@ static ko_longopt_t longopts[] = {
     { "delete", ko_required_argument, 414 },
     { "cancel_session", ko_required_argument, 415 },
     { "cost", ko_no_argument, 416 },
+    { "debug", ko_no_argument, 417 },
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     { "disable_fips", ko_no_argument, 500 },
 #endif
@@ -572,6 +570,10 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
 
         case 416:
             cfg->get_cost = 1;
+            break;
+
+        case 417:
+            cfg->level = ACVP_LOG_LVL_DEBUG;
             break;
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -28,6 +28,10 @@ extern "C"
 #define ALG_STR_MAX_LEN 256 /* arbitrary */
 extern char value[JSON_STRING_LENGTH];
 
+#define ANSI_COLOR_RED "\x1b[31m"
+#define ANSI_COLOR_YELLOW "\x1b[33m"
+#define ANSI_COLOR_RESET "\x1b[0m"
+
 typedef struct app_config {
     ACVP_LOG_LVL level;
     int sample;

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -141,13 +141,30 @@ static int verify_algorithms(APP_CONFIG *cfg) {
     return rv;
 }
 
-/*
- * This is a minimal and rudimentary logging handler.
- * libacvp calls this function to for debugs, warnings,
- * and errors.
- */
-static ACVP_RESULT progress(char *msg) {
-    printf("%s", msg);
+/* libacvp calls this function for status updates, debugs, warnings, and errors. */
+static ACVP_RESULT progress(char *msg, ACVP_LOG_LVL level) {
+
+    printf("[ACVP]");
+
+    switch (level) {
+    case ACVP_LOG_LVL_ERR:
+        printf(ANSI_COLOR_RED "[ERROR]" ANSI_COLOR_RESET);
+        break;
+    case ACVP_LOG_LVL_WARN:
+        printf(ANSI_COLOR_YELLOW "[WARNING]" ANSI_COLOR_RESET);
+        break;
+    case ACVP_LOG_LVL_STATUS:
+    case ACVP_LOG_LVL_INFO:
+    case ACVP_LOG_LVL_VERBOSE:
+    case ACVP_LOG_LVL_DEBUG:
+    case ACVP_LOG_LVL_NONE:
+    case ACVP_LOG_LVL_MAX:
+    default:
+        break;
+    }
+
+    printf(": %s\n", msg);
+
     return ACVP_SUCCESS;
 }
 

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -52,7 +52,8 @@ typedef enum acvp_log_lvl {
     ACVP_LOG_LVL_STATUS,
     ACVP_LOG_LVL_INFO,
     ACVP_LOG_LVL_VERBOSE,
-    ACVP_LOG_LVL_MAX = ACVP_LOG_LVL_VERBOSE,
+    ACVP_LOG_LVL_DEBUG,
+    ACVP_LOG_LVL_MAX
 } ACVP_LOG_LVL;
 
 /**
@@ -3976,7 +3977,7 @@ ACVP_RESULT acvp_cap_set_prereq(ACVP_CTX *ctx,
  * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_create_test_session(ACVP_CTX **ctx,
-                                     ACVP_RESULT (*progress_cb)(char *msg),
+                                     ACVP_RESULT (*progress_cb)(char *msg, ACVP_LOG_LVL level),
                                      ACVP_LOG_LVL level);
 
 /**

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -177,7 +177,7 @@ ACVP_ALG_HANDLER alg_tbl[ACVP_ALG_MAX] = {
  * a new context to be used for the test session.
  */
 ACVP_RESULT acvp_create_test_session(ACVP_CTX **ctx,
-                                     ACVP_RESULT (*progress_cb)(char *msg),
+                                     ACVP_RESULT (*progress_cb)(char *msg, ACVP_LOG_LVL level),
                                      ACVP_LOG_LVL level) {
     if (!ctx) {
         return ACVP_INVALID_ARG;
@@ -195,7 +195,10 @@ ACVP_RESULT acvp_create_test_session(ACVP_CTX **ctx,
         (*ctx)->test_progress_cb = progress_cb;
     }
 
-    (*ctx)->debug = level;
+    (*ctx)->log_lvl= level;
+    if (level >= ACVP_LOG_LVL_DEBUG) {
+        (*ctx)->debug = 1;
+    }
 
     return ACVP_SUCCESS;
 }
@@ -1292,7 +1295,7 @@ ACVP_RESULT acvp_upload_vectors_from_file(ACVP_CTX *ctx, const char *rsp_filenam
         ctx->kat_resp = vec_array_val;
 
         json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
-        if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        if (ctx->log_lvl == ACVP_LOG_LVL_VERBOSE) {
             printf("\n\n%s\n\n", json_result);
         } else {
             ACVP_LOG_INFO("\n\n%s\n\n", json_result);
@@ -1432,7 +1435,6 @@ ACVP_RESULT acvp_get_expected_results(ACVP_CTX *ctx, const char *request_filenam
     }
 
     ACVP_LOG_STATUS("Beginning output of expected results...");
-    ACVP_LOG_NEWLINE;
 
     if (save_filename) {
         //write the session URL and JWT to the file first
@@ -2799,7 +2801,7 @@ static ACVP_RESULT acvp_login(ACVP_CTX *ctx, int refresh) {
      */
     rv = acvp_send_login(ctx, login, login_len);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_STATUS("Login Send Failed");
+        ACVP_LOG_ERR("Login Send Failed");
         goto end;
     }
 
@@ -3223,7 +3225,7 @@ static ACVP_RESULT acvp_get_result_test_session(ACVP_CTX *ctx, char *session_url
                 strcmp_s("error", 5, status, &diff);
             if (!diff) {
                 const char *vs_url = json_object_get_string(current, "vectorSetUrl");
-                if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+                if (ctx->log_lvl == ACVP_LOG_LVL_VERBOSE) {
                     ACVP_LOG_STATUS("Getting details for failed Vector Set...");
                     rv = acvp_retrieve_vector_set_result(ctx, vs_url);
                     printf("\n%s\n", ctx->curl_buf);
@@ -3498,7 +3500,7 @@ ACVP_RESULT acvp_run(ACVP_CTX *ctx, int fips_validation) {
                 }
             }
         }
-        if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        if (ctx->log_lvl == ACVP_LOG_LVL_VERBOSE) {
             printf("\n\n%s\n\n", ctx->curl_buf);
         } else {
             ACVP_LOG_STATUS("GET Response:\n\n%s\n", ctx->curl_buf);
@@ -3530,7 +3532,7 @@ ACVP_RESULT acvp_run(ACVP_CTX *ctx, int fips_validation) {
                 }
             }
         }
-        if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        if (ctx->log_lvl == ACVP_LOG_LVL_VERBOSE) {
             printf("\n\n%s\n\n", ctx->curl_buf);
         } else {
             ACVP_LOG_STATUS("DELETE Response:\n\n%s\n", ctx->curl_buf);

--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -944,7 +944,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         //Log the test group info as we receive it - if algs use default values instead of server
         //provided ones, don't log them, especially for alg-specific values
-        if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        if (ctx->log_lvl == ACVP_LOG_LVL_VERBOSE) {
             ACVP_LOG_NEWLINE;
             ACVP_LOG_VERBOSE("    Test group: %d", i);
             ACVP_LOG_VERBOSE("      testtype: %s", test_type_str);
@@ -981,7 +981,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                        *key = NULL, *tag = NULL, *aad = NULL, *salt = NULL;
             unsigned int tc_id = 0;
 
-            if (ctx->debug == ACVP_LOG_LVL_VERBOSE) ACVP_LOG_NEWLINE;
+            if (ctx->log_lvl == ACVP_LOG_LVL_VERBOSE) ACVP_LOG_NEWLINE;
             ACVP_LOG_VERBOSE("Found new AES test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);

--- a/src/acvp_cmac.c
+++ b/src/acvp_cmac.c
@@ -333,7 +333,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             rv = ACVP_MISSING_ARG;
             goto err;
         }
-        if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+        if (ctx->log_lvl == ACVP_LOG_LVL_VERBOSE) {
             ACVP_LOG_NEWLINE;
             ACVP_LOG_VERBOSE("    Test group: %d", i);
             ACVP_LOG_VERBOSE("      testtype: %s", test_type_str);
@@ -347,7 +347,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
         for (j = 0; j < t_cnt; j++) {
-             if (ctx->debug == ACVP_LOG_LVL_VERBOSE) ACVP_LOG_NEWLINE;
+             if (ctx->log_lvl == ACVP_LOG_LVL_VERBOSE) ACVP_LOG_NEWLINE;
             ACVP_LOG_VERBOSE("Found new cmac test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -351,7 +351,7 @@ static long acvp_curl_http_post(ACVP_CTX *ctx, const char *url, const char *data
      */
     crv = curl_easy_perform(hnd);
     if (crv != CURLE_OK) {
-        ACVP_LOG_ERR("Curl failed with code %d (%s)\n", crv, curl_easy_strerror(crv));
+        ACVP_LOG_ERR("Curl failed with code %d (%s)", crv, curl_easy_strerror(crv));
     }
 
     /*
@@ -451,7 +451,7 @@ static long acvp_curl_http_put(ACVP_CTX *ctx, const char *url, const char *data,
         memzero_s(ctx->curl_buf, ACVP_CURL_BUF_MAX);
     }
 
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+    if (ctx->log_lvl == ACVP_LOG_LVL_VERBOSE) {
         printf("\nHTTP PUT:\n\n%s\n", data);
     }
 
@@ -460,7 +460,7 @@ static long acvp_curl_http_put(ACVP_CTX *ctx, const char *url, const char *data,
      */
     crv = curl_easy_perform(hnd);
     if (crv != CURLE_OK) {
-        ACVP_LOG_ERR("Curl failed with code %d (%s)\n", crv, curl_easy_strerror(crv));
+        ACVP_LOG_ERR("Curl failed with code %d (%s)", crv, curl_easy_strerror(crv));
     }
 
     /*
@@ -556,7 +556,7 @@ static long acvp_curl_http_delete(ACVP_CTX *ctx, const char *url) {
         memzero_s(ctx->curl_buf, ACVP_CURL_BUF_MAX);
     }
 
-    if (ctx->debug == ACVP_LOG_LVL_VERBOSE) {
+    if (ctx->log_lvl == ACVP_LOG_LVL_VERBOSE) {
         printf("\nHTTP DELETE: %s\n", url);
     }
 
@@ -565,7 +565,7 @@ static long acvp_curl_http_delete(ACVP_CTX *ctx, const char *url) {
      */
     crv = curl_easy_perform(hnd);
     if (crv != CURLE_OK) {
-        ACVP_LOG_ERR("Curl failed with code %d (%s)\n", crv, curl_easy_strerror(crv));
+        ACVP_LOG_ERR("Curl failed with code %d (%s) ", crv, curl_easy_strerror(crv));
     }
 
     /*

--- a/test/test_acvp_utils.c
+++ b/test/test_acvp_utils.c
@@ -20,14 +20,14 @@ ACVP_CTX *ctx;
 Test(LogMsg, null_ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    acvp_log_msg(NULL, ACVP_LOG_LVL_MAX, "test");
+    acvp_log_msg(NULL, ACVP_LOG_LVL_MAX, __func__, __LINE__, "test");
     cr_assert(rv == ACVP_SUCCESS);
 
     setup_empty_ctx(&ctx);
-    acvp_log_msg(ctx, ACVP_LOG_LVL_MAX+1, "test");
+    acvp_log_msg(ctx, ACVP_LOG_LVL_MAX+1, __func__, __LINE__, "test");
     cr_assert(rv == ACVP_SUCCESS);
 
-    acvp_log_msg(ctx, ACVP_LOG_LVL_MAX, NULL);
+    acvp_log_msg(ctx, ACVP_LOG_LVL_MAX, __func__, __LINE__, NULL);
     cr_assert(rv == ACVP_SUCCESS);
     
     acvp_cleanup(ctx);

--- a/test/ut_common.c
+++ b/test/ut_common.c
@@ -19,9 +19,8 @@ int counter_fail = 0;
  * libacvp calls this function to for debugs, warnings,
  * and errors.
  */
-ACVP_RESULT progress(char *msg)
-{
-    printf("%s", msg);
+ACVP_RESULT progress(char *msg, ACVP_LOG_LVL level) {
+    printf("[ACVP]: %s\n", msg);
     return ACVP_SUCCESS;
 }
 

--- a/test/ut_common.h
+++ b/test/ut_common.h
@@ -21,7 +21,7 @@ int counter_set;
 int counter_fail;
 
 void teardown_ctx(ACVP_CTX **ctx);
-ACVP_RESULT progress(char *msg);
+ACVP_RESULT progress(char *msg, ACVP_LOG_LVL level);
 void setup_empty_ctx(ACVP_CTX **ctx);
 int dummy_handler_success(ACVP_TEST_CASE *test_case);
 int dummy_handler_failure(ACVP_TEST_CASE *test_case);


### PR DESCRIPTION
Previously, the library formatted all output messages with ACVP info before sending it to the application's log handler. Now, we just send a plain message and log level to the application log handler. The exception is "debug" mode, where the library prepends function and line information before sending it to the application.

The application now does some fun color coding for errors and warnings by default. 
The application has simplified formatting for output, e.g. not including line info by default and not including things like [STATUS] or [INFO]