### PR TITLE
First set of return code updates

### DIFF
--- a/app/app_utils.c
+++ b/app/app_utils.c
@@ -187,7 +187,7 @@ static ACVP_RESULT totp(char **token, int token_max) {
     if (seed_len  == 0) {
         printf("Failed to decode TOTP seed\n");
         free(new_seed);
-        return ACVP_TOTP_DECODE_FAIL;
+        return ACVP_TOTP_FAIL;
     }
 
 
@@ -200,7 +200,7 @@ static ACVP_RESULT totp(char **token, int token_max) {
     if (md_len == 0) {
         printf("Failed to create TOTP\n");
         free(new_seed);
-        return ACVP_CRYPTO_MODULE_FAIL;
+        return ACVP_TOTP_FAIL;
     }
     os = hash[(int)md_len - 1] & 0xf;
 

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -81,31 +81,39 @@ typedef struct acvp_ctx_t ACVP_CTX;
  */
 typedef enum acvp_result {
     ACVP_SUCCESS = 0,
-    ACVP_MALLOC_FAIL,    /**< Error allocating memory */
-    ACVP_NO_CTX,         /**< No valid context */
-    ACVP_TRANSPORT_FAIL, /**< Error exchanging data with server */
-    ACVP_JSON_ERR,
-    ACVP_NO_DATA,
-    ACVP_UNSUPPORTED_OP,
-    ACVP_CLEANUP_FAIL,
-    ACVP_KAT_DOWNLOAD_RETRY,
-    ACVP_OE_RETRY,
-    ACVP_INVALID_ARG,
-    ACVP_MISSING_ARG,
-    ACVP_CRYPTO_MODULE_FAIL,
-    ACVP_CRYPTO_TAG_FAIL,
-    ACVP_CRYPTO_WRAP_FAIL,
-    ACVP_NO_TOKEN,
-    ACVP_NO_CAP,
-    ACVP_MALFORMED_JSON, /**< For use if the json is unable to be parsed properly */
-    ACVP_TC_DATA_INVALID, /**< Test case JSON is formatted properly, but the data is bad or does not match the spec */
-    ACVP_DATA_TOO_LARGE,
-    ACVP_DUP_CIPHER,
-    ACVP_TOTP_DECODE_FAIL,
-    ACVP_TOTP_MISSING_SEED,
-    ACVP_DUPLICATE_CTX,
-    ACVP_JWT_EXPIRED,
-    ACVP_JWT_INVALID,
+    ACVP_MALLOC_FAIL,        /**< Error allocating memory */
+    ACVP_NO_CTX,             /**< An initalized context was expected but not present */
+    ACVP_TRANSPORT_FAIL,     /**< Error exchanging data with server */
+    ACVP_NO_DATA,            /**< Required data for operation is missing */
+    ACVP_UNSUPPORTED_OP,     /**< An operation has been requested that is not supported. This can
+                                  either be because parameters are not valid or because the library
+                                  does not support something at the time */
+    ACVP_CLEANUP_FAIL,       /**< Failure when cleaning up (e.g. freeing memory) after operations */
+    ACVP_KAT_DOWNLOAD_RETRY, /**< Does not neccessarily indicate an error, but that data requested
+                                  from server is not yet ready to be accessed */
+    ACVP_INVALID_ARG,        /**< A provided argument or parameter is not valid for the given operation */
+    ACVP_MISSING_ARG,        /**< A required argument or parameter is not provided/null/0 */
+    ACVP_CRYPTO_MODULE_FAIL, /**< A non-zero return code was provided by the application callback 
+                                  for test case processin; this should indicate that the application
+                                  failed to process the test case*/
+    ACVP_NO_CAP,             /**< A registered capability object for the given algorithm does not exist. This
+                                  usually means an operation is being requested for an algorithm that is not yet
+                                  registered */
+    ACVP_MALFORMED_JSON,     /**< The given JSON is not properly formatted/readable JSON */
+    ACVP_JSON_ERR,           /**< Error occured attempting to parse JSON into data stuctures */
+    ACVP_TC_MISSING_DATA,    /**< Data is missing from test case JSON */
+    ACVP_TC_INVALID_DATA,    /**< Test case JSON is formatted properly, but the data is bad, does not
+                                  match the registration, or does not match the spec */
+    ACVP_DATA_TOO_LARGE,     /**< The given parameter larger than the library allows. This can apply to strings,
+                                  server responses, files, etc */
+    ACVP_CONVERT_DATA_ERR,   /**< Error converting data between hexidecimal and binary (either direction) */
+    ACVP_DUP_CIPHER,         /**< The client is attempting to register an algorithm that has already been registered */
+    ACVP_TOTP_FAIL,          /**< A failure occured attempting to generate a TOTP */
+    ACVP_CTX_NOT_EMPTY,      /**< Occurs specifically when an attempt is made to initialize a CTX that is already initialized */
+    ACVP_JWT_MISSING,        /**< A JSON web token is missing from a file or from memory but was expected */
+    ACVP_JWT_EXPIRED,        /**< The provided JWT was not accepted by the server because it is expired */
+    ACVP_JWT_INVALID,        /**< A provided JSON web token is invalid due to its size, encoding, or contents */
+    ACVP_INTERNAL_ERR,       /**< An unexpected error occuring internally to libacvp */
     ACVP_RESULT_MAX
 } ACVP_RESULT;
 

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -2272,6 +2272,9 @@ static ACVP_RESULT acvp_build_dsa_hashalgs(JSON_Object *cap_obj,
 
     json_object_set_value(cap_obj, "hashAlg", json_value_init_array());
     sha_arr = json_object_get_array(cap_obj, "hashAlg");
+    if (!sha_arr) {
+        return ACVP_JSON_ERR;
+    }
 
     if (attrs->sha & ACVP_SHA1) {
         json_array_append_string(sha_arr, "SHA-1");
@@ -3701,7 +3704,7 @@ static ACVP_RESULT acvp_build_kda_onestep_register_cap(ACVP_CTX *ctx,
     mode = acvp_lookup_cipher_mode_str(cap_entry->cipher);
     if (!mode) {
         ACVP_LOG_ERR("Unable to find mode string for KDA-ONESTEP when building registration");
-        rv = ACVP_INVALID_ARG;
+        rv = ACVP_INTERNAL_ERR;
         goto err;
     }
     json_object_set_string(cap_obj, "mode", mode);

--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -779,7 +779,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             keyingOption = json_object_get_number(groupobj, "keyingOption");
             if (keyingOption > 2 || keyingOption < 1) {
                 ACVP_LOG_ERR("Server JSON invalid 'keyingOption', %d", keyingOption);
-                rv = ACVP_TC_DATA_INVALID;
+                rv = ACVP_TC_INVALID_DATA;
                 goto err;
             }
         }
@@ -991,13 +991,11 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 /* Process the current DES encrypt test vector... */
                 int t_rv = (cap->crypto_handler)(&tc);
                 if (t_rv) {
-                    if (rv != ACVP_CRYPTO_WRAP_FAIL) {
-                        ACVP_LOG_ERR("ERROR: crypto module failed the operation");
-                        json_value_free(r_tval);
-                        acvp_des_release_tc(&stc);
-                        rv = ACVP_CRYPTO_MODULE_FAIL;
-                        goto err;
-                    }
+                    ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                    json_value_free(r_tval);
+                    acvp_des_release_tc(&stc);
+                    rv = ACVP_CRYPTO_MODULE_FAIL;
+                    goto err;
                 }
 
                 /*

--- a/src/acvp_kda.c
+++ b/src/acvp_kda.c
@@ -1006,13 +1006,13 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
             alg_str = json_object_get_string(configobj, "macMode");
             if (!alg_str) {
                 ACVP_LOG_ERR("Server JSON missing 'macMode'");
-                rv = ACVP_TC_DATA_INVALID;
+                rv = ACVP_TC_INVALID_DATA;
                 goto err;
             }
             mac_mode = read_mac_mode(alg_str);
             if (!mac_mode) {
                 ACVP_LOG_ERR("Sever JSON invalid 'macMode'");
-                rv = ACVP_TC_DATA_INVALID;
+                rv = ACVP_TC_INVALID_DATA;
                 goto err;
             }
         } else {
@@ -1094,33 +1094,33 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
             kdf_mode_str = json_object_get_string(configobj, "kdfMode");
             if (!kdf_mode_str) {
                 ACVP_LOG_ERR("Server JSON missing kdfMode");
-                rv = ACVP_TC_DATA_INVALID;
+                rv = ACVP_TC_INVALID_DATA;
                 goto err;
             }
             kdf_mode = read_mode(kdf_mode_str);
             if (!kdf_mode) {
                 ACVP_LOG_ERR("Server JSON invalid kdfMode");
-                rv = ACVP_TC_DATA_INVALID;
+                rv = ACVP_TC_INVALID_DATA;
                 goto err;
             }
 
             ctr_loc_str = json_object_get_string(configobj, "counterLocation");
             if (!ctr_loc_str) {
                 ACVP_LOG_ERR("Server JSON missing counterLocation");
-                rv = ACVP_TC_DATA_INVALID;
+                rv = ACVP_TC_INVALID_DATA;
                 goto err;
             }
             ctr_loc = read_ctr_location(ctr_loc_str);
             if (!ctr_loc) {
                 ACVP_LOG_ERR("Server JSON invalid counterLocation.");
-                rv = ACVP_TC_DATA_INVALID;
+                rv = ACVP_TC_INVALID_DATA;
                 goto err;
             }
 
             ctr_len = json_object_get_number(configobj, "counterLen");
             if (ctr_len <= 0) {
                 ACVP_LOG_ERR("Server JSON missing or invalid counterLen.");
-                rv = ACVP_TC_DATA_INVALID;
+                rv = ACVP_TC_INVALID_DATA;
                 goto err;
             }
 
@@ -1130,12 +1130,12 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
             || (kdf_mode == ACVP_KDF108_MODE_FEEDBACK && !kdfcap->cap.kda_twostep_cap->kdf_params.feedback_mode.requires_empty_iv)) {
                 if (iv_len < 0) {
                     ACVP_LOG_ERR("Server JSON missing or invalid ivLen.");
-                    rv = ACVP_TC_DATA_INVALID;
+                    rv = ACVP_TC_INVALID_DATA;
                     goto err;
                 }
             } else if (iv_len > 0) {
                 ACVP_LOG_ERR("Client registered requiring empty IV, but server sent non-zero ivLen");
-                rv = ACVP_TC_DATA_INVALID;
+                rv = ACVP_TC_INVALID_DATA;
                 goto err;
             }
         }
@@ -1212,7 +1212,7 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
             }
             if (strnlen_s(z, ACVP_KDA_Z_STR_MAX + 1) > ACVP_KDA_Z_STR_MAX) {
                 ACVP_LOG_ERR("Server JSON 'z' too long");
-                rv = ACVP_TC_DATA_INVALID;
+                rv = ACVP_TC_INVALID_DATA;
                 goto err;
             }
 
@@ -1220,7 +1220,7 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
                 iv_str = json_object_get_string(paramobj, "iv");
                 if (!iv_str) {
                     ACVP_LOG_ERR("Server JSON missing 'iv'");
-                    rv = ACVP_TC_DATA_INVALID;
+                    rv = ACVP_TC_INVALID_DATA;
                     goto err;
                 }
             }

--- a/src/acvp_kdf135_x942.c
+++ b/src/acvp_kdf135_x942.c
@@ -41,7 +41,7 @@ static ACVP_RESULT acvp_kdf135_x942_output_tc(ACVP_CTX *ctx, ACVP_KDF135_X942_TC
         json_object_set_string(tc_rsp, "derivedKey", (const char *)tmp);
     } else {
         ACVP_LOG_ERR("Error outputting test case for X942 KDF. Dkm_len MUST equal key_len.");
-        rv = ACVP_TC_DATA_INVALID;
+        rv = ACVP_TC_INVALID_DATA;
         goto err;
     }
     rv = ACVP_SUCCESS;

--- a/src/acvp_rsa_keygen.c
+++ b/src/acvp_rsa_keygen.c
@@ -491,7 +491,7 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         test_type_str = json_object_get_string(groupobj, "testType");
         if (!test_type_str) {
             ACVP_LOG_ERR("Missing testType from server JSON for RSA keyGen");
-            rv = ACVP_TC_DATA_INVALID;
+            rv = ACVP_TC_INVALID_DATA;
             goto err;
         }
         test_type = read_test_type(test_type_str);

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -216,7 +216,7 @@ Test(CREATE_CTX, dup_ctx) {
     cr_assert(rv == ACVP_SUCCESS);
     
     rv = acvp_create_test_session(&ctx, &progress, ACVP_LOG_LVL_VERBOSE);
-    cr_assert(rv == ACVP_DUPLICATE_CTX);
+    cr_assert(rv == ACVP_CTX_NOT_EMPTY);
     
     teardown_ctx(&ctx);
 }
@@ -537,7 +537,7 @@ Test(RUN, bad_totp_cb, .init = setup_full_ctx, .fini = teardown) {
     rv = acvp_set_2fa_callback(ctx, &dummy_totp_overflow);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_run(ctx, 0);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TOTP_FAIL);
 }
 
 /*

--- a/test/test_acvp_aes.c
+++ b/test/test_acvp_aes.c
@@ -1252,7 +1252,7 @@ Test(AES_API, empty_ctx) {
     }
 
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_UNSUPPORTED_OP);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 
 end:
@@ -1285,7 +1285,7 @@ Test(AES_API, null_ctx) {
  */
 Test(AES_API, null_json_obj, .init = setup, .fini = teardown) {
     rv  = acvp_aes_kat_handler(ctx, NULL);
-    cr_assert(rv == ACVP_MALFORMED_JSON);
+    cr_assert(rv == ACVP_JSON_ERR);
 }
 
 /*
@@ -1318,7 +1318,7 @@ Test(AES_HANDLER, wrong_algorithm, .init = setup, .fini = teardown) {
         return;
     }
     rv = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_UNSUPPORTED_OP);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1335,7 +1335,7 @@ Test(AES_HANDLER, missing_direction, .init = setup, .fini = teardown) {
         return;
     }
     rv = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MISSING_ARG);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 
@@ -1352,7 +1352,7 @@ Test(AES_HANDLER, wrong_direction, .init = setup, .fini = teardown) {
         return;
     }
     rv = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1369,7 +1369,7 @@ Test(AES_HANDLER, missing_testType, .init = setup, .fini = teardown) {
         return;
     }
     rv = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MISSING_ARG);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 
@@ -1386,7 +1386,7 @@ Test(AES_HANDLER, wrong_testType, .init = setup, .fini = teardown) {
         return;
     }
     rv = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1403,7 +1403,7 @@ Test(AES_HANDLER, missing_keyLen, .init = setup, .fini = teardown) {
         return;
     }
     rv = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1420,7 +1420,7 @@ Test(AES_HANDLER, wrong_keyLen, .init = setup, .fini = teardown) {
         return;
     }
     rv = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1437,7 +1437,7 @@ Test(AES_HANDLER, big_ptLen, .init = setup, .fini = teardown) {
         return;
     }
     rv = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1454,7 +1454,7 @@ Test(AES_HANDLER, missing_ivLen, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MISSING_ARG);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 
@@ -1471,7 +1471,7 @@ Test(AES_HANDLER, small_ivLen_gcm, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1488,7 +1488,7 @@ Test(AES_HANDLER, big_ivLen_gcm, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1505,7 +1505,7 @@ Test(AES_HANDLER, small_ivLen_ccm, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1522,7 +1522,7 @@ Test(AES_HANDLER, big_ivLen_ccm, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1539,7 +1539,7 @@ Test(AES_HANDLER, wrong_ivLen_ccm, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1556,7 +1556,7 @@ Test(AES_HANDLER, small_tagLen, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1573,7 +1573,7 @@ Test(AES_HANDLER, big_tagLen, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1590,7 +1590,7 @@ Test(AES_HANDLER, big_aadLen, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1607,7 +1607,7 @@ Test(AES_HANDLER, missing_key, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MISSING_ARG);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 
@@ -1624,7 +1624,7 @@ Test(AES_HANDLER, long_key, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1641,7 +1641,7 @@ Test(AES_HANDLER, missing_pt, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MISSING_ARG);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 
@@ -1658,7 +1658,7 @@ Test(AES_HANDLER, long_pt, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1675,7 +1675,7 @@ Test(AES_HANDLER, missing_ct, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MISSING_ARG);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 
@@ -1692,7 +1692,7 @@ Test(AES_HANDLER, long_ct, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1709,7 +1709,7 @@ Test(AES_HANDLER, missing_tag, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MISSING_ARG);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 
@@ -1726,7 +1726,7 @@ Test(AES_HANDLER, long_tag, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1743,7 +1743,7 @@ Test(AES_HANDLER, missing_iv, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MISSING_ARG);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 
@@ -1760,7 +1760,7 @@ Test(AES_HANDLER, long_iv, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1777,7 +1777,7 @@ Test(AES_HANDLER, missing_aad, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MISSING_ARG);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 
@@ -1794,7 +1794,7 @@ Test(AES_HANDLER, long_aad, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_INVALID_ARG);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1811,7 +1811,7 @@ Test(AES_HANDLER, missing_gid, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MALFORMED_JSON);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 
@@ -1828,7 +1828,7 @@ Test(AES_HANDLER, bad_inc_ctr, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MALFORMED_JSON);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1845,7 +1845,7 @@ Test(AES_HANDLER, bad_ovrflw_ctr, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MALFORMED_JSON);
+    cr_assert(rv == ACVP_TC_INVALID_DATA);
     json_value_free(val);
 }
 
@@ -1862,7 +1862,7 @@ Test(AES_HANDLER, tgLast, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MISSING_ARG);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 
@@ -1879,7 +1879,7 @@ Test(AES_HANDLER, tcLast, .init = setup, .fini = teardown) {
         return;
     }
     rv  = acvp_aes_kat_handler(ctx, obj);
-    cr_assert(rv == ACVP_MISSING_ARG);
+    cr_assert(rv == ACVP_TC_MISSING_DATA);
     json_value_free(val);
 }
 

--- a/test/test_acvp_utils.c
+++ b/test/test_acvp_utils.c
@@ -159,7 +159,7 @@ Test(LookupErrorString, null_ctx) {
     char *dup = "ctx already initialized";
     char *ukn = "Unknown error";
 
-    str = acvp_lookup_error_string(ACVP_DUPLICATE_CTX);
+    str = acvp_lookup_error_string(ACVP_CTX_NOT_EMPTY);
     cr_assert(!strncmp(str, dup, strlen(dup)));
 
     str = acvp_lookup_error_string(ACVP_RESULT_MAX);


### PR DESCRIPTION
Updated list of return values for ACVP_RESULT. Some have been renamed, some added, some removed. Largest changes started with AES library code; these updates will come in parts.

I expect there will be more return code changes as these updates come through; values will be added as needed as I go through the library.

One of the biggest changes here involves separating ACVP_MISSING/INVALID_ARG from ACVP_TC_MISSING/INVALID_DATA. The more generic "arg" values should be reserved for things like public API calls. 

We also added an "ACVP_INTERNAL_ERR" code. This seems oddly generic, but it is intended to be used in places where the code logically should not be able to fail at all but we still require some sort of handling (e.g. "default" cases in switches where all values are handled).

Added comment descriptions to all ACVP_RESULTs.