### PR TITLE
Updates to MS build system for 2.0

### DIFF
--- a/ms/acvp_app.sln
+++ b/ms/acvp_app.sln
@@ -1,58 +1,22 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+VisualStudioVersion = 16.0.33423.256
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "acvp_app", "resources\acvp_app.vcxproj", "{6A63359B-E912-421D-B6B9-02A9B45B3067}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		fom_legacy_ssl_no_safec|x64 = fom_legacy_ssl_no_safec|x64
-		fom_legacy_ssl_no_safec|x86 = fom_legacy_ssl_no_safec|x86
-		fom_legacy_ssl|x64 = fom_legacy_ssl|x64
-		fom_legacy_ssl|x86 = fom_legacy_ssl|x86
-		fom_no_safec|x64 = fom_no_safec|x64
-		fom_no_safec|x86 = fom_no_safec|x86
 		fom|x64 = fom|x64
 		fom|x86 = fom|x86
-		nofom_legacy_ssl_no_safec|x64 = nofom_legacy_ssl_no_safec|x64
-		nofom_legacy_ssl_no_safec|x86 = nofom_legacy_ssl_no_safec|x86
-		nofom_legacy_ssl|x64 = nofom_legacy_ssl|x64
-		nofom_legacy_ssl|x86 = nofom_legacy_ssl|x86
-		nofom_no_safec|x64 = nofom_no_safec|x64
-		nofom_no_safec|x86 = nofom_no_safec|x86
 		nofom|x64 = nofom|x64
 		nofom|x86 = nofom|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_legacy_ssl_no_safec|x64.ActiveCfg = fom_legacy_ssl_no_safec|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_legacy_ssl_no_safec|x64.Build.0 = fom_legacy_ssl_no_safec|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_legacy_ssl_no_safec|x86.ActiveCfg = fom_legacy_ssl_no_safec|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_legacy_ssl_no_safec|x86.Build.0 = fom_legacy_ssl_no_safec|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_legacy_ssl|x64.ActiveCfg = fom_legacy_ssl|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_legacy_ssl|x64.Build.0 = fom_legacy_ssl|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_legacy_ssl|x86.ActiveCfg = fom_legacy_ssl|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_legacy_ssl|x86.Build.0 = fom_legacy_ssl|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_no_safec|x64.ActiveCfg = fom_no_safec|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_no_safec|x64.Build.0 = fom_no_safec|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_no_safec|x86.ActiveCfg = fom_no_safec|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom_no_safec|x86.Build.0 = fom_no_safec|Win32
 		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom|x64.ActiveCfg = fom|x64
 		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom|x64.Build.0 = fom|x64
 		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom|x86.ActiveCfg = fom|Win32
 		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom|x86.Build.0 = fom|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_legacy_ssl_no_safec|x64.ActiveCfg = nofom_legacy_ssl_no_safec|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_legacy_ssl_no_safec|x64.Build.0 = nofom_legacy_ssl_no_safec|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_legacy_ssl_no_safec|x86.ActiveCfg = nofom_legacy_ssl_no_safec|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_legacy_ssl_no_safec|x86.Build.0 = nofom_legacy_ssl_no_safec|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_legacy_ssl|x64.ActiveCfg = nofom_legacy_ssl|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_legacy_ssl|x64.Build.0 = nofom_legacy_ssl|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_legacy_ssl|x86.ActiveCfg = nofom_legacy_ssl|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_legacy_ssl|x86.Build.0 = nofom_legacy_ssl|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_no_safec|x64.ActiveCfg = nofom_no_safec|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_no_safec|x64.Build.0 = nofom_no_safec|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_no_safec|x86.ActiveCfg = nofom_no_safec|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom_no_safec|x86.Build.0 = nofom_no_safec|Win32
 		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom|x64.ActiveCfg = nofom|x64
 		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom|x64.Build.0 = nofom|x64
 		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom|x86.ActiveCfg = nofom|Win32
@@ -62,6 +26,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {A681267A-2315-4DE9-B518-E89F343EEA9B}
+		SolutionGuid = {95F53676-75CB-4D5A-8DBD-68D3A2F3451D}
 	EndGlobalSection
 EndGlobal

--- a/ms/config_windows.bat
+++ b/ms/config_windows.bat
@@ -3,23 +3,11 @@
 rem "x86" or "x64"
 set ACVP_ARCH=x64
 
+rem path to OpenSSL 1.1.1 or greater
 set SSL_DIR=C:\Path\to\dir
-rem set true for SSL versions before 1.1.0
-set LEGACY_SSL=FALSE
 
-rem for non-runtime testing - will use OpenSSL as normal if empty
-set FOM_DIR=C:\Path\to\dir
+rem for non-runtime testing. Only provided for SSL versions less than 3.0.
+set FOM_DIR=
 
-rem if libcurl dir is empty, OFFLINE_BUILD must be true for windows
+rem if libcurl dir is empty, libacvp will build for offline mode only
 set LIBCURL_DIR=C:\Path\to\dir
-
-rem if SAFEC_DIR is empty, we will not use an external library and use the safeC stub instead
-set SAFEC_DIR=C:\Path\to\dir
-
-rem options
-rem build libacvp statically - will also look for static dependencies
-set STATIC_BUILD=FALSE
-rem for static builds only; creates a version of library that can only be used for offline processing of vector sets
-set OFFLINE_BUILD=FALSE
-rem Needed for using acvp_app with a FOM that does not support NIST KDF functions, like OpenSSL fom 2.0
-set DISABLE_KDF=TRUE

--- a/ms/libacvp.sln
+++ b/ms/libacvp.sln
@@ -1,55 +1,31 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+VisualStudioVersion = 16.0.33423.256
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libacvp", "resources\libacvp.vcxproj", "{D96A91BF-B55A-42FF-8053-4519103AF513}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		shared_no_safec|x64 = shared_no_safec|x64
-		shared_no_safec|x86 = shared_no_safec|x86
+		offline|x64 = offline|x64
+		offline|x86 = offline|x86
 		shared|x64 = shared|x64
 		shared|x86 = shared|x86
-		static_no_safec|x64 = static_no_safec|x64
-		static_no_safec|x86 = static_no_safec|x86
-		static_offline_no_safec|x64 = static_offline_no_safec|x64
-		static_offline_no_safec|x86 = static_offline_no_safec|x86
-		static_offline|x64 = static_offline|x64
-		static_offline|x86 = static_offline|x86
-		static|x64 = static|x64
-		static|x86 = static|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.shared_no_safec|x64.ActiveCfg = shared_no_safec|x64
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.shared_no_safec|x64.Build.0 = shared_no_safec|x64
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.shared_no_safec|x86.ActiveCfg = shared_no_safec|Win32
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.shared_no_safec|x86.Build.0 = shared_no_safec|Win32
+		{D96A91BF-B55A-42FF-8053-4519103AF513}.offline|x64.ActiveCfg = offline|x64
+		{D96A91BF-B55A-42FF-8053-4519103AF513}.offline|x64.Build.0 = offline|x64
+		{D96A91BF-B55A-42FF-8053-4519103AF513}.offline|x86.ActiveCfg = offline|Win32
+		{D96A91BF-B55A-42FF-8053-4519103AF513}.offline|x86.Build.0 = offline|Win32
 		{D96A91BF-B55A-42FF-8053-4519103AF513}.shared|x64.ActiveCfg = shared|x64
 		{D96A91BF-B55A-42FF-8053-4519103AF513}.shared|x64.Build.0 = shared|x64
 		{D96A91BF-B55A-42FF-8053-4519103AF513}.shared|x86.ActiveCfg = shared|Win32
 		{D96A91BF-B55A-42FF-8053-4519103AF513}.shared|x86.Build.0 = shared|Win32
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_no_safec|x64.ActiveCfg = static_no_safec|x64
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_no_safec|x64.Build.0 = static_no_safec|x64
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_no_safec|x86.ActiveCfg = static_no_safec|Win32
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_no_safec|x86.Build.0 = static_no_safec|Win32
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_offline_no_safec|x64.ActiveCfg = static_offline_no_safec|x64
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_offline_no_safec|x64.Build.0 = static_offline_no_safec|x64
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_offline_no_safec|x86.ActiveCfg = static_offline_no_safec|Win32
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_offline_no_safec|x86.Build.0 = static_offline_no_safec|Win32
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_offline|x64.ActiveCfg = static_offline|x64
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_offline|x64.Build.0 = static_offline|x64
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_offline|x86.ActiveCfg = static_offline|Win32
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static_offline|x86.Build.0 = static_offline|Win32
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static|x64.ActiveCfg = static|x64
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static|x64.Build.0 = static|x64
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static|x86.ActiveCfg = static|Win32
-		{D96A91BF-B55A-42FF-8053-4519103AF513}.static|x86.Build.0 = static|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {04B635CC-137E-4AED-A01C-23AC998B1FAC}
+		SolutionGuid = {F316F415-ED5E-4154-AB22-B9B75733A0A4}
 	EndGlobalSection
 EndGlobal

--- a/ms/make_app.bat
+++ b/ms/make_app.bat
@@ -2,15 +2,14 @@
 
 set ACV_INC_PATHS=
 set ACV_LIB_PATHS=
-set ACV_ROOT_PATH=
 
 rem Visual Studio wants absolute paths in some cases
 set ACV_ROOT_PATH_REL=%~dp0..\
 for %%i in ("%ACV_ROOT_PATH_REL%") do SET "ACV_ROOT_PATH=%%~fi
-if [%FOM_DIR%] == [] (
-  echo "No fom, some algorithms will not be available for testing"
-  set PROJ_CONFIG=nofom
-) else (
+
+set PROJ_CONFIG="nofom"
+
+if NOT [%FOM_DIR%] == [] (
   set ACV_LIB_PATHS=%FOM_DIR%\lib
   set ACV_INC_PATHS=%FOM_DIR%\include
   set PROJ_CONFIG=fom
@@ -24,26 +23,6 @@ if [%SSL_DIR%] == [] (
   set ACV_INC_PATHS=%ACV_INC_PATHS%;%SSL_DIR%\include
 )
 
-if %LEGACY_SSL%==TRUE (
-  set PROJ_CONFIG=%PROJ_CONFIG%_legacy_ssl
-)
-
-if [%SAFEC_DIR%] == [] (
-  set PROJ_CONFIG=%PROJ_CONFIG%_no_safec
-  set ACV_INC_PATHS=%ACV_INC_PATHS%;%ACV_ROOT_PATH%\safe_c_stub\include
-) else (
-  set ACV_LIB_PATHS=%ACV_LIB_PATHS%;%SAFEC_DIR%
-  set ACV_INC_PATHS=%ACV_INC_PATHS%;%SAFEC_DIR%\include
-)
-
-if NOT %DISABLE_KDF%==TRUE (
-  set ACV_KDF_SUPPORT=OPENSSL_KDF_SUPPORT
-)
-
-if %STATIC_BUILD%==TRUE (
-  set ACV_CURL_STATIC=CURL_STATICLIB
-)
-
 set ACV_LIB_PATHS=%ACV_LIB_PATHS%;%~dp0%build
 set ACV_INC_PATHS=%ACV_INC_PATHS%;%ACV_ROOT_PATH%\include
 
@@ -51,7 +30,7 @@ msbuild ms\acvp_app.sln /p:Configuration=%PROJ_CONFIG% /p:Platform=%ACVP_ARCH% /
 goto :end
 
 :error
-  exit 1
+  exit /b
 
 :end
 

--- a/ms/make_lib.bat
+++ b/ms/make_lib.bat
@@ -6,41 +6,24 @@ set ACV_LIB_PATHS=
 rem Visual Studio wants absolute paths in some cases
 set ACV_ROOT_PATH_REL=%~dp0..\
 for %%i in ("%ACV_ROOT_PATH_REL%") do SET "ACV_ROOT_PATH=%%~fi
-if "%STATIC_BUILD%" == "TRUE" (
-  set PROJ_CONFIG=static
-) else (
-  set PROJ_CONFIG=shared
-)
 
-if "%OFFLINE_BUILD%" == "TRUE" (
-  set PROJ_CONFIG=%PROJ_CONFIG%_offline
-) else (
-  if [%LIBCURL_DIR%] == [] (
-    echo "curl dir not specified - attempting to use murl and link to ssl..."
-	  if [%SSL_DIR%] == [] (
-	    echo "No SSL dir specified. Curl directory, or SSL dir if using Murl, must be specified. exiting..."
-      goto :error
-	  ) else (
-      set ACV_LIB_PATHS=%SSL_DIR%\lib
-	    set ACV_INC_PATHS=%SSL_DIR%\include
-	  )
-  ) else (
-    set ACV_LIB_PATHS=%LIBCURL_DIR%\lib
-   	set ACV_INC_PATHS=%LIBCURL_DIR%\include
-  )
-)
+set PROJ_CONFIG=shared
 
-if [%SAFEC_DIR%] == [] (
-  set PROJ_CONFIG=%PROJ_CONFIG%_no_safec
-  set ACV_INC_PATHS=%ACV_INC_PATHS%;%ACV_ROOT_PATH%\safe_c_stub\include
+if [%LIBCURL_DIR%] == [] (
+  set PROJ_CONFIG=offline
 ) else (
-  set ACV_LIB_PATHS=%ACV_LIB_PATHS%;%SAFEC_DIR%
-  set ACV_INC_PATHS=%ACV_INC_PATHS%;%SAFEC_DIR%\include
+  set ACV_LIB_PATHS=%LIBCURL_DIR%\lib
+  set ACV_INC_PATHS=%LIBCURL_DIR%\include
 )
 
 if [%LIBCURL_DIR%] == [] (
-  set PROJ_CONFIG=%PROJ_CONFIG%_murl
-  set ACV_INC_PATHS=%ACV_INC_PATHS%;%ACV_ROOT_PATH%\murl
+  if [%SSL_DIR%] == [] (
+    echo "No SSL dir specified. Must be provided for online builds. exiting..."
+    goto :error
+  ) else (
+    set ACV_LIB_PATHS=%ACV_LIB_PATHS%;%SSL_DIR%\lib
+    set ACV_INC_PATHS=%ACV_INC_PATHS%;%SSL_DIR%\include
+  )
 )
 
 set ACV_INC_PATHS=%ACV_INC_PATHS%;%ACV_ROOT_PATH%\include\acvp
@@ -49,7 +32,7 @@ msbuild ms\libacvp.sln /p:Configuration=%PROJ_CONFIG% /p:Platform=%ACVP_ARCH% /p
 goto :end
 
 :error
-  exit 1
-
+  exit /b
+  
 :end
 

--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -120,6 +120,7 @@ EXPORTS
   acvp_protocol_version
   acvp_mark_as_delete_only
   acvp_cancel_test_session
+  acvp_get_vector_set_count
   acvp_cap_kda_enable
   acvp_cap_kda_set_parm
   acvp_cap_kda_twostep_set_parm
@@ -144,3 +145,4 @@ EXPORTS
   acvp_get_kdf_alg
   acvp_get_drbg_alg
   acvp_get_kas_alg
+  acvp_get_kmac_alg

--- a/ms/resources/acvp_app.vcxproj
+++ b/ms/resources/acvp_app.vcxproj
@@ -1,60 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="fom_legacy_ssl_no_safec|Win32">
-      <Configuration>fom_legacy_ssl_no_safec</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="fom_legacy_ssl_no_safec|x64">
-      <Configuration>fom_legacy_ssl_no_safec</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="fom_legacy_ssl|Win32">
-      <Configuration>fom_legacy_ssl</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="fom_legacy_ssl|x64">
-      <Configuration>fom_legacy_ssl</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="fom_no_safec|Win32">
-      <Configuration>fom_no_safec</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="fom_no_safec|x64">
-      <Configuration>fom_no_safec</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="fom|Win32">
       <Configuration>fom</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="fom|x64">
       <Configuration>fom</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="nofom_legacy_ssl_no_safec|Win32">
-      <Configuration>nofom_legacy_ssl_no_safec</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="nofom_legacy_ssl_no_safec|x64">
-      <Configuration>nofom_legacy_ssl_no_safec</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="nofom_legacy_ssl|Win32">
-      <Configuration>nofom_legacy_ssl</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="nofom_legacy_ssl|x64">
-      <Configuration>nofom_legacy_ssl</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="nofom_no_safec|Win32">
-      <Configuration>nofom_no_safec</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="nofom_no_safec|x64">
-      <Configuration>nofom_no_safec</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="nofom|Win32">
@@ -70,71 +22,23 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{6A63359B-E912-421D-B6B9-02A9B45B3067}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='fom|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|x64'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|x64'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|x64'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|x64'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|x64'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|x64'">
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -148,57 +52,7 @@
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
     <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|Win32'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|Win32'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|Win32'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|Win32'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|Win32'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|Win32'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='fom|x64'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|x64'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|x64'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|x64'">
     <OutDir>$(SolutionDir)\build\</OutDir>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
     <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
@@ -208,179 +62,44 @@
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
     <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|x64'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|x64'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|x64'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;fipscanister.lib;libcrypto.lib;libssl.lib;safeclib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>ACVP_NO_RUNTIME;__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|Win32'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;fipscanister.lib;libeay32.lib;ssleay32.lib; Ws2_32.lib;safeclib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>ACVP_NO_RUNTIME;__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|Win32'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;fipscanister.lib;libeay32.lib;ssleay32.lib; Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>ACVP_NO_RUNTIME;__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|Win32'">
     <Link>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;fipscanister.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
       <PreprocessorDefinitions>ACVP_NO_RUNTIME;__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='fom|x64'">
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;fipscanister.lib;libcrypto.lib;libssl.lib;safeclib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>ACVP_NO_RUNTIME;__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|x64'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;fipscanister.lib;libeay32.lib;ssleay32.lib; Ws2_32.lib;safeclib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>ACVP_NO_RUNTIME;__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|x64'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;fipscanister.lib;libeay32.lib;ssleay32.lib; Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>ACVP_NO_RUNTIME;__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|x64'">
-    <Link>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;fipscanister.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
       <PreprocessorDefinitions>ACVP_NO_RUNTIME;__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libssl.lib;libcrypto.lib;safeclib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
       <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libssl.lib;libcrypto.lib;safeclib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|Win32'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libeay32.lib;ssleay32.lib;safeclib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|x64'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libeay32.lib;ssleay32.lib;safeclib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|Win32'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libeay32.lib;ssleay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|x64'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libeay32.lib;ssleay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|Win32'">
-    <Link>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
       <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|x64'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -400,138 +119,19 @@
     <ClCompile Include="..\..\app\app_rsa.c" />
     <ClCompile Include="..\..\app\app_sha.c" />
     <ClCompile Include="..\..\app\app_utils.c" />
-    <ClCompile Include="..\..\safe_c_stub\src\safe_str_stub.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|x64'">false</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\safe_c_stub\src\safe_mem_stub.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|x64'">false</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="..\..\safe_c_stub\src\safe_str_stub.c" />
+    <ClCompile Include="..\..\safe_c_stub\src\safe_mem_stub.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\app\app_fips_init_lcl.h" />
     <ClInclude Include="..\..\app\app_fips_lcl.h" />
     <ClInclude Include="..\..\app\app_lcl.h" />
     <ClInclude Include="..\..\app\ketopt.h" />
-    <ClCompile Include="..\..\safe_c_stub\include\mem_primitives_lib.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|x64'">false</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\safe_c_stub\include\safe_lib.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|x64'">false</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\safe_c_stub\include\safe_lib_errno.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|x64'">false</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\safe_c_stub\include\safe_mem_lib.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|x64'">false</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\safe_c_stub\include\safe_str_lib.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='fom_legacy_ssl_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='nofom_no_safec|x64'">false</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="..\..\safe_c_stub\include\mem_primitives_lib.h" />
+    <ClCompile Include="..\..\safe_c_stub\include\safe_lib.h" />
+    <ClCompile Include="..\..\safe_c_stub\include\safe_lib_errno.h" />
+    <ClCompile Include="..\..\safe_c_stub\include\safe_mem_lib.h" />
+    <ClCompile Include="..\..\safe_c_stub\include\safe_str_lib.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ms/resources/libacvp.vcxproj
+++ b/ms/resources/libacvp.vcxproj
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="shared_no_safec|Win32">
-      <Configuration>shared_no_safec</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="shared_no_safec|x64">
-      <Configuration>shared_no_safec</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="shared|Win32">
       <Configuration>shared</Configuration>
       <Platform>Win32</Platform>
@@ -17,36 +9,12 @@
       <Configuration>shared</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="static_no_safec|Win32">
-      <Configuration>static_no_safec</Configuration>
+    <ProjectConfiguration Include="offline|Win32">
+      <Configuration>offline</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="static_no_safec|x64">
-      <Configuration>static_no_safec</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="static_offline_no_safec|Win32">
-      <Configuration>static_offline_no_safec</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="static_offline_no_safec|x64">
-      <Configuration>static_offline_no_safec</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="static_offline|Win32">
-      <Configuration>static_offline</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="static_offline|x64">
-      <Configuration>static_offline</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="static|Win32">
-      <Configuration>static</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="static|x64">
-      <Configuration>static</Configuration>
+    <ProjectConfiguration Include="offline|x64">
+      <Configuration>offline</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
@@ -54,67 +22,27 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{D96A91BF-B55A-42FF-8053-4519103AF513}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='static_offline|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='offline|Win32'">
+    <PlatformToolset>v142</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='static_offline|x64'">
-    <PlatformToolset>v141</PlatformToolset>
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='static|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='static|x64'">
-    <PlatformToolset>v141</PlatformToolset>
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='offline|x64'">
+    <PlatformToolset>v142</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='shared|x64'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='shared|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|x64'">
-    <PlatformToolset>v141</PlatformToolset>
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='static_no_safec|x64'">
-    <PlatformToolset>v141</PlatformToolset>
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='static_no_safec|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|Win32'">
-    <PlatformToolset>v141</PlatformToolset>
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|x64'">
-    <PlatformToolset>v141</PlatformToolset>
-    <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -123,37 +51,12 @@
   <ImportGroup Label="Shared">
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|Win32'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|x64'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='shared|Win32'">
     <OutDir>$(SolutionDir)\build\</OutDir>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
     <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='static|Win32'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='static_no_safec|Win32'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='static_offline|Win32'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|Win32'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='offline|Win32'">
     <OutDir>$(SolutionDir)\build\</OutDir>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
     <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
@@ -163,29 +66,14 @@
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
     <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='static|x64'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='static_no_safec|x64'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='static_offline|x64'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|x64'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='offline|x64'">
     <OutDir>$(SolutionDir)\build\</OutDir>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
     <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='shared|Win32'">
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libcurl.lib;safeclib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
     </Link>
@@ -198,192 +86,46 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='shared|x64'">
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libcurl.lib;safeclib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS);$(ProjectDir)..\..\safe_c_stub\include</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>None</DebugInformationFormat>
       <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='offline|Win32'">
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;WIN32;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>None</DebugInformationFormat>
+      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;ACVP_OFFLINE;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='offline|x64'">
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;WIN32;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>None</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;ACVP_OFFLINE;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include</AdditionalIncludeDirectories>
     </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='static|Win32'">
-    <Lib>
-      <AdditionalDependencies>$(ACV_STATIC_LIB_DEPENDENCIES);libcurl_a.lib;safeclib.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Lib>
-    <Link>
-      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
-    </Link>
-    <ClCompile>
-      <Optimization>Disabled</Optimization>
-      <DebugInformationFormat>None</DebugInformationFormat>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;CURL_STATICLIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='static|x64'">
-    <Lib>
-      <AdditionalDependencies>$(ACV_STATIC_LIB_DEPENDENCIES);libcurl_a.lib;safeclib.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Lib>
-    <Link>
-      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
-    </Link>
-    <ClCompile>
-      <Optimization>Disabled</Optimization>
-      <DebugInformationFormat>None</DebugInformationFormat>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;CURL_STATICLIB;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='static_no_safec|Win32'">
-    <Lib>
-      <AdditionalDependencies>$(ACV_STATIC_LIB_DEPENDENCIES);libcurl_a.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Lib>
-    <Link>
-      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
-    </Link>
-    <ClCompile>
-      <Optimization>Disabled</Optimization>
-      <DebugInformationFormat>None</DebugInformationFormat>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;CURL_STATICLIB;WIN32;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='static_no_safec|x64'">
-    <Lib>
-      <AdditionalDependencies>$(ACV_STATIC_LIB_DEPENDENCIES);libcurl_a.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Lib>
-    <Link>
-      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
-    </Link>
-    <ClCompile>
-      <Optimization>Disabled</Optimization>
-      <DebugInformationFormat>None</DebugInformationFormat>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;CURL_STATICLIB;WIN32;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='static_offline|Win32'">
-    <Lib>
-      <AdditionalDependencies>$(ACV_STATIC_LIB_DEPENDENCIES);safeclib.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Lib>
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;CURL_STATICLIB;ACVP_OFFLINE</PreprocessorDefinitions>
-      <Optimization>Disabled</Optimization>
-      <DebugInformationFormat>None</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='static_offline|x64'">
-    <Lib>
-      <AdditionalDependencies>$(ACV_STATIC_LIB_DEPENDENCIES);safeclib.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Lib>
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;CURL_STATICLIB;ACVP_OFFLINE</PreprocessorDefinitions>
-      <Optimization>Disabled</Optimization>
-      <DebugInformationFormat>None</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|Win32'">
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;CURL_STATICLIB;WIN32;ACVP_OFFLINE</PreprocessorDefinitions>
-      <Optimization>Disabled</Optimization>
-      <DebugInformationFormat>None</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
-    </Link>
-    <Lib>
-      <AdditionalDependencies>$(ACV_STATIC_LIB_DEPENDENCIES);</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Lib>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|x64'">
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;CURL_STATICLIB;WIN32;ACVP_OFFLINE</PreprocessorDefinitions>
-      <Optimization>Disabled</Optimization>
-      <DebugInformationFormat>None</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
-    </Link>
-    <Lib>
-      <AdditionalDependencies>$(ACV_STATIC_LIB_DEPENDENCIES);</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\safe_c_stub\src\safe_mem_stub.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|x64'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\safe_c_stub\src\safe_str_stub.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|x64'">true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="..\..\safe_c_stub\src\safe_mem_stub.c" />
+    <ClCompile Include="..\..\safe_c_stub\src\safe_str_stub.c" />
     <ClCompile Include="..\..\src\acvp.c" />
     <ClCompile Include="..\..\src\acvp_aes.c" />
     <ClCompile Include="..\..\src\acvp_build_register.c" />
@@ -398,7 +140,6 @@
     <ClCompile Include="..\..\src\acvp_kas_ecc.c" />
     <ClCompile Include="..\..\src\acvp_kas_ffc.c" />
     <ClCompile Include="..\..\src\acvp_kas_ifc.c" />
-    <ClCompile Include="..\..\src\acvp_kmac.c" />
     <ClCompile Include="..\..\src\acvp_kts_ifc.c" />
     <ClCompile Include="..\..\src\acvp_pbkdf.c" />
     <ClCompile Include="..\..\src\acvp_kdf_tls12.c" />
@@ -413,6 +154,7 @@
     <ClCompile Include="..\..\src\acvp_kdf135_ssh.c" />
     <ClCompile Include="..\..\src\acvp_kdf135_x942.c" />
     <ClCompile Include="..\..\src\acvp_kdf135_x963.c" />
+    <ClCompile Include="..\..\src\acvp_kmac.c" />
     <ClCompile Include="..\..\src\acvp_operating_env.c" />
     <ClCompile Include="..\..\src\acvp_rsa_keygen.c" />
     <ClCompile Include="..\..\src\acvp_rsa_sig.c" />
@@ -425,76 +167,11 @@
     <ClInclude Include="..\..\include\acvp\acvp.h" />
     <ClInclude Include="..\..\include\acvp\acvp_lcl.h" />
     <ClInclude Include="..\..\include\acvp\parson.h" />
-    <ClInclude Include="..\..\safe_c_stub\include\mem_primitives_lib.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|x64'">true</ExcludedFromBuild>
-    </ClInclude>
-    <ClInclude Include="..\..\safe_c_stub\include\safe_lib.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|x64'">true</ExcludedFromBuild>
-    </ClInclude>
-    <ClInclude Include="..\..\safe_c_stub\include\safe_lib_errno.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|x64'">true</ExcludedFromBuild>
-    </ClInclude>
-    <ClInclude Include="..\..\safe_c_stub\include\safe_mem_lib.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|x64'">true</ExcludedFromBuild>
-    </ClInclude>
-    <ClInclude Include="..\..\safe_c_stub\include\safe_str_lib.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|Win32'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_no_safec|x64'">false</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='shared|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='static_offline|x64'">true</ExcludedFromBuild>
-    </ClInclude>
+    <ClInclude Include="..\..\safe_c_stub\include\mem_primitives_lib.h" />
+    <ClInclude Include="..\..\safe_c_stub\include\safe_lib.h" />
+    <ClInclude Include="..\..\safe_c_stub\include\safe_lib_errno.h" />
+    <ClInclude Include="..\..\safe_c_stub\include\safe_mem_lib.h" />
+    <ClInclude Include="..\..\safe_c_stub\include\safe_str_lib.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Source.def" />

--- a/ms/resources/libacvp.vcxproj.filters
+++ b/ms/resources/libacvp.vcxproj.filters
@@ -30,9 +30,6 @@
     <ClCompile Include="..\..\src\acvp_cmac.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\acvp_kmac.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\acvp_des.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -100,6 +97,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\acvp_kdf135_x963.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\acvp_kmac.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\acvp_operating_env.c">

--- a/src/acvp_kas_ifc.c
+++ b/src/acvp_kas_ifc.c
@@ -137,14 +137,14 @@ static ACVP_RESULT acvp_kas_ifc_ssc_val_output_tc(ACVP_KAS_IFC_TC *stc,
     if (stc->kas_role == ACVP_KAS_IFC_INITIATOR) {
         if (stc->iut_ct_z_len == stc->provided_ct_z_len) {
             memcmp_s(stc->iut_ct_z, stc->iut_ct_z_len, stc->provided_ct_z, stc->provided_ct_z_len, &diff);
-            rv += diff;
+            rv += abs(diff);
         } else {
             rv++;
         }
     } else if (stc->scheme != ACVP_KAS_IFC_KAS2) {
         if (stc->server_pt_z_len == stc->provided_pt_z_len) {
             memcmp_s(stc->server_pt_z, stc->server_pt_z_len, stc->provided_pt_z, stc->provided_pt_z_len, &diff);
-            rv += diff;
+            rv += abs(diff);
         } else {
             rv++;
         }
@@ -170,7 +170,7 @@ static ACVP_RESULT acvp_kas_ifc_ssc_val_output_tc(ACVP_KAS_IFC_TC *stc,
                             stc->iut_pt_z, stc->iut_pt_z_len);
             }
             memcmp_s(merge, len, stc->provided_kas2_z, stc->provided_kas2_z_len, &diff);
-            rv += diff;
+            rv += abs(diff);
         } else {
             rv++;
         }


### PR DESCRIPTION
Windows build system had several redundant or unnecessary build options:
SafeC build options removed (they don't apply, always using safeC stub)
Legacy SSL (<= 1.0.2) options removed
static linking options removed (Just support DLLs)

Left in offline mode builds for now.

Fully tested Running OpenSSL 3.0.X tests on windows - success! IDed an issue in KAS-IFC where a test case could output as Passed when It was supposed to fail because diffs from memcmp added up to 0 (this could have happened on any platform but since windows only returns -1/0/1 for memcmp, it made the issue manifest much more quickly and obviously. Took some time to track down!)

Note: changes to MS proj files are typically software generated; any formatting issues or anything there typically aren't from me.
