### PR TITLE
API changes, log algorithm list

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -115,9 +115,6 @@ static void print_usage(int code) {
     printf("      --vector_upload <file>\n");
     printf("      -u <file>\n");
     printf("\n");
-    printf("To process kat vectors from a JSON file use:\n");
-    printf("      --kat <file>\n");
-    printf("\n");
     printf("Note: --resume_session and --get_results use the test session info file created automatically by the library as input\n");
     printf("\n");
     printf("To resume a previous test session that was interupted:\n");
@@ -237,7 +234,6 @@ static ko_longopt_t longopts[] = {
     { "lms", ko_no_argument, 327 },
     { "all_algs", ko_no_argument, 350 },
     { "manual_registration", ko_required_argument, 400 },
-    { "kat", ko_required_argument, 401 },
     { "fips_validation", ko_required_argument, 402 },
     { "vector_req", ko_required_argument, 403 },
     { "vector_rsp", ko_required_argument, 404 },
@@ -452,14 +448,6 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
                 return 1;
             }
             strcpy_s(cfg->reg_file, JSON_FILENAME_LENGTH + 1, opt.arg);
-            break;
-
-        case 401:
-            cfg->kat = 1;
-            if (!check_option_length(opt.arg, c, JSON_FILENAME_LENGTH)) {
-                return 1;
-            }
-            strcpy_s(cfg->kat_file, JSON_FILENAME_LENGTH + 1, opt.arg);
             break;
 
         case 402:

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -46,7 +46,6 @@ typedef struct app_config {
     int post;
     int put;
     int delete;
-    int kat;
     int empty_alg;
     int fips_validation;
     int get_expected;
@@ -65,7 +64,6 @@ typedef struct app_config {
     char post_filename[JSON_FILENAME_LENGTH + 1];
     char put_filename[JSON_FILENAME_LENGTH + 1];
     char delete_url[JSON_REQUEST_LENGTH + 1];
-    char kat_file[JSON_FILENAME_LENGTH + 1];
     char validation_metadata_file[JSON_FILENAME_LENGTH + 1];
     char save_file[JSON_FILENAME_LENGTH + 1];
 

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -346,7 +346,7 @@ int main(int argc, char **argv) {
          * "acvp_enable_*" API calls... could reduce the
          * size of this file if you choose to use this capability.
          */
-        rv = acvp_set_json_filename(ctx, cfg.reg_file);
+        rv = acvp_set_registration_file(ctx, cfg.reg_file);
         if (rv != ACVP_SUCCESS) {
             printf("Failed to set json file within ACVP ctx (rv=%d)\n", rv);
             goto end;
@@ -411,11 +411,6 @@ int main(int argc, char **argv) {
         }
         if (reg) free(reg);
         goto end;
-    }
-
-    if (cfg.kat) {
-       rv = acvp_load_kat_filename(ctx, cfg.kat_file);
-       goto end;
     }
 
     if (cfg.vector_req && cfg.vector_rsp) {

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -4373,7 +4373,7 @@ ACVP_RESULT acvp_oe_oe_set_dependency(ACVP_CTX *ctx,
                                       unsigned int dependency_id);
 
 /**
- * @brief acvp_set_json_filename specifies JSON registration file to be used during registration.
+ * @brief acvp_set_registration_file specifies JSON registration file to be used during registration.
  *        This allows the app to skip the acvp_enable_* API calls
  *
  * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
@@ -4381,7 +4381,7 @@ ACVP_RESULT acvp_oe_oe_set_dependency(ACVP_CTX *ctx,
  *
  * @return ACVP_RESULT
  */
-ACVP_RESULT acvp_set_json_filename(ACVP_CTX *ctx, const char *json_filename);
+ACVP_RESULT acvp_set_registration_file(ACVP_CTX *ctx, const char *json_filename);
 
 /**
  * @brief acvp_get_current_registration returns a string form of the currently registered set of capabilities. If a test
@@ -4393,17 +4393,6 @@ ACVP_RESULT acvp_set_json_filename(ACVP_CTX *ctx, const char *json_filename);
  * @return The string (char*) form of the current registration. The string must be later freed by the user.
  */
 char *acvp_get_current_registration(ACVP_CTX *ctx, int *len);
-
-/**
- * @brief acvp_load_kat_filename loads and processes JSON kat vector file This option will not
- *        communicate with the server at all.
- *
- * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
- * @param kat_filename Name of the file that contains the JSON kat vectors
- *
- * @return ACVP_RESULT
- */
-ACVP_RESULT acvp_load_kat_filename(ACVP_CTX *ctx, const char *kat_filename);
 
 /**
  * @brief Uploads a set of vector set responses that were processed from an offline vector set JSON

--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -102,9 +102,8 @@ EXPORTS
   acvp_oe_dependency_new
   acvp_oe_oe_new
   acvp_oe_oe_set_dependency
-  acvp_set_json_filename
+  acvp_set_registration_file
   acvp_get_current_registration
-  acvp_load_kat_filename
   acvp_upload_vectors_from_file
   acvp_run_vectors_from_file
   acvp_put_data_from_file

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -967,45 +967,6 @@ static void acvp_list_failing_algorithms(ACVP_CTX *ctx, ACVP_STRING_LIST **list,
 }
 
 /*
- * Allows application to load JSON kat vector file within context
- * to be read in and used for vector testing
- */
-ACVP_RESULT acvp_load_kat_filename(ACVP_CTX *ctx, const char *kat_filename) {
-    JSON_Object *obj = NULL;
-    JSON_Value *val = NULL;
-    ACVP_RESULT rv = ACVP_SUCCESS;
-    JSON_Array *reg_array;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!kat_filename) {
-        ACVP_LOG_ERR("Must provide value for JSON filename");
-        return ACVP_MISSING_ARG;
-    }
-
-    if (strnlen_s(kat_filename, ACVP_JSON_FILENAME_MAX + 1) > ACVP_JSON_FILENAME_MAX) {
-        ACVP_LOG_ERR("Provided kat_filename length > max(%d)", ACVP_JSON_FILENAME_MAX);
-        return ACVP_INVALID_ARG;
-    }
-
-    val = json_parse_file(kat_filename);
-
-    reg_array = json_value_get_array(val);
-    obj = json_array_get_object(reg_array, 1);
-    if (!obj) {
-        ACVP_LOG_ERR("JSON obj parse error");
-        json_value_free(val);
-        return ACVP_INVALID_ARG;
-    }
-
-    /* Process the kat vector(s) */
-    rv  = acvp_dispatch_vector_set(ctx, obj);
-    json_value_free(val);
-    return rv;
-}
-
-/*
  * Allows application to load JSON vector file(req_filename) within context
  * to be read in and used for vector testing. The results are
  * then saved in a response file(rsp_filename).
@@ -1784,7 +1745,7 @@ end:
  * Allows application to set JSON filename within context
  * to be read in during registration
  */
-ACVP_RESULT acvp_set_json_filename(ACVP_CTX *ctx, const char *json_filename) {
+ACVP_RESULT acvp_set_registration_file(ACVP_CTX *ctx, const char *json_filename) {
     if (!ctx) {
         return ACVP_NO_CTX;
     }

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -4656,18 +4656,14 @@ ACVP_RESULT acvp_build_registration_json(ACVP_CTX *ctx, JSON_Value **reg) {
     JSON_Value *val = NULL, *cap_val = NULL;
     JSON_Array *caps_arr = NULL;
     JSON_Object *cap_obj = NULL;
+    const char *name = NULL, *mode = NULL;
 
     if (!ctx) {
         ACVP_LOG_ERR("No ctx for build_test_session");
         return ACVP_NO_CTX;
     }
 
-  /*  val = json_value_init_object();
-    obj = json_value_get_object(val);
 
-
-    json_object_set_value(obj, "algorithms", json_value_init_array());
-    caps_arr = json_object_get_array(obj, "algorithms"); */
     val = json_value_init_array();
     caps_arr = json_value_get_array(val);
     /*
@@ -4682,6 +4678,14 @@ ACVP_RESULT acvp_build_registration_json(ACVP_CTX *ctx, JSON_Value **reg) {
              */
             cap_val = json_value_init_object();
             cap_obj = json_value_get_object(cap_val);
+            name = acvp_lookup_cipher_name(cap_entry->cipher);
+            if (name) {
+                ACVP_LOG_INFO("Building registration for %s", name);
+                mode = acvp_lookup_cipher_mode_str(cap_entry->cipher);
+                if (mode) {
+                    ACVP_LOG_INFO("    Mode: %s", mode);
+                }
+            }
 
             /*
              * Build up the capability JSON based on the cipher type

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -252,7 +252,7 @@ Test(SET_SESSION_PARAMS, null_params_2fa, .init = setup, .fini = teardown) {
 Test(SET_SESSION_PARAMS, set_input_json_good, .init = setup, .fini = teardown) {
     rv = acvp_mark_as_request_only(ctx, "test.json");
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_set_json_filename(ctx, filename);
+    rv = acvp_set_registration_file(ctx, filename);
     cr_assert(rv == ACVP_SUCCESS);
 }
 
@@ -260,10 +260,10 @@ Test(SET_SESSION_PARAMS, set_input_json_good, .init = setup, .fini = teardown) {
  * This test sets json filename - null params
  */
 Test(SET_SESSION_PARAMS, set_input_json_null_params, .init = setup, .fini = teardown) {
-    rv = acvp_set_json_filename(NULL, filename);
+    rv = acvp_set_registration_file(NULL, filename);
     cr_assert(rv == ACVP_NO_CTX);
 
-    rv = acvp_set_json_filename(ctx, NULL);
+    rv = acvp_set_registration_file(ctx, NULL);
     cr_assert(rv == ACVP_MISSING_ARG);
 }
 
@@ -673,22 +673,6 @@ Test(PROCESS_TESTS, run_vectors_from_file, .init = setup_full_ctx, .fini = teard
     cr_assert(rv == ACVP_MISSING_ARG);
 
     rv = acvp_run_vectors_from_file(ctx, "json/req.json", "json/rsp1.json");
-    cr_assert(rv == ACVP_SUCCESS);
-
-}
-
-/*
- * Test acvp_load_kat_filename
- */
-Test(PROCESS_TESTS, load_kat_filename, .init = setup_full_ctx, .fini = teardown) {
-
-    rv = acvp_load_kat_filename(NULL, "test");
-    cr_assert(rv == ACVP_NO_CTX);
-
-    rv = acvp_load_kat_filename(ctx, NULL);
-    cr_assert(rv == ACVP_MISSING_ARG);
-
-    rv = acvp_load_kat_filename(ctx, "json/aes/aes.json");
     cr_assert(rv == ACVP_SUCCESS);
 
 }


### PR DESCRIPTION
Rename acvp_set_json_filename to acvp_set_registration_file; original name too vague.

Remove acvp_load_kat_filename; this API seemed to just run a vector set but not save the results off anywhere. 

Make the registration builder log the name and mode of all algorithms when using info level logging.