### PR TITLE
Added sleep API that is platform indepedent

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -233,11 +233,7 @@ int main(int argc, char **argv) {
         printf("* your configuration. Proceed at your own risk. Continuing in 5 seconds...        *\n");
         printf("***********************************************************************************\n");
         printf("\n");
-        #ifdef _WIN32
-            Sleep(5 * 1000);
-        #else
-            sleep(5);
-        #endif
+        acvp_sleep(5);
     }
 #endif
 

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -4560,6 +4560,13 @@ ACVP_SUB_DRBG acvp_get_drbg_alg(ACVP_CIPHER cipher);
 ACVP_SUB_KAS acvp_get_kas_alg(ACVP_CIPHER cipher);
 ACVP_SUB_LMS acvp_get_lms_alg(ACVP_CIPHER cipher);
 
+/**
+ * @brief acvp_sleep() waits a given number of seconds before continuing processing. This function performs identically across platforms.
+ *
+ * @param seconds the number of seconds to wait
+ */
+void acvp_sleep(int seconds);
+
 /** @} */
 /** @internal ALL APIS SHOULD BE ADDED ABOVE THESE BLOCKS */
 

--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -145,3 +145,4 @@ EXPORTS
   acvp_get_drbg_alg
   acvp_get_kas_alg
   acvp_get_kmac_alg
+  acvp_sleep

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2774,14 +2774,7 @@ static ACVP_RESULT acvp_retry_handler(ACVP_CTX *ctx, int *retry_period, unsigned
         ACVP_LOG_STATUS("200 OK, waiting %u seconds and trying again...", *retry_period);
     }
 
-    #ifdef _WIN32
-    /*
-     * Windows uses milliseconds
-     */
-    Sleep(*retry_period * 1000);
-    #else
-    sleep(*retry_period);
-    #endif
+    acvp_sleep(*retry_period);
 
     /* ensure that all parameters are valid and that we do not wait longer than ACVP_MAX_WAIT_TIME */
     if (modifier < 1 || modifier > ACVP_RETRY_MODIFIER_MAX) {

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -4678,12 +4678,15 @@ ACVP_RESULT acvp_build_registration_json(ACVP_CTX *ctx, JSON_Value **reg) {
              */
             cap_val = json_value_init_object();
             cap_obj = json_value_get_object(cap_val);
-            name = acvp_lookup_cipher_name(cap_entry->cipher);
-            if (name) {
-                ACVP_LOG_INFO("Building registration for %s", name);
-                mode = acvp_lookup_cipher_mode_str(cap_entry->cipher);
-                if (mode) {
-                    ACVP_LOG_INFO("    Mode: %s", mode);
+
+            if (ctx->log_lvl >= ACVP_LOG_LVL_INFO) {
+                name = acvp_lookup_cipher_name(cap_entry->cipher);
+                if (name) {
+                    ACVP_LOG_INFO("Building registration for %s", name);
+                    mode = acvp_lookup_cipher_mode_str(cap_entry->cipher);
+                    if (mode) {
+                        ACVP_LOG_INFO("    Mode: %s", mode);
+                    }
                 }
             }
 

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -1470,3 +1470,10 @@ end:
     return return_code;
 }
 
+void acvp_sleep(int seconds) {
+#ifdef _WIN32
+    Sleep(seconds * 1000);
+#else
+    sleep(seconds);
+#endif
+}


### PR DESCRIPTION
Since libacvp runs on many different types of platforms, adding an acvp_sleep API to make things a bit cleaner and avoid extra ifdefs. application code can use as well.

Also included a small optimization to the just added alg name logging code.