### PR TITLE
Edits to caps; AES-GCM min IV, KDF108 allowed hashes

### DIFF
--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -3025,7 +3025,7 @@ ACVP_RESULT acvp_cap_kts_ifc_set_param_string(ACVP_CTX *ctx,
 ACVP_RESULT acvp_cap_kts_ifc_set_scheme_string(ACVP_CTX *ctx,
                                                ACVP_CIPHER cipher,
                                                ACVP_KTS_IFC_SCHEME_TYPE scheme,
-                                               ACVP_KTS_IFC_PARAM param,
+                                               ACVP_KTS_IFC_SCHEME_PARAM param,
                                                char *value);
 
 /**

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -1560,7 +1560,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
     case ACVP_AES_GCM:
         switch (parm) {
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
-            if (min >= 8 && max <= 1024) {
+            if (min >= 0 && max <= 1024) {
                 retval = ACVP_SUCCESS;
             }
             break;
@@ -5733,11 +5733,23 @@ ACVP_RESULT acvp_cap_kdf108_set_parm(ACVP_CTX *ctx,
             result = acvp_append_name_list(&mode_obj->mac_mode, ACVP_ALG_HMAC_SHA2_512);
             break;
         case ACVP_KDF108_MAC_MODE_HMAC_SHA512_224:
+            result = acvp_append_name_list(&mode_obj->mac_mode, ACVP_ALG_HMAC_SHA2_512_224);
+            break;
         case ACVP_KDF108_MAC_MODE_HMAC_SHA512_256:
+            result = acvp_append_name_list(&mode_obj->mac_mode, ACVP_ALG_HMAC_SHA2_512_256);
+            break;
         case ACVP_KDF108_MAC_MODE_HMAC_SHA3_224:
+            result = acvp_append_name_list(&mode_obj->mac_mode, ACVP_ALG_HMAC_SHA3_224);
+            break;
         case ACVP_KDF108_MAC_MODE_HMAC_SHA3_256:
+            result = acvp_append_name_list(&mode_obj->mac_mode, ACVP_ALG_HMAC_SHA3_256);
+            break;
         case ACVP_KDF108_MAC_MODE_HMAC_SHA3_384:
+            result = acvp_append_name_list(&mode_obj->mac_mode, ACVP_ALG_HMAC_SHA3_384);
+            break;
         case ACVP_KDF108_MAC_MODE_HMAC_SHA3_512:
+            result = acvp_append_name_list(&mode_obj->mac_mode, ACVP_ALG_HMAC_SHA3_512);
+            break;
         default:
             return ACVP_INVALID_ARG;
         }

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -8541,7 +8541,7 @@ ACVP_RESULT acvp_cap_kts_ifc_set_param_string(ACVP_CTX *ctx,
 ACVP_RESULT acvp_cap_kts_ifc_set_scheme_string(ACVP_CTX *ctx,
                                                ACVP_CIPHER cipher,
                                                ACVP_KTS_IFC_SCHEME_TYPE scheme,
-                                               ACVP_KTS_IFC_PARAM param,
+                                               ACVP_KTS_IFC_SCHEME_PARAM param,
                                                char *value) {
     unsigned int len = strnlen_s(value, ACVP_CAPABILITY_STR_MAX + 1);
     ACVP_KTS_IFC_CAP *kts_ifc_cap = NULL;
@@ -8600,7 +8600,6 @@ ACVP_RESULT acvp_cap_kts_ifc_set_scheme_string(ACVP_CTX *ctx,
     case ACVP_KTS_IFC_ROLE:
     case ACVP_KTS_IFC_L:
     case ACVP_KTS_IFC_MAC_METHODS:
-    case ACVP_KTS_IFC_FIXEDPUBEXP:
     default:
         ACVP_LOG_ERR("Invalid param");
         return ACVP_INVALID_ARG;

--- a/src/acvp_kda.c
+++ b/src/acvp_kda.c
@@ -126,6 +126,7 @@ static ACVP_RESULT acvp_kda_onestep_init_tc(ACVP_CTX *ctx,
                                              ACVP_KDA_TEST_TYPE test_type) {
     ACVP_RESULT rv;
 
+    stc->cipher = ACVP_KDA_ONESTEP;
     stc->tc_id = tc_id;
     stc->type = test_type;
     stc->aux_function = aux_function;
@@ -319,6 +320,7 @@ static ACVP_RESULT acvp_kda_twostep_init_tc(ACVP_CTX *ctx,
                                              ACVP_KDA_TEST_TYPE test_type) {
     ACVP_RESULT rv;
 
+    stc->cipher = ACVP_KDA_TWOSTEP;
     stc->tc_id = tc_id;
     stc->type = test_type;
     stc->macFunction = mac_mode;
@@ -480,6 +482,7 @@ static ACVP_RESULT acvp_kda_hkdf_init_tc(ACVP_CTX *ctx,
                                              ACVP_KDA_TEST_TYPE test_type) {
     ACVP_RESULT rv;
 
+    stc->cipher = ACVP_KDA_HKDF;
     stc->tc_id = tc_id;
     stc->type = test_type;
     stc->hmacAlg = hmac_alg;


### PR DESCRIPTION
Both changes tested against 3.0.8 and 3.1.