### PR TITLE
Various bugfixes and capability fixes

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1064,7 +1064,20 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN,
                                   0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
-
+#if 0
+    /*  TEST: 1) malloc buffer, concat full message, process with a single call;
+     *        2) oneshot function or a single call to update; never multiple calls to update
+     *        3) allowed for SHA1 and SHA2 (all), not SHA3 or SHAKE
+     */
+    rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA1, ACVP_HASH_LARGE_DATA, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA1, ACVP_HASH_LARGE_DATA, 2);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA1, ACVP_HASH_LARGE_DATA, 4);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA1, ACVP_HASH_LARGE_DATA, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+#endif
     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA224, ACVP_HASH_MESSAGE_LEN,
@@ -1614,6 +1627,28 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_FIXED_DATA_ORDER, ACVP_KDF108_FIXED_DATA_ORDER_BEFORE);
     CHECK_ENABLE_CAP_RV(rv);
+
+    /* KDF108 KMAC Mode */
+#if 0
+    /* Only valid for OpenSSL 3.1 */
+    /* Call sequence is very close to regular kdf108, with no creation of fixed data */
+    #if OPENSSL_VERSION_NUMBER >= 0x30100000L
+	rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_KMAC, value);
+	CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_KMAC_128);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_KMAC_256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_DERIVATION_KEYLEN, 112, 4096, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_DERIVED_KEYLEN, 112, 4096, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_CONTEXT_LEN, 8, 4096, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_LABEL_LEN, 8, 4096, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    #endif
+#endif
 
     /* PBKDF */
     rv = acvp_cap_pbkdf_enable(ctx, &app_pbkdf_handler);

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -523,7 +523,8 @@ typedef enum acvp_kdf135_srtp_param {
 typedef enum acvp_kdf108_mode {
     ACVP_KDF108_MODE_COUNTER = 1,
     ACVP_KDF108_MODE_FEEDBACK,
-    ACVP_KDF108_MODE_DPI
+    ACVP_KDF108_MODE_DPI,
+    ACVP_KDF108_MODE_KMAC
 } ACVP_KDF108_MODE;
 
 /** @enum ACVP_KDF108_MAC_MODE_VAL */
@@ -544,6 +545,8 @@ typedef enum acvp_kdf108_mac_mode_val {
     ACVP_KDF108_MAC_MODE_HMAC_SHA3_256,
     ACVP_KDF108_MAC_MODE_HMAC_SHA3_384,
     ACVP_KDF108_MAC_MODE_HMAC_SHA3_512,
+    ACVP_KDF108_MAC_MODE_KMAC_128,
+    ACVP_KDF108_MAC_MODE_KMAC_256,
     ACVP_KDF108_MAC_MODE_MAX
 } ACVP_KDF108_MAC_MODE_VAL;
 
@@ -798,6 +801,10 @@ typedef enum acvp_kdf108_param {
     ACVP_KDF108_COUNTER_LEN,
     ACVP_KDF108_SUPPORTS_EMPTY_IV,
     ACVP_KDF108_REQUIRES_EMPTY_IV,
+    ACVP_KDF108_DERIVATION_KEYLEN, /**< KDF108-KMAC only */
+    ACVP_KDF108_DERIVED_KEYLEN,    /**< KDF108-KMAC only */
+    ACVP_KDF108_CONTEXT_LEN,       /**< KDF108-KMAC only */
+    ACVP_KDF108_LABEL_LEN,         /**< KDF108-KMAC only */
     ACVP_KDF108_PARAM_MAX
 } ACVP_KDF108_PARM;
 
@@ -1305,13 +1312,17 @@ typedef struct acvp_kdf108_tc_t {
     ACVP_KDF108_MODE mode;
     ACVP_KDF108_MAC_MODE_VAL mac_mode;
     ACVP_KDF108_FIXED_DATA_ORDER_VAL counter_location;
-    unsigned char *key_in;
-    unsigned char *key_out;
+    unsigned char *key_in;      /**< KDF108-KMAC: KeyDerivationKey */
+    unsigned char *key_out;     /**< KDF108-KMAC: Generated Key (output) */
     unsigned char *fixed_data;
     unsigned char *iv;
+    unsigned char *context;     /**< KDF108-KMAC: Context */
+    unsigned char *label;       /**< KDF108-KMAC: Label */
     int key_in_len;             /**< Length of key_in (in bytes) */
     int key_out_len;            /**< Length of key_out (in bytes) */
     int iv_len;                 /**< Length of iv (in bytes) */
+    int context_len;            /**< Length of context (KMAC-only, in bytes) */
+    int label_len;              /**< Length of label (KMAC-only, in bytes) */
     int fixed_data_len;         /**< Length of fixed_data (in bytes).
                                      --- User supplied ---
                                      Must be <= ACVP_KDF108_FIXED_DATA_MAX */

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -641,7 +641,8 @@ typedef enum acvp_hash_param {
     ACVP_HASH_IN_EMPTY,
     ACVP_HASH_OUT_BIT, /**< Used for ACVP_HASH_SHAKE_128, ACVP_HASH_SHAKE_256 */
     ACVP_HASH_OUT_LENGTH, /**< Used for ACVP_HASH_SHAKE_128, ACVP_HASH_SHAKE_256 */
-    ACVP_HASH_MESSAGE_LEN
+    ACVP_HASH_MESSAGE_LEN,
+    ACVP_HASH_LARGE_DATA
 } ACVP_HASH_PARM;
 
 /**
@@ -985,7 +986,8 @@ typedef enum acvp_hash_testtype {
     ACVP_HASH_TEST_TYPE_NONE = 0,
     ACVP_HASH_TEST_TYPE_AFT,
     ACVP_HASH_TEST_TYPE_MCT,
-    ACVP_HASH_TEST_TYPE_VOT
+    ACVP_HASH_TEST_TYPE_VOT,
+    ACVP_HASH_TEST_TYPE_LDT
 } ACVP_HASH_TESTTYPE;
 
 /** @enum ACVP_CMAC_TESTTYPE */
@@ -1073,6 +1075,12 @@ typedef enum acvp_xof_support_option {
     ACVP_XOF_SUPPORT_BOTH
 } ACVP_XOF_SUPPORT_OPTION;
 
+/** @enum ACVP_HASH_EXPANSION_METHOD */
+typedef enum acvp_hash_expansion_method {
+    ACVP_HASH_EXPANSION_NA = 0,
+    ACVP_HASH_EXPANSION_REPEATING
+} ACVP_HASH_EXPANSION_METHOD;
+
 /**
  * @struct ACVP_SYM_CIPHER_TC
  * @brief This struct holds data that represents a single test case for a symmetric cipher, such as
@@ -1131,7 +1139,8 @@ typedef struct acvp_sym_cipher_tc_t {
 typedef struct acvp_hash_tc_t {
     ACVP_CIPHER cipher;
     unsigned int tc_id;           /**< Test case id */
-    ACVP_HASH_TESTTYPE test_type; /**< KAT or MCT or VOT */
+    ACVP_HASH_TESTTYPE test_type; /**< KAT, MCT, VOT, or LDT */
+    ACVP_HASH_EXPANSION_METHOD exp_method;  /**< LDT Expansion Technique  */
     unsigned char *msg; /**< Message input */
     unsigned char *m1; /**< Mesage input #1
                             Provided when \ref ACVP_HASH_TC.test_type is MCT */
@@ -1148,6 +1157,8 @@ typedef struct acvp_hash_tc_t {
     unsigned int xof_bit_len; /**< XOF (extendable output format) length
                                    The expected length (in bits) of \ref ACVP_HASH_TC.md
                                    Only provided when \ref ACVP_HASH_TC.test_type is VOT */
+    unsigned long long int exp_len; /**< The final length (in bytes) of the expanded content
+                                         Only provided when \ref ACVP_HASH_TC.test_type is LDT */
     unsigned char *md; /**< The resulting digest calculated for the test case.
                             SUPPLIED BY USER */
     unsigned int md_len; /**< The length (in bytes) of \ref ACVP_HASH_TC.md

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -3025,7 +3025,7 @@ ACVP_RESULT acvp_cap_kts_ifc_set_param_string(ACVP_CTX *ctx,
 ACVP_RESULT acvp_cap_kts_ifc_set_scheme_string(ACVP_CTX *ctx,
                                                ACVP_CIPHER cipher,
                                                ACVP_KTS_IFC_SCHEME_TYPE scheme,
-                                               ACVP_KTS_IFC_PARAM param,
+                                               ACVP_KTS_IFC_SCHEME_PARAM param,
                                                char *value);
 
 /**

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -77,6 +77,7 @@
 #define ACVP_REV_STR_SP800_56BR2 "Sp800-56Br2"
 #define ACVP_REV_STR_SP800_56CR1 "Sp800-56Cr1"
 #define ACVP_REV_STR_SP800_56CR2 "Sp800-56Cr2"
+#define ACVP_REV_STR_SP800_108R1 "Sp800-108r1"
 #define ACVP_REV_STR_RFC8446 "RFC8446"
 #define ACVP_REV_STR_RFC7627 "RFC7627"
 
@@ -363,6 +364,7 @@
 #define ACVP_MODE_COUNTER           "counter"
 #define ACVP_MODE_FEEDBACK          "feedback"
 #define ACVP_MODE_DPI               "double pipeline iteration"
+#define ACVP_MODE_KMAC              "KMAC"
 #define ACVP_KDF135_ALG_STR         "kdf-components"
 
 #define ACVP_AUTH_METHOD_DSA_STR "dsa"
@@ -686,6 +688,14 @@
 #define ACVP_KDF108_FIXED_DATA_BIT_MAX 512 /**< Arbitrary */
 #define ACVP_KDF108_FIXED_DATA_BYTE_MAX (ACVP_KDF108_FIXED_DATA_BIT_MAX >> 3)
 #define ACVP_KDF108_FIXED_DATA_STR_MAX (ACVP_KDF108_FIXED_DATA_BIT_MAX >> 2)
+
+#define ACVP_KDF108_CONTEXT_BIT_MAX 4096 /**< Based on supportedLengths */
+#define ACVP_KDF108_CONTEXT_BYTE_MAX (ACVP_KDF108_CONTEXT_BIT_MAX >> 3)
+#define ACVP_KDF108_CONTEXT_STR_MAX (ACVP_KDF108_CONTEXT_BIT_MAX >> 2)
+
+#define ACVP_KDF108_LABEL_BIT_MAX 4096 /**< Based on supportedLengths */
+#define ACVP_KDF108_LABEL_BYTE_MAX (ACVP_KDF108_LABEL_BIT_MAX >> 3)
+#define ACVP_KDF108_LABEL_STR_MAX (ACVP_KDF108_LABEL_BIT_MAX >> 2)
 /*
  * END KDF108
  */
@@ -1144,12 +1154,17 @@ typedef struct acvp_kdf108_mode_params {
     ACVP_SL_LIST *counter_lens;
     int empty_iv_support;
     int requires_empty_iv;
+    ACVP_JSON_DOMAIN_OBJ derivation_keylens;
+    ACVP_JSON_DOMAIN_OBJ derived_keylens;
+    ACVP_JSON_DOMAIN_OBJ context_lens;
+    ACVP_JSON_DOMAIN_OBJ label_lens;
 } ACVP_KDF108_MODE_PARAMS;
 
 typedef struct acvp_kdf108_capability {
     ACVP_KDF108_MODE_PARAMS counter_mode;
     ACVP_KDF108_MODE_PARAMS feedback_mode;
     ACVP_KDF108_MODE_PARAMS dpi_mode;
+    ACVP_KDF108_MODE_PARAMS kmac_mode;
 } ACVP_KDF108_CAP;
 
 typedef struct acvp_kdf135_ssh_capability {

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1128,6 +1128,7 @@ typedef struct acvp_hash_capability {
                       Only for ACVP_HASH_SHAKE_* */
     ACVP_JSON_DOMAIN_OBJ out_len; /**< Required for ACVP_HASH_SHAKE_* */
     ACVP_JSON_DOMAIN_OBJ msg_length;
+    ACVP_SL_LIST *large_lens;
 } ACVP_HASH_CAP;
 
 typedef struct acvp_kdf135_snmp_capability {

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -3011,7 +3011,7 @@ static ACVP_RESULT acvp_dispatch_vector_set(ACVP_CTX *ctx, JSON_Object *obj) {
                  ACVP_ALG_NAME_MAX,
                  alg, &diff);
         if (!diff) {
-            if (mode == NULL) {
+            if (mode == NULL || alg_tbl[i].cipher == ACVP_KDF108) { // KDF108-KMAC has a mode!
                 rv = (alg_tbl[i].handler)(ctx, obj);
                 return rv;
             }

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -11,12 +11,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#ifdef _WIN32
-#include <io.h>
-#include <Windows.h>
-#else
-#include <unistd.h>
-#endif
 #include <math.h>
 #include "acvp.h"
 #include "acvp_lcl.h"

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -568,6 +568,17 @@ static void acvp_cap_free_kdf108(ACVP_KDF108_CAP *cap) {
             acvp_cap_free_domain(&mode_obj->supported_lens);
         }
 
+        if (cap->kmac_mode.kdf_mode) {
+            mode_obj = &cap->kmac_mode;
+            if (mode_obj->mac_mode) {
+                acvp_cap_free_nl(mode_obj->mac_mode);
+            }
+            acvp_cap_free_domain(&mode_obj->derivation_keylens);
+            acvp_cap_free_domain(&mode_obj->derived_keylens);
+            acvp_cap_free_domain(&mode_obj->context_lens);
+            acvp_cap_free_domain(&mode_obj->label_lens);
+        }
+
         cap = NULL;
     }
 }

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -927,7 +927,7 @@ static ACVP_RESULT acvp_build_drbg_register_cap(JSON_Object *cap_obj, ACVP_CAPS_
     JSON_Array *capabilities_array = NULL;
     const char *mode_str = NULL;
 
-    if (!&cap_entry->cap.drbg_cap) {
+    if (!cap_entry->cap.drbg_cap) {
         return ACVP_NO_CAP;
     } else {
         cap = cap_entry->cap.drbg_cap;

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -92,6 +92,8 @@ static ACVP_RESULT acvp_lookup_prereqVals(JSON_Object *cap_obj, ACVP_CAPS_LIST *
 
 static ACVP_RESULT acvp_build_hash_register_cap(JSON_Object *cap_obj, ACVP_CAPS_LIST *cap_entry) {
     JSON_Array *msg_array = NULL;
+    JSON_Array *temp_arr = NULL;
+    ACVP_SL_LIST *sl_list = NULL;
     JSON_Value *msg_val = NULL;
     JSON_Object *msg_obj = NULL;
     ACVP_HASH_CAP *hash_cap = cap_entry->cap.hash_cap;
@@ -147,6 +149,17 @@ static ACVP_RESULT acvp_build_hash_register_cap(JSON_Object *cap_obj, ACVP_CAPS_
         json_object_set_number(msg_obj, "max", hash_cap->msg_length.max);
         json_object_set_number(msg_obj, "increment", hash_cap->msg_length.increment);
         json_array_append_value(msg_array, msg_val);
+
+        /* Set the supported large data lengths */
+        if (cap_entry->cap.hash_cap->large_lens) {
+            json_object_set_value(cap_obj, "performLargeDataTest", json_value_init_array());
+            temp_arr = json_object_get_array(cap_obj, "performLargeDataTest");
+            sl_list = cap_entry->cap.hash_cap->large_lens;
+            while (sl_list) {
+                json_array_append_number(temp_arr, sl_list->length);
+                sl_list = sl_list->next;
+            }
+        }
     }
 
     return ACVP_SUCCESS;

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -1560,7 +1560,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
     case ACVP_AES_GCM:
         switch (parm) {
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
-            if (min >= 8 && max <= 1024) {
+            if (min >= 0 && max <= 1024) {
                 retval = ACVP_SUCCESS;
             }
             break;
@@ -6555,7 +6555,6 @@ static ACVP_RESULT acvp_add_kas_ecc_prereq_val(ACVP_CTX *ctx, ACVP_KAS_ECC_CAP_M
                                                char *value) {
     ACVP_PREREQ_LIST *prereq_entry, *prereq_entry_2;
 
-    ACVP_LOG_INFO("KAS-ECC mode %d", mode);
     prereq_entry = calloc(1, sizeof(ACVP_PREREQ_LIST));
     if (!prereq_entry) {
         return ACVP_MALLOC_FAIL;
@@ -8529,7 +8528,7 @@ ACVP_RESULT acvp_cap_kts_ifc_set_param_string(ACVP_CTX *ctx,
 ACVP_RESULT acvp_cap_kts_ifc_set_scheme_string(ACVP_CTX *ctx,
                                                ACVP_CIPHER cipher,
                                                ACVP_KTS_IFC_SCHEME_TYPE scheme,
-                                               ACVP_KTS_IFC_PARAM param,
+                                               ACVP_KTS_IFC_SCHEME_PARAM param,
                                                char *value) {
     unsigned int len = strnlen_s(value, ACVP_CAPABILITY_STR_MAX + 1);
     ACVP_KTS_IFC_CAP *kts_ifc_cap = NULL;
@@ -8588,7 +8587,6 @@ ACVP_RESULT acvp_cap_kts_ifc_set_scheme_string(ACVP_CTX *ctx,
     case ACVP_KTS_IFC_ROLE:
     case ACVP_KTS_IFC_L:
     case ACVP_KTS_IFC_MAC_METHODS:
-    case ACVP_KTS_IFC_FIXEDPUBEXP:
     default:
         ACVP_LOG_ERR("Invalid param");
         return ACVP_INVALID_ARG;

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -608,8 +608,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                     rv = ACVP_INVALID_ARG;
                     goto err;
                 }
-            }            
-            else {
+            } else {
                 msg = json_object_get_string(testobj, "msg");
                 if (!msg) {
                     ACVP_LOG_ERR("Server JSON missing 'msg'");
@@ -851,8 +850,7 @@ static ACVP_RESULT acvp_hash_init_tc(ACVP_CTX *ctx,
         stc->msg_len = msg_len;
         stc->exp_len = exp_len;
         stc->exp_method = exp_method;
-    }
-    else {
+    } else {
         stc->msg_len = (msg_len + 7) / 8;
         stc->xof_len = (xof_len + 7) / 8;
         stc->xof_bit_len = xof_len;

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -32,6 +32,8 @@ static ACVP_RESULT acvp_hash_init_tc(ACVP_CTX *ctx,
                                      unsigned int msg_len,
                                      const char *msg,
                                      unsigned int xof_len,
+                                     unsigned long long int exp_len,  // LDT expected data length
+                                     ACVP_HASH_EXPANSION_METHOD exp_method,
                                      ACVP_CIPHER alg_id);
 
 static ACVP_RESULT acvp_hash_release_tc(ACVP_HASH_TC *stc);
@@ -382,6 +384,22 @@ static ACVP_HASH_TESTTYPE read_test_type(const char *tt_str) {
         return ACVP_HASH_TEST_TYPE_VOT;
     }
 
+    strcmp_s("LDT", 3, tt_str, &diff);
+    if (!diff) {
+        return ACVP_HASH_TEST_TYPE_LDT;
+    }
+
+    return 0;
+}
+
+static ACVP_HASH_EXPANSION_METHOD read_exp_method(const char *exp_str) {
+    int diff = 0;
+
+    strcmp_s("repeating", 9, exp_str, &diff);
+    if (!diff) {
+        return ACVP_HASH_EXPANSION_REPEATING;
+    }
+
     return 0;
 }
 
@@ -393,6 +411,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     JSON_Object *testobj = NULL;
     JSON_Array *groups;
     JSON_Array *tests;
+    JSON_Object *ldtobj = NULL;  // Inner object for LDTs
 
     JSON_Value *reg_arry_val = NULL;
     JSON_Object *reg_obj = NULL;
@@ -412,9 +431,11 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     JSON_Array *res_tarr = NULL; /* Response resultsArray */
     ACVP_RESULT rv = ACVP_SUCCESS;
     ACVP_CIPHER alg_id = 0;
+    ACVP_HASH_EXPANSION_METHOD exp_method = 0;
     char *json_result = NULL;
     const char *alg_str = NULL;
     const char *test_type_str, *msg = NULL;
+    const char *exp_method_str = NULL;
 
     if (!ctx) {
         ACVP_LOG_ERR("No ctx for handler operation");
@@ -470,6 +491,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         ACVP_HASH_TESTTYPE test_type = 0;
         int tgId = 0;
         unsigned int min_xof_len = 0, max_xof_len = 0;
+        unsigned long long int exp_len = 0LL;
 
         groupval = json_array_get_value(groups, i);
         groupobj = json_value_get_object(groupval);
@@ -544,33 +566,78 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             tc_id = json_object_get_number(testobj, "tcId");
 
-            msg = json_object_get_string(testobj, "msg");
-            if (!msg) {
-                ACVP_LOG_ERR("Server JSON missing 'msg'");
-                rv = ACVP_MISSING_ARG;
-                goto err;
-            }
-            if (alg_id != ACVP_HASH_SHAKE_128 && alg_id != ACVP_HASH_SHAKE_256) {
-                max_len = ACVP_HASH_MSG_STR_MAX;
-            } else {
-                max_len = ACVP_SHAKE_MSG_STR_MAX;
-            }
-            tmp_msg_len = strnlen_s(msg, max_len + 1);
-            if (tmp_msg_len > max_len) {
-                ACVP_LOG_ERR("'msg' too long, max allowed=(%d)", max_len);
-                rv = ACVP_INVALID_ARG;
-                goto err;
-            }
-            // Convert to bits
-            msglen = tmp_msg_len * 4;
-
-            if (test_type == ACVP_HASH_TEST_TYPE_VOT) {
-                xof_len = json_object_get_number(testobj, "outLen");
-                if (!(xof_len >= ACVP_HASH_XOF_MD_BIT_MIN &&
-                      xof_len <= ACVP_HASH_XOF_MD_BIT_MAX)) {
-                    ACVP_LOG_ERR("Server JSON invalid 'outLen'(%d)", xof_len);
+            // Based on test type: LDT vs AFT && VOT
+            if (test_type == ACVP_HASH_TEST_TYPE_LDT) {
+                if (alg_id < ACVP_HASH_SHA1 || alg_id > ACVP_HASH_SHA512_256) {
+                    ACVP_LOG_ERR("Server JSON invalid test type for non-SHA1 or SHA2)");
                     rv = ACVP_INVALID_ARG;
                     goto err;
+                }
+
+                ldtobj = json_object_get_object(testobj, "largeMsg");
+
+                msg = json_object_get_string(ldtobj, "content");
+                if (!msg) {
+                    ACVP_LOG_ERR("Server JSON missing 'content'");
+                    rv = ACVP_MISSING_ARG;
+                    goto err;
+                }
+                max_len = ACVP_HASH_MSG_STR_MAX;
+                tmp_msg_len = strnlen_s(msg, max_len + 1);
+                if (tmp_msg_len > max_len) {
+                    ACVP_LOG_ERR("'msg' too long, max allowed=(%d)", max_len);
+                    rv = ACVP_INVALID_ARG;
+                    goto err;
+                }
+                msglen = tmp_msg_len/2;  // tmp_msg_len is ASCII chars, we store hex bytes
+
+                max_len = json_object_get_number(ldtobj, "contentLength")/8;  // In bits; store as bytes
+                if (msglen != max_len) {
+                    ACVP_LOG_ERR("Length of content (%d) does not match stated length (%d)", tmp_msg_len, max_len);
+                    rv = ACVP_INVALID_ARG;
+                    goto err;
+                }
+
+                exp_len = json_object_get_number(ldtobj, "fullLength")/8;  // In bits; store as bytes
+                // Variable size, and large; no need to validate
+
+                exp_method_str = json_object_get_string(ldtobj, "expansionTechnique");
+                exp_method = read_exp_method(exp_method_str);
+                if (exp_method != ACVP_HASH_EXPANSION_REPEATING) {
+                    ACVP_LOG_ERR("Invalid LDT expansion technique (only 'repeating' is allowed for Hash/SHA).");
+                    rv = ACVP_INVALID_ARG;
+                    goto err;
+                }
+            }            
+            else {
+                msg = json_object_get_string(testobj, "msg");
+                if (!msg) {
+                    ACVP_LOG_ERR("Server JSON missing 'msg'");
+                    rv = ACVP_MISSING_ARG;
+                    goto err;
+                }
+                if (alg_id != ACVP_HASH_SHAKE_128 && alg_id != ACVP_HASH_SHAKE_256) {
+                    max_len = ACVP_HASH_MSG_STR_MAX;
+                } else {
+                    max_len = ACVP_SHAKE_MSG_STR_MAX;
+                }
+                tmp_msg_len = strnlen_s(msg, max_len + 1);
+                if (tmp_msg_len > max_len) {
+                    ACVP_LOG_ERR("'msg' too long, max allowed=(%d)", max_len);
+                    rv = ACVP_INVALID_ARG;
+                    goto err;
+                }
+                // Convert to bits
+                msglen = tmp_msg_len * 4;
+
+                if (test_type == ACVP_HASH_TEST_TYPE_VOT) {
+                    xof_len = json_object_get_number(testobj, "outLen");
+                    if (!(xof_len >= ACVP_HASH_XOF_MD_BIT_MIN &&
+                        xof_len <= ACVP_HASH_XOF_MD_BIT_MAX)) {
+                        ACVP_LOG_ERR("Server JSON invalid 'outLen'(%d)", xof_len);
+                        rv = ACVP_INVALID_ARG;
+                        goto err;
+                    }
                 }
             }
 
@@ -580,6 +647,9 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             ACVP_LOG_VERBOSE("              msg: %s", msg);
             if (test_type == ACVP_HASH_TEST_TYPE_VOT) {
                 ACVP_LOG_VERBOSE("    outLen: %d", xof_len);
+            }
+            if (test_type == ACVP_HASH_TEST_TYPE_LDT) {
+                ACVP_LOG_VERBOSE("       fullLength: %llu", exp_len);
             }
             ACVP_LOG_VERBOSE("         testtype: %s", test_type_str);
 
@@ -595,7 +665,8 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              * Setup the test case data that will be passed down to
              * the crypto module.
              */
-            rv = acvp_hash_init_tc(ctx, &stc, tc_id, test_type, msglen, msg, xof_len,alg_id);
+            rv = acvp_hash_init_tc(ctx, &stc, tc_id, test_type, msglen, msg, 
+                                    xof_len, exp_len, exp_method, alg_id);
             if (rv != ACVP_SUCCESS) {
                 ACVP_LOG_ERR("Init for stc (test case) failed");
                 acvp_hash_release_tc(&stc);
@@ -714,6 +785,8 @@ static ACVP_RESULT acvp_hash_init_tc(ACVP_CTX *ctx,
                                      unsigned int msg_len,
                                      const char *msg,
                                      unsigned int xof_len,
+                                     unsigned long long int exp_len,  // LDT expected data length
+                                     ACVP_HASH_EXPANSION_METHOD exp_method,
                                      ACVP_CIPHER alg_id) {
     ACVP_RESULT rv;
 
@@ -725,7 +798,8 @@ static ACVP_RESULT acvp_hash_init_tc(ACVP_CTX *ctx,
     }
     if (!stc->msg) { return ACVP_MALLOC_FAIL; }
 
-    if (test_type == ACVP_HASH_TEST_TYPE_AFT) {
+    if (test_type == ACVP_HASH_TEST_TYPE_AFT ||
+        test_type == ACVP_HASH_TEST_TYPE_LDT) {
         /* AFT */
         stc->md = calloc(1, ACVP_HASH_MD_BYTE_MAX);
         if (!stc->md) { return ACVP_MALLOC_FAIL; }
@@ -771,11 +845,18 @@ static ACVP_RESULT acvp_hash_init_tc(ACVP_CTX *ctx,
     }
 
     stc->tc_id = tc_id;
-    stc->msg_len = (msg_len + 7) / 8;
-    stc->xof_len = (xof_len + 7) / 8;
-    stc->xof_bit_len = xof_len;
     stc->cipher = alg_id;
     stc->test_type = test_type;
+    if (stc->test_type == ACVP_HASH_TEST_TYPE_LDT) {
+        stc->msg_len = msg_len;
+        stc->exp_len = exp_len;
+        stc->exp_method = exp_method;
+    }
+    else {
+        stc->msg_len = (msg_len + 7) / 8;
+        stc->xof_len = (xof_len + 7) / 8;
+        stc->xof_bit_len = xof_len;
+    }
 
     return ACVP_SUCCESS;
 }

--- a/src/acvp_kda.c
+++ b/src/acvp_kda.c
@@ -126,6 +126,7 @@ static ACVP_RESULT acvp_kda_onestep_init_tc(ACVP_CTX *ctx,
                                              ACVP_KDA_TEST_TYPE test_type) {
     ACVP_RESULT rv;
 
+    stc->cipher = ACVP_KDA_ONESTEP;
     stc->tc_id = tc_id;
     stc->type = test_type;
     stc->aux_function = aux_function;
@@ -319,6 +320,7 @@ static ACVP_RESULT acvp_kda_twostep_init_tc(ACVP_CTX *ctx,
                                              ACVP_KDA_TEST_TYPE test_type) {
     ACVP_RESULT rv;
 
+    stc->cipher = ACVP_KDA_TWOSTEP;
     stc->tc_id = tc_id;
     stc->type = test_type;
     stc->macFunction = mac_mode;
@@ -480,6 +482,7 @@ static ACVP_RESULT acvp_kda_hkdf_init_tc(ACVP_CTX *ctx,
                                              ACVP_KDA_TEST_TYPE test_type) {
     ACVP_RESULT rv;
 
+    stc->cipher = ACVP_KDA_HKDF;
     stc->tc_id = tc_id;
     stc->type = test_type;
     stc->hmacAlg = hmac_alg;

--- a/src/acvp_kdf108.c
+++ b/src/acvp_kdf108.c
@@ -53,8 +53,7 @@ static ACVP_RESULT acvp_kdf108_output_tc(ACVP_CTX *ctx,
     }
     if (stc->mode == ACVP_KDF108_MODE_KMAC) {
         json_object_set_string(tc_rsp, "derivedKey", tmp);
-    }
-    else {
+    } else {
         json_object_set_string(tc_rsp, "keyOut", tmp);
         free(tmp);
 
@@ -135,8 +134,7 @@ static ACVP_RESULT acvp_kdf108_init_tc(ACVP_KDF108_TC *stc,
             rv = acvp_hexstr_to_bin(label, stc->label, label_len, NULL);
             if (rv != ACVP_SUCCESS) return rv;
         }
-    }
-    else {
+    } else {
         stc->fixed_data = calloc(ACVP_KDF108_FIXED_DATA_BYTE_MAX, sizeof(unsigned char));
         if (!stc->fixed_data) { return ACVP_MALLOC_FAIL; }
 
@@ -447,8 +445,7 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 rv = ACVP_INVALID_ARG;
                 goto err;
             }
-        }
-        else {
+        } else {
             kdf_mode_str = json_object_get_string(groupobj, "kdfMode");
             if (!kdf_mode_str) {
                 ACVP_LOG_ERR("Failed to include kdfMode");
@@ -591,8 +588,7 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 // Get the keyout byte length  (+1 for overflow bits)
                 key_out_len = (key_out_bit_len + 7) / 8;
 
-            }
-            else {
+            } else {
                 key_in_str = json_object_get_string(testobj, "keyIn");
                 if (!key_in_str) {
                     ACVP_LOG_ERR("Server JSON missing keyIn");
@@ -647,8 +643,7 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 ACVP_LOG_VERBOSE(" keyDerivationKey: %s", key_in_str);
                 ACVP_LOG_VERBOSE("          context: %s", context_str);
                 ACVP_LOG_VERBOSE("            label: %s", label_str);
-            }
-            else {
+            } else {
                 ACVP_LOG_VERBOSE("            keyIn: %s", key_in_str);
                 ACVP_LOG_VERBOSE("         deferred: %d", deferred);
             }

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -1477,3 +1477,4 @@ void acvp_sleep(int seconds) {
     sleep(seconds);
 #endif
 }
+

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -17,6 +17,13 @@
 #include "acvp_lcl.h"
 #include "safe_lib.h"
 
+#ifdef _WIN32
+#include <io.h>
+#include <Windows.h>
+#else
+#include <unistd.h>
+#endif
+
 #ifdef USE_MURL
 #include "murl.h"
 #elif !defined ACVP_OFFLINE


### PR DESCRIPTION
Fix DRBG ptr ref error
Fix AES-GCM min IV length (8->0)
Fix arguments and enum for KTS IFC set scheme function
Set ciphers in KDA TC structs
Add blank line before EOF (some editors complain without it)