### PR TITLE
Merge GET apis, rsa fix

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -307,15 +307,10 @@ int main(int argc, char **argv) {
     }
 
     if (cfg.get) {
-        rv = acvp_mark_as_get_only(ctx, cfg.get_string);
+        rv = acvp_mark_as_get_only(ctx, cfg.get_string, cfg.save_to ? cfg.save_file : NULL);
         if (rv != ACVP_SUCCESS) {
             printf("Failed to mark as get only.\n");
             goto end;
-        } else if (cfg.save_to) {
-            rv = acvp_set_get_save_file(ctx, cfg.save_file);
-            if (rv != ACVP_SUCCESS) {
-                printf("Failed to set save file for get request, continuing anyway...\n");
-            }
         }
     }
 

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -4285,23 +4285,11 @@ ACVP_RESULT acvp_mark_as_request_only(ACVP_CTX *ctx, char *filename);
  *
  * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
  * @param string used for the get, such as '/acvp/v1/requests/383'
+ * @param save_filename an optional parameter that results in the GET output being saved to a file
  *
  * @return ACVP_RESULT
  */
-ACVP_RESULT acvp_mark_as_get_only(ACVP_CTX *ctx, char *string);
-
-/**
- * @brief acvp_set_get_save_file() indicates a file to save get requests to. This function will
- *        only work if acvp_mark_as_get_only() has already been successfully called. It will take a
- *        string parameter for the location to save the results from the GET request indicated in
- *        acvp_mark_as_get_only() to as a file.
- *
- * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
- * @param filename location to save the GET results to (assumes data in JSON format)
- *
- * @return ACVP_RESULT
- */
-ACVP_RESULT acvp_set_get_save_file(ACVP_CTX *ctx, char *filename);
+ACVP_RESULT acvp_mark_as_get_only(ACVP_CTX *ctx, char *string, const char *save_filename);
 
 /**
  * @brief acvp_mark_as_post_only() marks the operation as a POST only. This function will take the

--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -91,7 +91,6 @@ EXPORTS
   acvp_mark_as_sample
   acvp_mark_as_request_only
   acvp_mark_as_get_only
-  acvp_set_get_save_file
   acvp_mark_as_post_only
   acvp_mark_as_put_after_test
   acvp_run

--- a/src/acvp_rsa_keygen.c
+++ b/src/acvp_rsa_keygen.c
@@ -648,7 +648,7 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             if (info_gen_by_server) {
                 unsigned int count = 0;
 
-                if (rand_pq == ACVP_RSA_KEYGEN_B36) {
+                if (rand_pq >= ACVP_RSA_KEYGEN_B34) {
                     bitlens = json_object_get_array(testobj, "bitlens");
                     count = json_array_get_count(bitlens);
                     if (count != 4) {

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -487,10 +487,7 @@ Test(RUN, marked_as_get, .init = setup_full_ctx, .fini = teardown) {
     rv = acvp_set_2fa_callback(ctx, &dummy_totp);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_mark_as_get_only(ctx, "/acvp/v1/test");
-    cr_assert(rv == ACVP_SUCCESS);
-    
-    rv = acvp_set_get_save_file(ctx, "filename.json");
+    rv = acvp_mark_as_get_only(ctx, "/acvp/v1/test", "filename.json");
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_run(ctx, 0);
@@ -762,38 +759,27 @@ Test(PROCESS_TESTS, mark_as_request_only, .init = setup_full_ctx, .fini = teardo
  */
 Test(PROCESS_TESTS, mark_as_get_only, .init = setup_full_ctx, .fini = teardown) {
 
-    rv = acvp_mark_as_get_only(NULL, "test");
+    rv = acvp_mark_as_get_only(NULL, "test", NULL);
     cr_assert(rv == ACVP_NO_CTX);
 
-    rv = acvp_mark_as_get_only(ctx, NULL);
+    rv = acvp_mark_as_get_only(ctx, NULL, NULL);
     cr_assert(rv == ACVP_MISSING_ARG);
 
-    rv = acvp_mark_as_get_only(ctx, "test");
+    rv = acvp_mark_as_get_only(ctx, "test", NULL);
     cr_assert(rv == ACVP_SUCCESS);
+
+    rv = acvp_mark_as_get_only(ctx, "", NULL);
+    cr_assert(rv == ACVP_INVALID_ARG);
+
+    rv = acvp_mark_as_get_only(ctx, "testFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLong", NULL);
+    cr_assert(rv == ACVP_INVALID_ARG);
+
+    rv = acvp_mark_as_get_only(ctx, "test", "testFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLong");
+    cr_assert(rv == ACVP_INVALID_ARG);
+
+    rv = acvp_mark_as_get_only(ctx, "test", "");
+    cr_assert(rv == ACVP_INVALID_ARG);
 }
-
-/*
- * Test acvp_set_get_save_file
- */
- Test(PROCESS_TESTS, set_get_save_file, .init = setup_full_ctx, .fini = teardown) {
-    rv = acvp_set_get_save_file(ctx, "haventCalledGetOnly.json");
-    cr_assert(rv == ACVP_UNSUPPORTED_OP);
-
-    rv = acvp_mark_as_get_only(ctx, "test");
-    cr_assert(rv == ACVP_SUCCESS);
-
-    rv = acvp_set_get_save_file(NULL, "noCtx.json");
-    cr_assert(rv == ACVP_NO_CTX);
-
-    rv = acvp_set_get_save_file(ctx, NULL);
-    cr_assert(rv == ACVP_MISSING_ARG);
-
-    rv = acvp_set_get_save_file(ctx, "testFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLongtestFileNameTooLong");
-    cr_assert(rv == ACVP_INVALID_ARG);
-
-    rv = acvp_set_get_save_file(ctx, "");
-    cr_assert(rv == ACVP_INVALID_ARG);
- }
 
 /*
  * Test acvp_mark_as_delete_only


### PR DESCRIPTION
Previously, to set a save file for a GET we used acvp_set_get_save_file. This was a stopgap added in a minor release. Now that we are doing a major release, just modify the acvp_mark_as_get_only API to accommodate a save file.

Small RSA keygen fix.