### PR TITLE
RSA primitive revision updates

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -2675,7 +2675,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_INFO_GEN_BY_SERVER, 1);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_KEY_FORMAT_CRT, 0);
+    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_KEY_FORMAT, ACVP_RSA_KEY_FORMAT_CRT);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_RANDOM);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2951,7 +2951,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512_256, 32);
     CHECK_ENABLE_CAP_RV(rv);
 
-#ifdef OPENSSL_RSA_PRIMITIVE /* only enable as needed, decrypt can take a long time */
+#ifdef OPENSSL_RSA_PRIMITIVE
     /* Enable Decryption Primitive */
     rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_DECPRIM, &app_rsa_decprim_handler);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2959,7 +2959,23 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_DECPRIM, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
+    /* Revision 1 should be testable if needed still */
+    //rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_REVISION, ACVP_REVISION_1_0);
+    //CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_KEY_FORMAT, ACVP_RSA_KEY_FORMAT_CRT);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_FIXED);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_MODULO, 2048);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_MODULO, 3072);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_MODULO, 4096);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_prim_set_exponent(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_FIXED_PUB_EXP_VAL, expo_str);
+    CHECK_ENABLE_CAP_RV(rv);
 #endif
+
     /* Enable Signature Primitive */
     rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2967,12 +2983,23 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGPRIM, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_PARM_KEY_FORMAT_CRT, 1);
+    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_KEY_FORMAT, ACVP_RSA_KEY_FORMAT_CRT);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_FIXED);
+    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_FIXED);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_prim_set_exponent(ctx, ACVP_RSA_PARM_FIXED_PUB_EXP_VAL, expo_str);
+    //rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_REVISION, ACVP_REVISION_1_0);
+    //CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_MODULO, 2048);
     CHECK_ENABLE_CAP_RV(rv);
+#ifdef ACVP_FIPS186_5
+    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_MODULO, 3072);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_MODULO, 4096);
+    CHECK_ENABLE_CAP_RV(rv);
+#endif
+    rv = acvp_cap_rsa_prim_set_exponent(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_FIXED_PUB_EXP_VAL, expo_str);
+    CHECK_ENABLE_CAP_RV(rv);
+
 end:
     if (expo_str) free(expo_str);
 

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -455,6 +455,7 @@ typedef enum acvp_conformance_t {
  */
 typedef enum acvp_revision_t {
     ACVP_REVISION_DEFAULT = 0,
+    ACVP_REVISION_1_0,
     ACVP_REVISION_SP800_56CR1,
     ACVP_REVISION_SP800_56AR3,
     ACVP_REVISION_FIPS186_4,
@@ -689,9 +690,11 @@ typedef enum acvp_drbg_param {
 typedef enum acvp_rsa_param {
     ACVP_RSA_PARM_PUB_EXP_MODE = 1,
     ACVP_RSA_PARM_FIXED_PUB_EXP_VAL,
-    ACVP_RSA_PARM_KEY_FORMAT_CRT,
+    ACVP_RSA_PARM_KEY_FORMAT,
     ACVP_RSA_PARM_RAND_PQ,
     ACVP_RSA_PARM_INFO_GEN_BY_SERVER,
+    ACVP_RSA_PARM_REVISION,
+    ACVP_RSA_PARM_MODULO
 } ACVP_RSA_PARM;
 
 /** @enum ACVP_RSA_PRIME_PARAM */
@@ -907,6 +910,7 @@ typedef enum acvp_rsa_prim_keyformat {
 typedef struct acvp_rsa_prim_tc_t {
     unsigned int tc_id;    /**< Test case id */
     unsigned char *cipher;
+    ACVP_RSA_PUB_EXP_MODE pub_exp_mode;
     int cipher_len;
     unsigned char *msg;
     int msg_len;
@@ -917,7 +921,7 @@ typedef struct acvp_rsa_prim_tc_t {
     int modulo;
     unsigned int fail;
     unsigned int pass;
-    int key_format;
+    ACVP_RSA_KEY_FORMAT key_format;
     unsigned char *n;
     unsigned char *e;
     unsigned char *d;
@@ -3319,10 +3323,12 @@ ACVP_RESULT acvp_cap_rsa_keygen_set_mode(ACVP_CTX *ctx,
                                          ACVP_RSA_KEYGEN_MODE value);
 
 ACVP_RESULT acvp_cap_rsa_prim_set_parm(ACVP_CTX *ctx,
-                                       ACVP_RSA_PARM prim_type,
+                                       ACVP_CIPHER cipher,
+                                       ACVP_RSA_PARM param,
                                        int value);
 
 ACVP_RESULT acvp_cap_rsa_prim_set_exponent(ACVP_CTX *ctx,
+                                           ACVP_CIPHER cipher,
                                            ACVP_RSA_PARM param,
                                            char *value);
 

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -69,7 +69,7 @@
  * ******************************************************
  ********************************************************
  */
-#define ACVP_REV_STR_DEFAULT "1.0"
+#define ACVP_REV_STR_1_0 "1.0"
 #define ACVP_REV_STR_2_0 "2.0"
 #define ACVP_REV_STR_FIPS186_4 "FIPS186-4"
 #define ACVP_REV_STR_FIPS186_5 "FIPS186-5"
@@ -82,98 +82,100 @@
 #define ACVP_REV_STR_RFC7627 "RFC7627"
 
 /* AES */
-#define ACVP_REV_AES_ECB             ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_CBC             ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_CBC_CS1         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_CBC_CS2         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_CBC_CS3         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_CFB1            ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_CFB8            ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_CFB128          ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_OFB             ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_CTR             ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_GCM             ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_GCM_SIV         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_CCM             ACVP_REV_STR_DEFAULT
+#define ACVP_REV_AES_ECB             ACVP_REV_STR_1_0
+#define ACVP_REV_AES_CBC             ACVP_REV_STR_1_0
+#define ACVP_REV_AES_CBC_CS1         ACVP_REV_STR_1_0
+#define ACVP_REV_AES_CBC_CS2         ACVP_REV_STR_1_0
+#define ACVP_REV_AES_CBC_CS3         ACVP_REV_STR_1_0
+#define ACVP_REV_AES_CFB1            ACVP_REV_STR_1_0
+#define ACVP_REV_AES_CFB8            ACVP_REV_STR_1_0
+#define ACVP_REV_AES_CFB128          ACVP_REV_STR_1_0
+#define ACVP_REV_AES_OFB             ACVP_REV_STR_1_0
+#define ACVP_REV_AES_CTR             ACVP_REV_STR_1_0
+#define ACVP_REV_AES_GCM             ACVP_REV_STR_1_0
+#define ACVP_REV_AES_GCM_SIV         ACVP_REV_STR_1_0
+#define ACVP_REV_AES_CCM             ACVP_REV_STR_1_0
 #define ACVP_REV_AES_XTS             ACVP_REV_STR_2_0
-#define ACVP_REV_AES_KW              ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_KWP             ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_GMAC            ACVP_REV_STR_DEFAULT
-#define ACVP_REV_AES_XPN             ACVP_REV_STR_DEFAULT
+#define ACVP_REV_AES_KW              ACVP_REV_STR_1_0
+#define ACVP_REV_AES_KWP             ACVP_REV_STR_1_0
+#define ACVP_REV_AES_GMAC            ACVP_REV_STR_1_0
+#define ACVP_REV_AES_XPN             ACVP_REV_STR_1_0
 
 /* TDES */
-#define ACVP_REV_TDES_OFB            ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_OFBI           ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_CFB1           ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_CFB8           ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_CFB64          ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_CFBP1          ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_CFBP8          ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_CFBP64         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_ECB            ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_CBC            ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_CBCI           ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_CTR            ACVP_REV_STR_DEFAULT
-#define ACVP_REV_TDES_KW             ACVP_REV_STR_DEFAULT
+#define ACVP_REV_TDES_OFB            ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_OFBI           ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_CFB1           ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_CFB8           ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_CFB64          ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_CFBP1          ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_CFBP8          ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_CFBP64         ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_ECB            ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_CBC            ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_CBCI           ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_CTR            ACVP_REV_STR_1_0
+#define ACVP_REV_TDES_KW             ACVP_REV_STR_1_0
 
 /* SHA */
-#define ACVP_REV_HASH_SHA1           ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HASH_SHA224         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HASH_SHA256         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HASH_SHA384         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HASH_SHA512         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HASH_SHA512_224     ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HASH_SHA512_256     ACVP_REV_STR_DEFAULT
+#define ACVP_REV_HASH_SHA1           ACVP_REV_STR_1_0
+#define ACVP_REV_HASH_SHA224         ACVP_REV_STR_1_0
+#define ACVP_REV_HASH_SHA256         ACVP_REV_STR_1_0
+#define ACVP_REV_HASH_SHA384         ACVP_REV_STR_1_0
+#define ACVP_REV_HASH_SHA512         ACVP_REV_STR_1_0
+#define ACVP_REV_HASH_SHA512_224     ACVP_REV_STR_1_0
+#define ACVP_REV_HASH_SHA512_256     ACVP_REV_STR_1_0
 #define ACVP_REV_HASH_SHA3_224       ACVP_REV_STR_2_0
 #define ACVP_REV_HASH_SHA3_256       ACVP_REV_STR_2_0
 #define ACVP_REV_HASH_SHA3_384       ACVP_REV_STR_2_0
 #define ACVP_REV_HASH_SHA3_512       ACVP_REV_STR_2_0
-#define ACVP_REV_HASH_SHAKE_128      ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HASH_SHAKE_256      ACVP_REV_STR_DEFAULT
+#define ACVP_REV_HASH_SHAKE_128      ACVP_REV_STR_1_0
+#define ACVP_REV_HASH_SHAKE_256      ACVP_REV_STR_1_0
 
 /* DRBG */
-#define ACVP_REV_HASHDRBG            ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HMACDRBG            ACVP_REV_STR_DEFAULT
-#define ACVP_REV_CTRDRBG             ACVP_REV_STR_DEFAULT
+#define ACVP_REV_HASHDRBG            ACVP_REV_STR_1_0
+#define ACVP_REV_HMACDRBG            ACVP_REV_STR_1_0
+#define ACVP_REV_CTRDRBG             ACVP_REV_STR_1_0
 
 /* HMAC */
-#define ACVP_REV_HMAC_SHA1           ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HMAC_SHA2_224       ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HMAC_SHA2_256       ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HMAC_SHA2_384       ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HMAC_SHA2_512       ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HMAC_SHA2_512_224   ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HMAC_SHA2_512_256   ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HMAC_SHA3_224       ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HMAC_SHA3_256       ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HMAC_SHA3_384       ACVP_REV_STR_DEFAULT
-#define ACVP_REV_HMAC_SHA3_512       ACVP_REV_STR_DEFAULT
+#define ACVP_REV_HMAC_SHA1           ACVP_REV_STR_1_0
+#define ACVP_REV_HMAC_SHA2_224       ACVP_REV_STR_1_0
+#define ACVP_REV_HMAC_SHA2_256       ACVP_REV_STR_1_0
+#define ACVP_REV_HMAC_SHA2_384       ACVP_REV_STR_1_0
+#define ACVP_REV_HMAC_SHA2_512       ACVP_REV_STR_1_0
+#define ACVP_REV_HMAC_SHA2_512_224   ACVP_REV_STR_1_0
+#define ACVP_REV_HMAC_SHA2_512_256   ACVP_REV_STR_1_0
+#define ACVP_REV_HMAC_SHA3_224       ACVP_REV_STR_1_0
+#define ACVP_REV_HMAC_SHA3_256       ACVP_REV_STR_1_0
+#define ACVP_REV_HMAC_SHA3_384       ACVP_REV_STR_1_0
+#define ACVP_REV_HMAC_SHA3_512       ACVP_REV_STR_1_0
 
 /* CMAC */
-#define ACVP_REV_CMAC_AES            ACVP_REV_STR_DEFAULT
-#define ACVP_REV_CMAC_TDES           ACVP_REV_STR_DEFAULT
+#define ACVP_REV_CMAC_AES            ACVP_REV_STR_1_0
+#define ACVP_REV_CMAC_TDES           ACVP_REV_STR_1_0
 
 /* KMAC */
-#define ACVP_REV_KMAC_128            ACVP_REV_STR_DEFAULT
-#define ACVP_REV_KMAC_256            ACVP_REV_STR_DEFAULT
+#define ACVP_REV_KMAC_128            ACVP_REV_STR_1_0
+#define ACVP_REV_KMAC_256            ACVP_REV_STR_1_0
 
 /* DSA */
-#define ACVP_REV_DSA                 ACVP_REV_STR_DEFAULT
+#define ACVP_REV_DSA                 ACVP_REV_STR_1_0
 
 /* RSA */
 #define ACVP_REV_RSA                 ACVP_REV_STR_FIPS186_4
-#define ACVP_REV_RSA_PRIM            ACVP_REV_STR_DEFAULT
+#define ACVP_REV_RSA_DECPRIM         ACVP_REV_STR_SP800_56BR2
+#define ACVP_REV_RSA_SIGPRIM         ACVP_REV_STR_2_0
+#define ACVP_REV_RSA_PRIM            ACVP_REV_STR_1_0
 
 /* ECDSA */
 #define ACVP_REV_ECDSA               ACVP_REV_STR_FIPS186_5
 
 /* KAS_ECC */
-#define ACVP_REV_KAS_ECC             ACVP_REV_STR_DEFAULT
+#define ACVP_REV_KAS_ECC             ACVP_REV_STR_1_0
 #define ACVP_REV_KAS_ECC_SSC         ACVP_REV_STR_SP800_56AR3
 
 
 /* KAS_FFC */
-#define ACVP_REV_KAS_FFC             ACVP_REV_STR_DEFAULT
+#define ACVP_REV_KAS_FFC             ACVP_REV_STR_1_0
 #define ACVP_REV_KAS_FFC_SSC         ACVP_REV_STR_SP800_56AR3
 
 /* KAS_IFC */
@@ -188,20 +190,20 @@
 #define ACVP_REV_KTS_IFC             ACVP_REV_STR_SP800_56BR2
 
 /* KDF */
-#define ACVP_REV_KDF135_SNMP         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_KDF135_SSH          ACVP_REV_STR_DEFAULT
-#define ACVP_REV_KDF135_SRTP         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_KDF135_IKEV2        ACVP_REV_STR_DEFAULT
-#define ACVP_REV_KDF135_IKEV1        ACVP_REV_STR_DEFAULT
-#define ACVP_REV_KDF135_TPM          ACVP_REV_STR_DEFAULT
-#define ACVP_REV_KDF135_X942         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_KDF135_X963         ACVP_REV_STR_DEFAULT
-#define ACVP_REV_KDF108              ACVP_REV_STR_DEFAULT
-#define ACVP_REV_PBKDF               ACVP_REV_STR_DEFAULT
-#define ACVP_REV_SAFE_PRIMES         ACVP_REV_STR_DEFAULT
+#define ACVP_REV_KDF135_SNMP         ACVP_REV_STR_1_0
+#define ACVP_REV_KDF135_SSH          ACVP_REV_STR_1_0
+#define ACVP_REV_KDF135_SRTP         ACVP_REV_STR_1_0
+#define ACVP_REV_KDF135_IKEV2        ACVP_REV_STR_1_0
+#define ACVP_REV_KDF135_IKEV1        ACVP_REV_STR_1_0
+#define ACVP_REV_KDF135_TPM          ACVP_REV_STR_1_0
+#define ACVP_REV_KDF135_X942         ACVP_REV_STR_1_0
+#define ACVP_REV_KDF135_X963         ACVP_REV_STR_1_0
+#define ACVP_REV_KDF108              ACVP_REV_STR_1_0
+#define ACVP_REV_PBKDF               ACVP_REV_STR_1_0
+#define ACVP_REV_SAFE_PRIMES         ACVP_REV_STR_1_0
 #define ACVP_REV_KDF_TLS12           ACVP_REV_STR_RFC7627
 #define ACVP_REV_KDF_TLS13           ACVP_REV_STR_RFC8446
-#define ACVP_REV_LMS                 ACVP_REV_STR_DEFAULT
+#define ACVP_REV_LMS                 ACVP_REV_STR_1_0
 
 
 /********************************************************
@@ -1327,13 +1329,14 @@ typedef struct acvp_rsa_keygen_capability_t {
 } ACVP_RSA_KEYGEN_CAP;
 
 typedef struct acvp_rsa_prim_capability_t {
+    ACVP_REVISION revision;                 // Empty if default is used
     unsigned int prim_type;
-    int key_format_crt;                     // if false, key format is assumed to be standard
+    ACVP_PARAM_LIST *key_formats;
     ACVP_RSA_PUB_EXP_MODE pub_exp_mode;
     char *fixed_pub_exp;               // hex value of e
     struct acvp_rsa_prim_capability_t *next; // to support multiple randPQ values
+    ACVP_SL_LIST *modulo;
 } ACVP_RSA_PRIM_CAP;
-
 
 typedef struct acvp_curve_hash_compatibility_list_t {
     ACVP_EC_CURVE curve;
@@ -1976,6 +1979,7 @@ const char *acvp_lookup_cipher_mode_str(ACVP_CIPHER cipher);
 
 const char *acvp_lookup_cipher_revision(ACVP_CIPHER alg);
 const char *acvp_lookup_alt_revision_string(ACVP_REVISION rev);
+ACVP_REVISION acvp_lookup_alt_revision(const char *str);
 
 ACVP_DRBG_MODE acvp_lookup_drbg_mode_index(const char *mode);
 
@@ -1985,6 +1989,7 @@ ACVP_DRBG_CAP_GROUP *acvp_locate_drbg_group_entry(ACVP_DRBG_MODE_LIST *mode, int
 ACVP_DRBG_CAP_GROUP *acvp_create_drbg_group(ACVP_DRBG_MODE_LIST *mode, int group);
 
 const char *acvp_lookup_rsa_randpq_name(int value);
+ACVP_RSA_PUB_EXP_MODE acvp_lookup_rsa_pub_exp_mode(const char *str);
 
 int acvp_lookup_rsa_randpq_index(const char *value);
 
@@ -2041,6 +2046,8 @@ ACVP_LMS_MODE acvp_lookup_lms_mode(const char *str);
 const char *acvp_lookup_lms_mode_str(ACVP_LMS_MODE mode);
 ACVP_LMOTS_MODE acvp_lookup_lmots_mode(const char *str);
 const char *acvp_lookup_lmots_mode_str(ACVP_LMOTS_MODE mode);
+const char *acvp_lookup_rsa_format_str(ACVP_RSA_KEY_FORMAT format);
+ACVP_RSA_PUB_EXP_MODE acvp_lookup_rsa_pub_exp_mode(const char *str);
 int acvp_is_domain_already_set(ACVP_JSON_DOMAIN_OBJ *domain);
 
 /* These functions are used for KDF108, but twostep uses KDF108 so we share them */

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -133,8 +133,8 @@ ACVP_ALG_HANDLER alg_tbl[ACVP_ALG_MAX] = {
     { ACVP_RSA_KEYGEN,        &acvp_rsa_keygen_kat_handler,       ACVP_ALG_RSA,               ACVP_MODE_KEYGEN, ACVP_REV_RSA, {ACVP_SUB_RSA_KEYGEN}},
     { ACVP_RSA_SIGGEN,        &acvp_rsa_siggen_kat_handler,       ACVP_ALG_RSA,               ACVP_MODE_SIGGEN, ACVP_REV_RSA, {ACVP_SUB_RSA_SIGGEN}},
     { ACVP_RSA_SIGVER,        &acvp_rsa_sigver_kat_handler,       ACVP_ALG_RSA,               ACVP_MODE_SIGVER, ACVP_REV_RSA, {ACVP_SUB_RSA_SIGVER}},
-    { ACVP_RSA_DECPRIM,       &acvp_rsa_decprim_kat_handler,      ACVP_ALG_RSA,               ACVP_MODE_DECPRIM, ACVP_REV_RSA_PRIM, {ACVP_SUB_RSA_DECPRIM}},
-    { ACVP_RSA_SIGPRIM,       &acvp_rsa_sigprim_kat_handler,      ACVP_ALG_RSA,               ACVP_MODE_SIGPRIM, ACVP_REV_RSA_PRIM, {ACVP_SUB_RSA_SIGPRIM}},
+    { ACVP_RSA_DECPRIM,       &acvp_rsa_decprim_kat_handler,      ACVP_ALG_RSA,               ACVP_MODE_DECPRIM, ACVP_REV_RSA_DECPRIM, {ACVP_SUB_RSA_DECPRIM}},
+    { ACVP_RSA_SIGPRIM,       &acvp_rsa_sigprim_kat_handler,      ACVP_ALG_RSA,               ACVP_MODE_SIGPRIM, ACVP_REV_RSA_SIGPRIM, {ACVP_SUB_RSA_SIGPRIM}},
     { ACVP_ECDSA_KEYGEN,      &acvp_ecdsa_keygen_kat_handler,     ACVP_ALG_ECDSA,             ACVP_MODE_KEYGEN, ACVP_REV_ECDSA, {ACVP_SUB_ECDSA_KEYGEN}},
     { ACVP_ECDSA_KEYVER,      &acvp_ecdsa_keyver_kat_handler,     ACVP_ALG_ECDSA,             ACVP_MODE_KEYVER, ACVP_REV_ECDSA, {ACVP_SUB_ECDSA_KEYVER}},
     { ACVP_ECDSA_SIGGEN,      &acvp_ecdsa_siggen_kat_handler,     ACVP_ALG_ECDSA,             ACVP_MODE_SIGGEN, ACVP_REV_ECDSA, {ACVP_SUB_ECDSA_SIGGEN}},
@@ -771,6 +771,8 @@ ACVP_RESULT acvp_free_test_session(ACVP_CTX *ctx) {
                 if (cap_entry->cap.rsa_prim_cap->fixed_pub_exp) {
                     free(cap_entry->cap.rsa_prim_cap->fixed_pub_exp);
                 }
+                acvp_cap_free_sl(cap_entry->cap.rsa_prim_cap->modulo);
+                acvp_cap_free_pl(cap_entry->cap.rsa_prim_cap->key_formats);
                 free(cap_entry->cap.rsa_prim_cap);
                 break;
             case ACVP_ECDSA_KEYGEN_TYPE:

--- a/src/acvp_rsa_keygen.c
+++ b/src/acvp_rsa_keygen.c
@@ -328,20 +328,6 @@ static ACVP_RSA_TESTTYPE read_test_type(const char *str) {
     return 0;
 }
 
-static ACVP_RSA_PUB_EXP_MODE read_pub_exp_mode(const char *str){
-    int diff = 1;
-
-    strcmp_s(ACVP_RSA_PUB_EXP_MODE_FIXED_STR,
-             ACVP_RSA_PUB_EXP_MODE_FIXED_STR_LEN, str, &diff);
-    if (!diff) return ACVP_RSA_PUB_EXP_MODE_FIXED;
-
-    strcmp_s(ACVP_RSA_PUB_EXP_MODE_RANDOM_STR,
-             ACVP_RSA_PUB_EXP_MODE_RANDOM_STR_LEN, str, &diff);
-    if (!diff) return ACVP_RSA_PUB_EXP_MODE_RANDOM;
-
-    return 0;
-}
-
 static ACVP_RSA_KEY_FORMAT read_key_format(const char *str){
     int diff = 1;
 
@@ -509,7 +495,7 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             rv = ACVP_MISSING_ARG;
             goto err;
         }
-        pub_exp_mode = read_pub_exp_mode(pub_exp_mode_str);
+        pub_exp_mode = acvp_lookup_rsa_pub_exp_mode(pub_exp_mode_str);
         if (!pub_exp_mode) {
             ACVP_LOG_ERR("Server JSON invalid 'pubExpMode'");
             rv = ACVP_INVALID_ARG;

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -185,7 +185,8 @@ const char *acvp_lookup_cipher_revision(ACVP_CIPHER alg) {
 static struct acvp_alt_revision_info alt_revision_tbl[] = {
     { ACVP_REVISION_SP800_56AR3, ACVP_REV_STR_SP800_56AR3 },
     { ACVP_REVISION_SP800_56CR1, ACVP_REV_STR_SP800_56CR1 },
-    { ACVP_REVISION_FIPS186_4, ACVP_REV_STR_DEFAULT }
+    { ACVP_REVISION_FIPS186_4, ACVP_REV_STR_1_0 },
+    { ACVP_REVISION_1_0, ACVP_REV_STR_1_0 }
 };
 static int alt_revision_tbl_length =
     sizeof(alt_revision_tbl) / sizeof(struct acvp_alt_revision_info);
@@ -202,6 +203,20 @@ const char *acvp_lookup_alt_revision_string(ACVP_REVISION rev) {
         }
     }
     return NULL;
+}
+
+/**
+ * This function returns the enum for a given alternative revision string, or 0 if not found
+ */
+ACVP_REVISION acvp_lookup_alt_revision(const char *str) {
+    int i = 0, diff = 1;
+    for (i = 0; i < alt_revision_tbl_length; i++) {
+        strcmp_s(alt_revision_tbl[i].name, ACVP_ALG_NAME_MAX, str, &diff);
+        if (!diff) {
+            return alt_revision_tbl[i].revision;
+        }
+    }
+    return 0;
 }
 
 /**
@@ -326,6 +341,20 @@ const char *acvp_lookup_rsa_randpq_name(int value) {
     default:
         return NULL;
     }
+}
+
+ACVP_RSA_PUB_EXP_MODE acvp_lookup_rsa_pub_exp_mode(const char *str) {
+    int diff = 1;
+
+    strcmp_s(ACVP_RSA_PUB_EXP_MODE_FIXED_STR,
+             ACVP_RSA_PUB_EXP_MODE_FIXED_STR_LEN, str, &diff);
+    if (!diff) return ACVP_RSA_PUB_EXP_MODE_FIXED;
+
+    strcmp_s(ACVP_RSA_PUB_EXP_MODE_RANDOM_STR,
+             ACVP_RSA_PUB_EXP_MODE_RANDOM_STR_LEN, str, &diff);
+    if (!diff) return ACVP_RSA_PUB_EXP_MODE_RANDOM;
+
+    return 0;
 }
 
 int acvp_lookup_rsa_randpq_index(const char *value) {
@@ -724,6 +753,24 @@ const char *acvp_lookup_lmots_mode_str(ACVP_LMOTS_MODE mode) {
     for (i = 0; i < lmots_mode_tbl_len; i++) {
         if (mode == lmots_mode_tbl[i].enum_value) {
             return lmots_mode_tbl[i].string;
+        }
+    }
+    return NULL;
+}
+
+/* This seems too small to dictate having its own table/function, but future expandability may be useful */
+static struct acvp_enum_string_pair rsa_key_format_tbl[] = {
+    { ACVP_RSA_KEY_FORMAT_STANDARD, "standard" },
+    { ACVP_RSA_KEY_FORMAT_CRT, "crt" }
+};
+
+static int rsa_key_format_tbl_len = sizeof(rsa_key_format_tbl) / sizeof(struct acvp_enum_string_pair);
+
+const char *acvp_lookup_rsa_format_str(ACVP_RSA_KEY_FORMAT format) {
+    int i = 0;
+    for (i = 0; i < rsa_key_format_tbl_len; i++) {
+        if (format == rsa_key_format_tbl[i].enum_value) {
+            return rsa_key_format_tbl[i].string;
         }
     }
     return NULL;


### PR DESCRIPTION
- RSA SigPrim updated to revision 2.0 (Main change is that can now use multiple modulus lengths)
- RSA DecPrim updated to SP800-56Br2. Changes the structure of the test to be less "guess and check" and more just basic decryption testing. Lots of parsing code and handler call code changes to accommodate
- APP BREAKING CHANGES: updates to prim capability APIs needed to allow new revisions
- Support for the 1.0 revisions is also still enabled due to various edge cases where they could be used. This won't be too difficult to remove down the road if it becomes cumbersome
- Replaced all references to a "default" revision to reference "1.0" revision. Now that many algorithms have many different revisions, a global default no longer makes sense
- UT updates not yet completed
- RSA DecPrim OpenSSL handler code pending more information (Will the new decprim revision be heavily enforced or required?) and possible changes on the OpenSSL codebase to accommodate needed boundary checks
- Due to multiple issues with git trying to move this diff from the 2.0 to 2.1 throttle branch, changes were moved over manually; I have reviewed several times but if you see anything that looks odd please point it out. Thanks!