### PR TITLE
Fix SHAKE, RSA, DRBG and KDA issues

### DIFF
--- a/app/app_drbg.c
+++ b/app/app_drbg.c
@@ -117,9 +117,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
     }
 
     params[0] = OSSL_PARAM_construct_uint(OSSL_RAND_PARAM_STRENGTH, &strength);
-    params[1] = OSSL_PARAM_construct_end(); /* HMAC */
-    params[2] = OSSL_PARAM_construct_end(); /* der func */
-    params[3] = OSSL_PARAM_construct_end();
+    params[1] = OSSL_PARAM_construct_end();
 
     if (EVP_RAND_CTX_set_params(test, params) != 1) {
         printf("Error setting test ctx params in DRBG\n");
@@ -137,6 +135,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
     params[0] = OSSL_PARAM_construct_utf8_string(param_str, tmp, 0);
     params[1] = OSSL_PARAM_construct_utf8_string(OSSL_DRBG_PARAM_MAC, mac_name, 0); //ignored if irrelevant
     params[2] = OSSL_PARAM_construct_int(OSSL_DRBG_PARAM_USE_DF, &der_func);
+    params[3] = OSSL_PARAM_construct_end();
     if (EVP_RAND_CTX_set_params(rctx, params) != 1) {
         printf("Error setting algorithm for DRBG\n");
         goto err;
@@ -144,6 +143,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
 
     params[0] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY, tc->entropy, tc->entropy_len);
     params[1] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_NONCE, tc->nonce, tc->nonce_len);
+    params[2] = OSSL_PARAM_construct_end();
     if (EVP_RAND_CTX_set_params(test, params) != 1) {
         printf("Error setting initial entropy/nonce for DRBG\n");
         goto err;
@@ -154,7 +154,23 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
 
+    if (!tc->pred_resist_enabled && tc->reseed) {
+        params[0] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY, tc->entropy_input_pr_0, tc->entropy_len);
+        params[1] = OSSL_PARAM_construct_end();
+        if (EVP_RAND_CTX_set_params(test, params) != 1) {
+            printf("Error setting reseed params for DRBG\n");
+            goto err;
+        }
+
+        if (EVP_RAND_reseed(rctx, tc->pred_resist_enabled, NULL, 0,
+                            tc->additional_input_0, tc->additional_input_len) != 1) {
+            printf("Error performing reseed DRBG\n");
+            goto err;
+        }
+    }
+
     params[0] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY, tc->entropy_input_pr_1, tc->entropy_len);
+    params[1] = OSSL_PARAM_construct_end();
     if (EVP_RAND_CTX_set_params(test, params) != 1) {
         printf("Error setting params for DRBG (1)\n");
         goto err;
@@ -168,6 +184,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
      }
 
     params[0] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY, tc->entropy_input_pr_2, tc->entropy_len);
+    params[1] = OSSL_PARAM_construct_end();
     if (EVP_RAND_CTX_set_params(test, params) != 1) {
         printf("Error setting params for DRBG (2)\n");
         goto err;

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -863,7 +863,7 @@
 #define ACVP_KDA_DKM_STR_MAX (ACVP_KDA_DKM_BIT_MAX >> 2)
 #define ACVP_KDA_DKM_BYTE_MAX (ACVP_KDA_DKM_BIT_MAX >> 3)
 
-#define ACVP_KDA_FIXED_BIT_MAX 8192 //arbitrary
+#define ACVP_KDA_FIXED_BIT_MAX 65536 //arbitrary
 #define ACVP_KDA_FIXED_STR_MAX (ACVP_KDA_FIXED_BIT_MAX >> 2)
 #define ACVP_KDA_FIXED_BYTE_MAX (ACVP_KDA_FIXED_BIT_MAX >> 3)
 
@@ -871,7 +871,7 @@
 #define ACVP_KDA_SALT_STR_MAX (ACVP_KDA_SALT_BIT_MAX >> 2)
 #define ACVP_KDA_SALT_BYTE_MAX (ACVP_KDA_SALT_BIT_MAX >> 3)
 
-#define ACVP_KDA_Z_BIT_MAX 65336 //arbitrary, used spec example
+#define ACVP_KDA_Z_BIT_MAX 65536 //arbitrary, used spec example
 #define ACVP_KDA_Z_STR_MAX (ACVP_KDA_Z_BIT_MAX >> 2)
 #define ACVP_KDA_Z_BYTE_MAX (ACVP_KDA_Z_BIT_MAX >> 3)
 

--- a/src/acvp_drbg.c
+++ b/src/acvp_drbg.c
@@ -327,7 +327,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             ACVP_LOG_VERBOSE("        Test case: %d", j);
             ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
             ACVP_LOG_VERBOSE("             entropyInput: %s", entropy);
-            ACVP_LOG_VERBOSE("             perso_string: %s", perso_string);
+            ACVP_LOG_VERBOSE("             persoString: %s", perso_string);
             ACVP_LOG_VERBOSE("             nonce: %s", nonce);
 
             /*

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -86,6 +86,9 @@ static ACVP_RESULT acvp_hash_output_mct_tc(ACVP_CTX *ctx, ACVP_HASH_TC *stc, JSO
     }
 
     json_object_set_string(r_tobj, "md", tmp);
+    if (stc->cipher == ACVP_HASH_SHAKE_128 || stc->cipher == ACVP_HASH_SHAKE_256) {
+        json_object_set_number(r_tobj, "outLen", stc->md_len * 8);
+    }
 
 end:
     if (tmp) free(tmp);
@@ -770,6 +773,9 @@ static ACVP_RESULT acvp_hash_output_tc(ACVP_CTX *ctx, ACVP_HASH_TC *stc, JSON_Ob
         goto end;
     }
     json_object_set_string(tc_rsp, "md", tmp);
+    if (stc->cipher == ACVP_HASH_SHAKE_128 || stc->cipher == ACVP_HASH_SHAKE_256) {
+        json_object_set_number(tc_rsp, "outLen", stc->md_len * 8);
+    }
 
 end:
     if (tmp) free(tmp);

--- a/src/acvp_rsa_keygen.c
+++ b/src/acvp_rsa_keygen.c
@@ -77,7 +77,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
     }
     json_object_set_string(tc_rsp, "e", (const char *)tmp);
 
-    if (stc->key_format == ACVP_RSA_KEY_FORMAT_CRT) {
+    if (stc->rand_pq == ACVP_RSA_KEYGEN_B36) {
         rv = acvp_bin_to_hexstr(stc->xp, stc->xp_len, tmp, ACVP_RSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
             ACVP_LOG_ERR("hex conversion failure (xp)");
@@ -142,14 +142,16 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
             }
             json_object_set_string(tc_rsp, "seed", (const char *)tmp);
             memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
-
-            json_object_set_value(tc_rsp, "bitlens", json_value_init_array());
-            JSON_Array *bitlens_array = json_object_get_array(tc_rsp, "bitlens");
-            json_array_append_number(bitlens_array, stc->bitlen1);
-            json_array_append_number(bitlens_array, stc->bitlen2);
-            json_array_append_number(bitlens_array, stc->bitlen3);
-            json_array_append_number(bitlens_array, stc->bitlen4);
         }
+    }
+
+    if (!(stc->rand_pq == ACVP_RSA_KEYGEN_B33)) {
+        json_object_set_value(tc_rsp, "bitlens", json_value_init_array());
+        JSON_Array *bitlens_array = json_object_get_array(tc_rsp, "bitlens");
+        json_array_append_number(bitlens_array, stc->bitlen1);
+        json_array_append_number(bitlens_array, stc->bitlen2);
+        json_array_append_number(bitlens_array, stc->bitlen3);
+        json_array_append_number(bitlens_array, stc->bitlen4);
     }
 
 err:


### PR DESCRIPTION
**Output outLen for SHAKE-128 and SHAKE-256 test vectors**

For SHAKE-128 and SHAKE-256, we should output `outLen`.

[Reference](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html#section-8.3)

**Output required fields for RSA KeyGen if randPQ B.3.6 used**

For RSA KeyGen with randPQ B.3.6, `xP`, `xP1`, `xP2` and other fields should be outputed.

[Reference](https://pages.nist.gov/ACVP/draft-celi-acvp-rsa.html#section-9.1)

**Fix "!predResistanceEnabled and reseedImplemented" for DRBG**

Reseed the DRBG before first generation.

[Reference](https://pages.nist.gov/ACVP/draft-vassilev-acvp-drbg.html#section-8.1-4.1)

**Update defines for KDA**

Max `z` bit is 65536.

[Reference](https://pages.nist.gov/ACVP/draft-hammett-acvp-kas-kdf-hkdf.html#section-7.3)
