### PR TITLE
FIPS 186-5 support for RSA, misc. RSA updates

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -2739,6 +2739,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 #ifndef ACVP_FIPS186_5
     rv = acvp_cap_rsa_siggen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
+    CHECK_ENABLE_CAP_RV(rv);
     // RSA w/ sigType: X9.31
     rv = acvp_cap_rsa_siggen_set_type(ctx, ACVP_RSA_SIG_TYPE_X931);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2843,6 +2844,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 #ifndef ACVP_FIPS186_5
     rv = acvp_cap_rsa_sigver_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
+    CHECK_ENABLE_CAP_RV(rv);
     // RSA w/ sigType: X9.31
     rv = acvp_cap_rsa_sigver_set_type(ctx, ACVP_RSA_SIG_TYPE_X931);
     CHECK_ENABLE_CAP_RV(rv);

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -2737,9 +2737,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGGEN, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-#ifdef ACVP_FIPS186_5
-
-#else
+#ifndef ACVP_FIPS186_5
     rv = acvp_cap_rsa_siggen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     // RSA w/ sigType: X9.31
     rv = acvp_cap_rsa_siggen_set_type(ctx, ACVP_RSA_SIG_TYPE_X931);
@@ -2843,9 +2841,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-#ifdef ACVP_FIPS186_5
-
-#else
+#ifndef ACVP_FIPS186_5
     rv = acvp_cap_rsa_sigver_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     // RSA w/ sigType: X9.31
     rv = acvp_cap_rsa_sigver_set_type(ctx, ACVP_RSA_SIG_TYPE_X931);

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -2678,11 +2678,38 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_INFO_GEN_BY_SERVER, 1);
+#ifdef ACVP_FIPS186_5
+    rv = acvp_cap_rsa_keygen_set_mode(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_KEY_FORMAT, ACVP_RSA_KEY_FORMAT_STANDARD);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 2048,
+                                        ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_2POW100);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_RANDOM);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 2048,
+                                        ACVP_RSA_PRIME_PMOD8, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 2048,
+                                        ACVP_RSA_PRIME_QMOD8, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 3072,
+                                        ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_2POW100);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 3072,
+                                        ACVP_RSA_PRIME_PMOD8, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 3072,
+                                        ACVP_RSA_PRIME_QMOD8, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 4096,
+                                        ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_2POW100);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 4096,
+                                        ACVP_RSA_PRIME_PMOD8, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 4096,
+                                        ACVP_RSA_PRIME_QMOD8, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+#else
+    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_keygen_set_mode(ctx, ACVP_RSA_KEYGEN_B36);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2695,6 +2722,13 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_B36, 4096,
                                         ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_TBLC2);
     CHECK_ENABLE_CAP_RV(rv);
+#endif
+    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_INFO_GEN_BY_SERVER, 1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_KEY_FORMAT, ACVP_RSA_KEY_FORMAT_STANDARD);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_RANDOM);
+    CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable siggen */
     rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
@@ -2703,6 +2737,10 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGGEN, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
+#ifdef ACVP_FIPS186_5
+
+#else
+    rv = acvp_cap_rsa_siggen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     // RSA w/ sigType: X9.31
     rv = acvp_cap_rsa_siggen_set_type(ctx, ACVP_RSA_SIG_TYPE_X931);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2724,6 +2762,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 4096, ACVP_SHA512, 0);
     CHECK_ENABLE_CAP_RV(rv);
+#endif
 
     // RSA w/ sigType: PKCS1v1.5
     rv = acvp_cap_rsa_siggen_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15);
@@ -2756,6 +2795,14 @@ static int enable_rsa(ACVP_CTX *ctx) {
     // RSA w/ sigType: PKCS1PSS -- has salt
     rv = acvp_cap_rsa_siggen_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS);
     CHECK_ENABLE_CAP_RV(rv);
+#ifdef ACVP_FIPS186_5
+    rv = acvp_cap_rsa_siggen_set_mod_mask(ctx, 2048, ACVP_RSA_MASK_FUNCTION_MGF1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_siggen_set_mod_mask(ctx, 3072, ACVP_RSA_MASK_FUNCTION_MGF1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_siggen_set_mod_mask(ctx, 4096, ACVP_RSA_MASK_FUNCTION_MGF1);
+    CHECK_ENABLE_CAP_RV(rv);
+#endif
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA224, 24);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA256, 32);
@@ -2796,9 +2843,10 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_parm(ctx, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_RANDOM);
-    CHECK_ENABLE_CAP_RV(rv);
+#ifdef ACVP_FIPS186_5
 
+#else
+    rv = acvp_cap_rsa_sigver_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     // RSA w/ sigType: X9.31
     rv = acvp_cap_rsa_sigver_set_type(ctx, ACVP_RSA_SIG_TYPE_X931);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2834,11 +2882,22 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 4096, ACVP_SHA512, 0);
     CHECK_ENABLE_CAP_RV(rv);
+#endif
+    rv = acvp_cap_rsa_sigver_set_parm(ctx, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_RANDOM);
+    CHECK_ENABLE_CAP_RV(rv);
+
 
     // RSA w/ sigType: PKCS1v1.5
     rv = acvp_cap_rsa_sigver_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15);
     CHECK_ENABLE_CAP_RV(rv);
+#ifndef ACVP_FIPS186_5
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 1024, ACVP_SHA1, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA1, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA1, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA1, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 1024, ACVP_SHA224, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2848,8 +2907,8 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 1024, ACVP_SHA512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA1, 0);
-    CHECK_ENABLE_CAP_RV(rv);
+#endif
+
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA224, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA256, 0);
@@ -2858,8 +2917,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512, 0);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA1, 0);
-    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA224, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA256, 0);
@@ -2867,8 +2924,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA384, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA1, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA224, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2882,6 +2937,14 @@ static int enable_rsa(ACVP_CTX *ctx) {
     // RSA w/ sigType: PKCS1PSS -- has salt
     rv = acvp_cap_rsa_sigver_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS);
     CHECK_ENABLE_CAP_RV(rv);
+#ifdef ACVP_FIPS186_5
+    rv = acvp_cap_rsa_sigver_set_mod_mask(ctx, 2048, ACVP_RSA_MASK_FUNCTION_MGF1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_mask(ctx, 3072, ACVP_RSA_MASK_FUNCTION_MGF1);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_mask(ctx, 4096, ACVP_RSA_MASK_FUNCTION_MGF1);
+    CHECK_ENABLE_CAP_RV(rv);
+#else
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 1024, ACVP_SHA1, 20);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 1024, ACVP_SHA224, 24);
@@ -2892,8 +2955,22 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 1024, ACVP_SHA512, 62);
     CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 1024, ACVP_SHA512_224, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 1024, ACVP_SHA512_256, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 1024, ACVP_SHA512_224, 24);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 1024, ACVP_SHA512_256, 32);
+    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA1, 20);
     CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA1, 20);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA1, 20);
+    CHECK_ENABLE_CAP_RV(rv);
+#endif
+
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA224, 24);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA256, 32);
@@ -2902,8 +2979,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512, 64);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA1, 20);
-    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA224, 24);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA256, 32);
@@ -2911,8 +2986,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA384, 48);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA512, 64);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA1, 20);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA224, 24);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2923,10 +2996,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512, 64);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 1024, ACVP_SHA512_224, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 1024, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_256, 0);
@@ -2938,10 +3007,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_224, 0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_256, 0);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 1024, ACVP_SHA512_224, 24);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 1024, ACVP_SHA512_256, 32);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512_224, 24);
     CHECK_ENABLE_CAP_RV(rv);

--- a/app/app_rsa.c
+++ b/app/app_rsa.c
@@ -154,6 +154,9 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
     OSSL_PARAM *pkey_params = NULL, *sig_params = NULL;
     const char *padding = NULL, *md = NULL;
     int salt_len = -1;
+#ifdef ACVP_FIPS186_5
+    int use_pss = 0;
+#endif
     BIGNUM *bn_e = NULL, *e = NULL, *n = NULL;
     ACVP_RSA_SIG_TC *tc;
 
@@ -190,6 +193,9 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_RSA_SIG_TYPE_PKCS1PSS:
         salt_len = tc->salt_len;
         padding = "pss";
+#ifdef ACVP_FIPS186_5
+        use_pss = 1;
+#endif
         break;
     case ACVP_RSA_SIG_TYPE_PKCS1V15:
         padding = "pkcs1";
@@ -200,37 +206,8 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
         goto err;
     }
 
-    switch (tc->hash_alg) {
-    case ACVP_SHA1:
-        md = "SHA-1";
-        break;
-    case ACVP_SHA224:
-        md = "SHA2-224";
-        break;
-    case ACVP_SHA256:
-        md = "SHA2-256";
-        break;
-    case ACVP_SHA384:
-        md = "SHA2-384";
-        break;
-    case ACVP_SHA512:
-        md = "SHA2-512";
-        break;
-    case ACVP_SHA512_224:
-        md = "SHA2-512/224";
-        break;
-    case ACVP_SHA512_256:
-        md = "SHA2-512/256";
-        break;
-    case ACVP_NO_SHA:
-    case ACVP_SHA3_224:
-    case ACVP_SHA3_256:
-    case ACVP_SHA3_384:
-    case ACVP_SHA3_512:
-    case ACVP_SHAKE_128:
-    case ACVP_SHAKE_256:
-    case ACVP_HASH_ALG_MAX:
-    default:
+    md = get_md_string_for_hash_alg(tc->hash_alg, NULL);
+    if (!md) {
         printf("\nError: hashAlg not supported for RSA SigGen\n");
         goto err;
     }
@@ -289,6 +266,11 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
         }
         OSSL_PARAM_BLD_push_utf8_string(sig_pbld, OSSL_SIGNATURE_PARAM_PAD_MODE, padding, 0);
         OSSL_PARAM_BLD_push_utf8_string(sig_pbld, OSSL_SIGNATURE_PARAM_DIGEST, md, 0);
+#ifdef ACVP_FIPS186_5
+        if (use_pss) {
+            OSSL_PARAM_BLD_push_utf8_string(sig_pbld, OSSL_SIGNATURE_PARAM_MGF1_DIGEST, md, 0);
+        }
+#endif
         sig_params = OSSL_PARAM_BLD_to_param(sig_pbld);
         if (!sig_params) {
             printf("Error building sig params in RSA sigver\n");

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -727,13 +727,16 @@ typedef enum acvp_rsa_param {
     ACVP_RSA_PARM_RAND_PQ,
     ACVP_RSA_PARM_INFO_GEN_BY_SERVER,
     ACVP_RSA_PARM_REVISION,
-    ACVP_RSA_PARM_MODULO
+    ACVP_RSA_PARM_MODULO,
+    ACVP_RSA_PARM_MASK_FUNCTION
 } ACVP_RSA_PARM;
 
 /** @enum ACVP_RSA_PRIME_PARAM */
 typedef enum acvp_rsa_prime_param {
     ACVP_RSA_PRIME_HASH_ALG = 1,
     ACVP_RSA_PRIME_TEST,
+    ACVP_RSA_PRIME_PMOD8,
+    ACVP_RSA_PRIME_QMOD8,
 } ACVP_RSA_PRIME_PARAM;
 
 /** @enum ACVP_ECDSA_PARM */
@@ -919,17 +922,37 @@ typedef enum acvp_rsa_pub_exp_mode {
 /** @enum ACVP_RSA_PRIME_TEST_TYPE */
 typedef enum acvp_rsa_prime_test_type {
     ACVP_RSA_PRIME_TEST_TBLC2 = 1,
-    ACVP_RSA_PRIME_TEST_TBLC3
+    ACVP_RSA_PRIME_TEST_TBLC3,
+    /* FIPS 186-5 */
+    ACVP_RSA_PRIME_TEST_2POW100,
+    ACVP_RSA_PRIME_TEST_2POW_SEC_STR
 } ACVP_RSA_PRIME_TEST_TYPE;
 
 /** @enum ACVP_RSA_KEYGEN_MODE */
 typedef enum acvp_rsa_keygen_mode_t {
-    ACVP_RSA_KEYGEN_B32 = 1,
+    ACVP_RSA_KEYGEN_NONE = 0,
+    ACVP_RSA_KEYGEN_B32,
     ACVP_RSA_KEYGEN_B33,
     ACVP_RSA_KEYGEN_B34,
     ACVP_RSA_KEYGEN_B35,
-    ACVP_RSA_KEYGEN_B36
+    ACVP_RSA_KEYGEN_B36,
+    /* These generally match the above ones, but the terminology has changed for FIPS 186-5 */
+    ACVP_RSA_KEYGEN_PROVABLE,
+    ACVP_RSA_KEYGEN_PROBABLE,
+    ACVP_RSA_KEYGEN_PROV_W_PROV_AUX,
+    ACVP_RSA_KEYGEN_PROB_W_PROV_AUX,
+    ACVP_RSA_KEYGEN_PROB_W_PROB_AUX,
+    ACVP_RSA_KEYGEN_MAX
 } ACVP_RSA_KEYGEN_MODE;
+
+/** @enum ACVP_RSA_MASK_FUNCTION */
+typedef enum acvp_rsa_mask_function_t {
+    ACVP_RSA_MASK_FUNCTION_NONE = 0,
+    ACVP_RSA_MASK_FUNCTION_MGF1,
+    ACVP_RSA_MASK_FUNCTION_SHAKE_128,
+    ACVP_RSA_MASK_FUNCTION_SHAKE_256,
+    ACVP_RSA_MASK_FUNCTION_MAX
+} ACVP_RSA_MASK_FUNCTION;
 
 /** @enum ACVP_RSA_SIG_TYPE */
 typedef enum acvp_rsa_sig_type {
@@ -1613,6 +1636,7 @@ typedef struct acvp_rsa_keygen_tc_t {
     unsigned int tc_id;    /**< Test case id */
     ACVP_HASH_ALG hash_alg;
     ACVP_RSA_TESTTYPE test_type;
+    ACVP_REVISION revision;
     ACVP_RSA_PRIME_TEST_TYPE prime_test;
     char *prime_result;
     char *pub_exp;
@@ -1735,6 +1759,7 @@ typedef struct acvp_eddsa_tc_t {
 typedef struct acvp_rsa_sig_tc_t {
     unsigned int tc_id; /**< Test case id */
     int tg_id;          /**< needed to keep e,n state */
+    ACVP_REVISION revision;
     char *group_e;
     char *group_n;
     ACVP_HASH_ALG hash_alg;
@@ -3403,6 +3428,10 @@ ACVP_RESULT acvp_cap_rsa_keygen_set_parm(ACVP_CTX *ctx,
                                          ACVP_RSA_PARM param,
                                          int value);
 
+ACVP_RESULT acvp_cap_rsa_siggen_set_parm(ACVP_CTX *ctx,
+                                             ACVP_RSA_PARM param,
+                                             int value);
+
 ACVP_RESULT acvp_cap_rsa_sigver_set_parm(ACVP_CTX *ctx,
                                          ACVP_RSA_PARM param,
                                          int value);
@@ -3437,6 +3466,14 @@ ACVP_RESULT acvp_cap_rsa_sigver_set_mod_parm(ACVP_CTX *ctx,
                                              unsigned int mod,
                                              int hash_alg,
                                              int salt_len);
+
+ACVP_RESULT acvp_cap_rsa_siggen_set_mod_mask(ACVP_CTX *ctx,
+                                             unsigned int mod,
+                                             int value);
+
+ACVP_RESULT acvp_cap_rsa_sigver_set_mod_mask(ACVP_CTX *ctx,
+                                             unsigned int mod,
+                                             int value);
 
 ACVP_RESULT acvp_cap_ecdsa_set_parm(ACVP_CTX *ctx,
                                     ACVP_CIPHER cipher,

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -285,8 +285,8 @@ static void acvp_cap_free_rsa_keygen_list(ACVP_CAPS_LIST *cap_list) {
         ACVP_RSA_MODE_CAPS_LIST *temp_mode_list;
 
         while (mode_list) {
-            acvp_cap_free_nl(mode_list->hash_algs);
-            acvp_cap_free_nl(mode_list->prime_tests);
+            acvp_cap_free_pl(mode_list->hash_algs);
+            acvp_cap_free_pl(mode_list->prime_tests);
 
             temp_mode_list = mode_list;
             mode_list = mode_list->next;
@@ -327,7 +327,7 @@ static void acvp_cap_free_rsa_sig_list(ACVP_CAPS_LIST *cap_list) {
         }
         while (mode_list) {
             acvp_cap_free_hash_pairs(mode_list->hash_pair);
-
+            acvp_cap_free_pl(mode_list->mask_functions);
             temp_mode_list = mode_list;
             mode_list = mode_list->next;
             free(temp_mode_list);

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -185,7 +185,7 @@ const char *acvp_lookup_cipher_revision(ACVP_CIPHER alg) {
 static struct acvp_alt_revision_info alt_revision_tbl[] = {
     { ACVP_REVISION_SP800_56AR3, ACVP_REV_STR_SP800_56AR3 },
     { ACVP_REVISION_SP800_56CR1, ACVP_REV_STR_SP800_56CR1 },
-    { ACVP_REVISION_FIPS186_4, ACVP_REV_STR_1_0 },
+    { ACVP_REVISION_FIPS186_4, ACVP_REV_STR_FIPS186_4 },
     { ACVP_REVISION_1_0, ACVP_REV_STR_1_0 }
 };
 static int alt_revision_tbl_length =
@@ -317,6 +317,34 @@ const char* acvp_lookup_cipher_mode_str(ACVP_CIPHER cipher) {
     return NULL;
 }
 
+const char *acvp_lookup_rsa_sig_type_str(ACVP_RSA_SIG_TYPE type) {
+    switch (type) {
+    case ACVP_RSA_SIG_TYPE_X931:
+        return ACVP_RSA_SIG_TYPE_X931_STR;
+    case ACVP_RSA_SIG_TYPE_PKCS1V15:
+        return ACVP_RSA_SIG_TYPE_PKCS1V15_STR;
+    case ACVP_RSA_SIG_TYPE_PKCS1PSS:
+        return ACVP_RSA_SIG_TYPE_PKCS1PSS_STR;
+    default:
+        return NULL;
+    }
+}
+
+const char *acvp_lookup_rsa_mask_func_str(ACVP_RSA_MASK_FUNCTION func) {
+    switch (func) {
+    case ACVP_RSA_MASK_FUNCTION_MGF1:
+        return ACVP_RSA_MASK_FUNC_STR_MGF1;
+    case ACVP_RSA_MASK_FUNCTION_SHAKE_128:
+        return ACVP_ALG_SHAKE_128;
+    case ACVP_RSA_MASK_FUNCTION_SHAKE_256:
+        return ACVP_ALG_SHAKE_256;
+    case ACVP_RSA_MASK_FUNCTION_NONE:
+    case ACVP_RSA_MASK_FUNCTION_MAX:
+    default:
+        return NULL;
+    }
+}
+
 /*
  * This method returns the string that corresponds to a randPQ
  * index value
@@ -324,20 +352,25 @@ const char* acvp_lookup_cipher_mode_str(ACVP_CIPHER cipher) {
 const char *acvp_lookup_rsa_randpq_name(int value) {
     switch (value) {
     case ACVP_RSA_KEYGEN_B32:
-        return "B.3.2"; // "provRP"
-
+        return ACVP_RSA_RANDPQ_STR_B32;
     case ACVP_RSA_KEYGEN_B33:
-        return "B.3.3"; // "probRP"
-
+        return ACVP_RSA_RANDPQ_STR_B33;
     case ACVP_RSA_KEYGEN_B34:
-        return "B.3.4"; // "provPC"
-
+        return ACVP_RSA_RANDPQ_STR_B34;
     case ACVP_RSA_KEYGEN_B35:
-        return "B.3.5"; // "bothPC"
-
+        return ACVP_RSA_RANDPQ_STR_B35;
     case ACVP_RSA_KEYGEN_B36:
-        return "B.3.6"; // "probPC"
-
+        return ACVP_RSA_RANDPQ_STR_B36;
+    case ACVP_RSA_KEYGEN_PROVABLE:
+        return ACVP_RSA_RANDPQ_STR_PROVABLE;
+    case ACVP_RSA_KEYGEN_PROBABLE:
+        return ACVP_RSA_RANDPQ_STR_PROBABLE;
+    case ACVP_RSA_KEYGEN_PROV_W_PROV_AUX:
+        return ACVP_RSA_RANDPQ_STR_PROV_W_PROV_AUX;
+    case ACVP_RSA_KEYGEN_PROB_W_PROV_AUX:
+        return ACVP_RSA_RANDPQ_STR_PROB_W_PROV_AUX;
+    case ACVP_RSA_KEYGEN_PROB_W_PROB_AUX:
+        return ACVP_RSA_RANDPQ_STR_PROB_W_PROB_AUX;
     default:
         return NULL;
     }
@@ -364,20 +397,35 @@ int acvp_lookup_rsa_randpq_index(const char *value) {
         return 0;
     }
 
-    strcmp_s("B.3.2", 5, value, &diff);
+    strcmp_s(ACVP_RSA_RANDPQ_STR_B32, sizeof(ACVP_RSA_RANDPQ_STR_B32) - 1, value, &diff);
     if (!diff) return ACVP_RSA_KEYGEN_B32;
 
-    strcmp_s("B.3.3", 5, value, &diff);
+    strcmp_s(ACVP_RSA_RANDPQ_STR_B33, sizeof(ACVP_RSA_RANDPQ_STR_B33) - 1, value, &diff);
     if (!diff) return ACVP_RSA_KEYGEN_B33;
 
-    strcmp_s("B.3.4", 5, value, &diff);
+    strcmp_s(ACVP_RSA_RANDPQ_STR_B34, sizeof(ACVP_RSA_RANDPQ_STR_B34) - 1, value, &diff);
     if (!diff) return ACVP_RSA_KEYGEN_B34;
 
-    strcmp_s("B.3.5", 5, value, &diff);
+    strcmp_s(ACVP_RSA_RANDPQ_STR_B35, sizeof(ACVP_RSA_RANDPQ_STR_B35) - 1, value, &diff);
     if (!diff) return ACVP_RSA_KEYGEN_B35;
 
-    strcmp_s("B.3.6", 5, value, &diff);
+    strcmp_s(ACVP_RSA_RANDPQ_STR_B36, sizeof(ACVP_RSA_RANDPQ_STR_B36) - 1, value, &diff);
     if (!diff) return ACVP_RSA_KEYGEN_B36;
+
+    strcmp_s(ACVP_RSA_RANDPQ_STR_PROVABLE, sizeof(ACVP_RSA_RANDPQ_STR_PROVABLE) - 1, value, &diff);
+    if (!diff) return ACVP_RSA_KEYGEN_PROVABLE;
+
+    strcmp_s(ACVP_RSA_RANDPQ_STR_PROBABLE, sizeof(ACVP_RSA_RANDPQ_STR_PROBABLE) - 1, value, &diff);
+    if (!diff) return ACVP_RSA_KEYGEN_PROBABLE;
+
+    strcmp_s(ACVP_RSA_RANDPQ_STR_PROV_W_PROV_AUX, sizeof(ACVP_RSA_RANDPQ_STR_PROV_W_PROV_AUX) - 1, value, &diff);
+    if (!diff) return ACVP_RSA_KEYGEN_PROV_W_PROV_AUX;
+
+    strcmp_s(ACVP_RSA_RANDPQ_STR_PROB_W_PROV_AUX, sizeof(ACVP_RSA_RANDPQ_STR_PROB_W_PROV_AUX) - 1, value, &diff);
+    if (!diff) return ACVP_RSA_KEYGEN_PROB_W_PROV_AUX;
+
+    strcmp_s(ACVP_RSA_RANDPQ_STR_PROB_W_PROB_AUX, sizeof(ACVP_RSA_RANDPQ_STR_PROB_W_PROB_AUX) - 1, value, &diff);
+    if (!diff) return ACVP_RSA_KEYGEN_PROB_W_PROB_AUX;
 
     return 0;
 }
@@ -504,11 +552,13 @@ const char *acvp_lookup_hash_alg_name(ACVP_HASH_ALG id) {
 const char *acvp_lookup_rsa_prime_test_name(ACVP_RSA_PRIME_TEST_TYPE type) {
     switch (type) {
     case ACVP_RSA_PRIME_TEST_TBLC2:
-        return ACVP_RSA_PRIME_TEST_TBLC2_STR;
-
+        return ACVP_RSA_PRIME_TEST_STR_TBLC2;
     case ACVP_RSA_PRIME_TEST_TBLC3:
-        return ACVP_RSA_PRIME_TEST_TBLC3_STR;
-
+        return ACVP_RSA_PRIME_TEST_STR_TBLC3;
+    case ACVP_RSA_PRIME_TEST_2POW100:
+        return ACVP_RSA_PRIME_TEST_STR_2POW100;
+    case ACVP_RSA_PRIME_TEST_2POW_SEC_STR:
+        return ACVP_RSA_PRIME_TEST_STR_2POW_SEC_STR;
     default:
         return NULL;
     }
@@ -520,10 +570,10 @@ ACVP_RESULT is_valid_prime_test(const char *value) {
 
     if (!value) { return ACVP_INVALID_ARG; }
 
-    strcmp_s(ACVP_RSA_PRIME_TEST_TBLC2_STR, 5, value, &diff);
+    strcmp_s(ACVP_RSA_PRIME_TEST_STR_TBLC2, sizeof(ACVP_RSA_PRIME_TEST_STR_TBLC2) - 1, value, &diff);
     if (!diff) return ACVP_SUCCESS;
 
-    strcmp_s(ACVP_RSA_PRIME_TEST_TBLC3_STR, 5, value, &diff);
+    strcmp_s(ACVP_RSA_PRIME_TEST_STR_TBLC3, sizeof(ACVP_RSA_PRIME_TEST_STR_TBLC3) - 1, value, &diff);
     if (!diff) return ACVP_SUCCESS;
 
     return ACVP_INVALID_ARG;


### PR DESCRIPTION
This one got a bit messy. The RSA capability registration code is pretty old so I brought it up to speed a little bit. It sill isn't perfect but its a little more consistent; I will make a second pass at it at some point.


- FIPS 186-5 support for RSA. 186-4 support is also maintained.
- Removed storing const string references in the RSA capability object (Just use enums and only pull strings when we are building the registration)
- New API's needed to set mask function for RSA signatures, as the other APIs didnt quite have the right combination of parameters