### PR TITLE
ECDSA fixes, SA fixes, build fixes

### DIFF
--- a/app/app_ecdsa.c
+++ b/app/app_ecdsa.c
@@ -202,6 +202,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
             }
 
             if (alg == ACVP_SUB_DET_ECDSA_SIGGEN) {
+#ifdef ACVP_FIPS186_5
                 if (pkey_pbld) OSSL_PARAM_BLD_free(pkey_pbld);
                 if (params) OSSL_PARAM_free(params);
                 pkey_pbld = NULL;
@@ -219,7 +220,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
                     printf("Error generating parameters for pkey generation in DetECDSA siggen\n");
                     goto err;
                 }
-
+#endif
                 if (pkey_ctx) EVP_PKEY_CTX_free(pkey_ctx);
                 pkey_ctx = NULL;
                 if (EVP_DigestSignInit_ex(sig_ctx, &pkey_ctx, md, NULL, NULL, group_pkey, NULL) != 1) {

--- a/app/app_eddsa.c
+++ b/app/app_eddsa.c
@@ -10,6 +10,8 @@
 #include "app_lcl.h"
 #include "safe_lib.h"
 
+#ifdef ACVP_FIPS186_5
+
 #include <openssl/evp.h>
 #include <openssl/param_build.h>
 #include <openssl/core_names.h>
@@ -313,7 +315,7 @@ err:
     return rv;
 }
 
-#if 0
+#else
 
 int app_eddsa_handler(ACVP_TEST_CASE *test_case) {
     if (!test_case) {

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -3087,7 +3087,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
 #ifndef ACVP_FIPS186_5
-    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_REVISION, ACVP_REVISION_FIPS186_4);
+    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_REVISION, ACVP_REVISION_1_0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K233);
     CHECK_ENABLE_CAP_RV(rv);
@@ -3125,7 +3125,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
 #ifndef ACVP_FIPS186_5
-    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_REVISION, ACVP_REVISION_FIPS186_4);
+    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_REVISION, ACVP_REVISION_1_0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K233);
     CHECK_ENABLE_CAP_RV(rv);
@@ -3170,7 +3170,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
 #ifndef ACVP_FIPS186_5
-    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_REVISION, ACVP_REVISION_FIPS186_4);
+    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_REVISION, ACVP_REVISION_1_0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K233);
     CHECK_ENABLE_CAP_RV(rv);
@@ -3252,7 +3252,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_COMPONENT_TEST, ACVP_ECDSA_COMPONENT_MODE_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
 #ifndef ACVP_FIPS186_5
-    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_REVISION, ACVP_REVISION_FIPS186_4);
+    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_REVISION, ACVP_REVISION_1_0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K233);
     CHECK_ENABLE_CAP_RV(rv);

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -190,7 +190,9 @@ static void app_cleanup(ACVP_CTX *ctx) {
 #endif
     app_rsa_cleanup();
     app_ecdsa_cleanup();
+#ifdef ACVP_FIPS186_5
     app_eddsa_cleanup();
+#endif
 #endif
 }
 

--- a/app/app_rsa.c
+++ b/app/app_rsa.c
@@ -347,7 +347,10 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
             printf("Error creating MD CTX in RSA sigver\n");
             goto err;
         }
-        EVP_DigestSignInit_ex(md_ctx, NULL, md, NULL, NULL, group_pkey, sig_params);
+        if (EVP_DigestSignInit_ex(md_ctx, NULL, md, NULL, NULL, group_pkey, sig_params) != 1) {
+            printf("Error initializing sign ctx in RSA siggen\n");
+            goto err;
+        }
         if (EVP_DigestSign(md_ctx, tc->signature, (size_t *)&tc->sig_len, tc->msg, tc->msg_len) != 1) {
             printf("Error while performing signature generation\n");
             goto err;

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -1683,7 +1683,6 @@ static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CTX *ctx, ACVP_CIPHER ciph
 static ACVP_RESULT acvp_build_eddsa_register_cap(ACVP_CTX *ctx,JSON_Object *cap_obj, ACVP_CAPS_LIST *cap_entry) {
     JSON_Array *curves_arr = NULL;
     ACVP_PARAM_LIST *current_curve = NULL;
-    JSON_Value *alg_caps_val = NULL;
     const char *revision = NULL, *tmp = NULL;
     ACVP_SUB_EDDSA alg;
     ACVP_EDDSA_CAP *eddsa_cap = NULL;
@@ -1739,7 +1738,6 @@ static ACVP_RESULT acvp_build_eddsa_register_cap(ACVP_CTX *ctx,JSON_Object *cap_
     while (current_curve) {
         tmp = acvp_lookup_ed_curve_name(current_curve->param);
         if (!tmp) {
-            if (alg_caps_val) json_value_free(alg_caps_val);
             return ACVP_MISSING_ARG;
         }
         json_array_append_string(curves_arr, tmp);

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -5479,8 +5479,8 @@ ACVP_RESULT acvp_cap_ecdsa_set_parm(ACVP_CTX *ctx,
             ACVP_LOG_ERR("Unable to set alternate revision for DetECDSA; not applicable at this time");
             return ACVP_INVALID_ARG;
         }
-        if (value != ACVP_REVISION_FIPS186_4) {
-            ACVP_LOG_ERR("Invalid ECDSA revision. Only revision FIPS 186-4 can be set for ECDSA. default is 186-5.");
+        if (value != ACVP_REVISION_1_0) {
+            ACVP_LOG_ERR("Invalid ECDSA revision. Only revision 1.0 (AKA FIPS 186-4) can be set for ECDSA. default is 186-5.");
             return ACVP_INVALID_ARG;
         }
         cap->revision = value;

--- a/src/acvp_eddsa.c
+++ b/src/acvp_eddsa.c
@@ -26,7 +26,7 @@ static ACVP_RESULT acvp_eddsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
  * the JSON processing for a single test case.
  */
 static ACVP_RESULT acvp_eddsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_EDDSA_TC *stc, JSON_Object *tc_rsp) {
-    ACVP_RESULT rv;
+    ACVP_RESULT rv = ACVP_SUCCESS;
     char *tmp = NULL;
 
     if (cipher == ACVP_EDDSA_SIGVER || cipher == ACVP_EDDSA_KEYVER) {


### PR DESCRIPTION
- Old revision of ECDSA should be 1.0, not 186-4. they are the same thing, just different in how ACVP named it
- static analysis fixes
- build fixes for non 186-5