### PR TITLE
Registration updates

### DIFF
--- a/app/app_sha.c
+++ b/app/app_sha.c
@@ -10,11 +10,9 @@
 #include "app_lcl.h"
 #include <openssl/evp.h>
 
-#ifdef ACVPAPP_HASH_LDT_SUPPORT
 #include "safe_mem_lib.h"
 
 int app_sha_ldt_handler();
-#endif
 
 int app_sha_handler(ACVP_TEST_CASE *test_case) {
     ACVP_HASH_TC    *tc;
@@ -95,11 +93,7 @@ int app_sha_handler(ACVP_TEST_CASE *test_case) {
     }
     md_ctx = EVP_MD_CTX_create();
     if (tc->test_type == ACVP_HASH_TEST_TYPE_LDT) {
-        #ifdef ACVPAPP_HASH_LDT_SUPPORT
-            rc = app_sha_ldt_handler(tc, md);
-        #else
-            printf("LDT not supported in this build of acvp_app\n");
-        #endif
+        rc = app_sha_ldt_handler(tc, md);
         goto end;
     } else if (tc->test_type == ACVP_HASH_TEST_TYPE_MCT && !sha3 && !shake) {
         /* If Monte Carlo we need to be able to init and then update
@@ -178,7 +172,6 @@ end:
  * 2) oneshot function or a single call to update; never multiple calls to update
  * 3) allowed for all SHA, not SHAKE
  */
-#ifdef ACVPAPP_HASH_LDT_SUPPORT
 int app_sha_ldt_handler(ACVP_HASH_TC *tc, EVP_MD *md) {
     unsigned char *large_data = NULL, *iter = NULL;
     int numcopies = 0, i = 0, rv = 1;
@@ -223,5 +216,3 @@ end:
     if (md_ctx) EVP_MD_CTX_destroy(md_ctx);
     return rv;
 }
-
-#endif

--- a/configure
+++ b/configure
@@ -947,7 +947,6 @@ with_criterion_dir
 enable_lib_check
 enable_ssp
 enable_wrapper_library
-enable_hash_ldt
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1620,7 +1619,6 @@ Optional Features:
                           Designed for use with offline builds, turns acvp_app
                           into a single API library for processing offline
                           tests
-  --enable-hash-ldt       Enables Large Data Testing for SHA in acvp_app
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -4968,13 +4966,13 @@ if ${lt_cv_nm_interface+:} false; then :
 else
   lt_cv_nm_interface="BSD nm"
   echo "int some_variable = 0;" > conftest.$ac_ext
-  (eval echo "\"\$as_me:4971: $ac_compile\"" >&5)
+  (eval echo "\"\$as_me:4969: $ac_compile\"" >&5)
   (eval "$ac_compile" 2>conftest.err)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4974: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
+  (eval echo "\"\$as_me:4972: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
   (eval "$NM \"conftest.$ac_objext\"" 2>conftest.err > conftest.out)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4977: output\"" >&5)
+  (eval echo "\"\$as_me:4975: output\"" >&5)
   cat conftest.out >&5
   if $GREP 'External.*some_variable' conftest.out > /dev/null; then
     lt_cv_nm_interface="MS dumpbin"
@@ -6179,7 +6177,7 @@ ia64-*-hpux*)
   ;;
 *-*-irix6*)
   # Find out which ABI we are using.
-  echo '#line 6182 "configure"' > conftest.$ac_ext
+  echo '#line 6180 "configure"' > conftest.$ac_ext
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
@@ -7708,11 +7706,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7711: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7709: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7715: \$? = $ac_status" >&5
+   echo "$as_me:7713: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8047,11 +8045,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8050: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8048: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:8054: \$? = $ac_status" >&5
+   echo "$as_me:8052: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8152,11 +8150,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8155: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8153: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8159: \$? = $ac_status" >&5
+   echo "$as_me:8157: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -8207,11 +8205,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8210: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8208: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8214: \$? = $ac_status" >&5
+   echo "$as_me:8212: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -10577,7 +10575,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10580 "configure"
+#line 10578 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -10673,7 +10671,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10676 "configure"
+#line 10674 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -11117,15 +11115,6 @@ if test "${enable_wrapper_library+set}" = set; then :
   enableval=$enable_wrapper_library; wraplib="$enableval"
 else
   wrap_lib=false
-fi
-
-
-# Enable large data test support (Hashing multiple GiB of data) for SHA in acvp_app
-# Check whether --enable-hash-ldt was given.
-if test "${enable_hash_ldt+set}" = set; then :
-  enableval=$enable_hash_ldt; ldt_support="yes"
-else
-  ldt_support="no"
 fi
 
 
@@ -11700,10 +11689,6 @@ if test "x$with_criterion" != "xno" ; then
 
     CRITERION_LDFLAGS="-L$criteriondir/lib -lcriterion"
 
-fi
-
-if test "x$ldt_support" = "xyes"; then
-    cond_alg_cflags="$cond_alg_cflags -DACVPAPP_HASH_LDT_SUPPORT"
 fi
 
  if test "x$with_criteriondir" != "xno"; then

--- a/configure.ac
+++ b/configure.ac
@@ -184,13 +184,6 @@ AC_ARG_ENABLE([wrapper-library],
 [wraplib="$enableval"],
 [wrap_lib=false])
 
-# Enable large data test support (Hashing multiple GiB of data) for SHA in acvp_app
-AC_ARG_ENABLE([hash-ldt],
-[AS_HELP_STRING([--enable-hash-ldt],
-[Enables Large Data Testing for SHA in acvp_app])],
-[ldt_support="yes"],
-[ldt_support="no"])
-
 ########################################################################################
 # End reading arguments. Begin testing presence of libs and setting certain make vars. #
 ########################################################################################
@@ -332,10 +325,6 @@ fi
 if test "x$with_criterion" != "xno" ; then
     AC_SUBST([CRITERION_CFLAGS], "-I$criteriondir/include")
     AC_SUBST([CRITERION_LDFLAGS], "-L$criteriondir/lib -lcriterion")
-fi
-
-if test "x$ldt_support" = "xyes"; then
-    cond_alg_cflags="$cond_alg_cflags -DACVPAPP_HASH_LDT_SUPPORT"
 fi
 
 AM_CONDITIONAL([UNIT_TEST_SUPPORTED], [test "x$with_criteriondir" != "xno"])

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -1242,6 +1242,7 @@ static ACVP_RESULT acvp_build_rsa_sig_register_cap(JSON_Object *cap_obj, ACVP_CA
     ACVP_RESULT result = ACVP_SUCCESS;
     ACVP_PARAM_LIST *plist = NULL;
     ACVP_RSA_SIG_CAP *rsa_cap_mode = NULL;
+    ACVP_REVISION rev = ACVP_REVISION_DEFAULT;
     JSON_Array *alg_specs_array = NULL, *sig_type_caps_array = NULL, *hash_pair_array = NULL, *mask_func_array = NULL;
     JSON_Value *alg_specs_val = NULL, *sig_type_val = NULL, *hash_pair_val = NULL;
     JSON_Object *alg_specs_obj = NULL, *sig_type_obj = NULL, *hash_pair_obj = NULL;
@@ -1267,6 +1268,7 @@ static ACVP_RESULT acvp_build_rsa_sig_register_cap(JSON_Object *cap_obj, ACVP_CA
 
     if (rsa_cap_mode->revision) {
         revision = acvp_lookup_alt_revision_string(rsa_cap_mode->revision);
+        rev = rsa_cap_mode->revision; /* Since caps are stringed together, we want the first value */
     } else {
         revision = acvp_lookup_cipher_revision(cap_entry->cipher);
     }
@@ -1309,7 +1311,7 @@ static ACVP_RESULT acvp_build_rsa_sig_register_cap(JSON_Object *cap_obj, ACVP_CA
 
             json_object_set_number(sig_type_obj, "modulo", current_sig_type_cap->modulo);
 
-            if (rsa_cap_mode->revision != ACVP_REVISION_FIPS186_4 && rsa_cap_mode->sig_type == ACVP_RSA_SIG_TYPE_PKCS1PSS) {
+            if (rev != ACVP_REVISION_FIPS186_4 && rsa_cap_mode->sig_type == ACVP_RSA_SIG_TYPE_PKCS1PSS) {
                 json_object_set_value(sig_type_obj, "maskFunction", json_value_init_array());
                 mask_func_array = json_object_get_array(sig_type_obj, "maskFunction");
                 plist = current_sig_type_cap->mask_functions;


### PR DESCRIPTION
- Disable EDDSA for non FIPS186-5 modules
- AES-CBC-CS3 PT len lower bound from 136 to 128 for 3.1.2
- give AES GMAC an IV range instead of a single IV for 3.1.2
- Large data testing for SHA:
    - Enabled for SHA3 for 3.0.8 or greater by default
    - Enabled for rest of SHA for 3.1.2 or greater by default
    - Removed the configure option to enable LDT since its now needed by default
- Add more HMAC modes for KDF sp800-108 for 3.1.2 or greater
- PBKDF: add SHA3 support for 3.1.2 or greater
- KAS-FFC: Add MODP modes back for 3.1.2 or greater
- Safe Primes: Add MODP modes back for 3.1.2 or greater
- ECDSA sigs: add SHA3 for 3.1.2 or greater
- RSA bugfix

More registration updates incoming, just the first batch