### PR TITLE
KMAC KDF, other fixes

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1573,7 +1573,6 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
     rv = acvp_cap_kdf135_x942_enable(ctx, &app_kdf135_x942_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X942, ACVP_PREREQ_SHA, value);
@@ -1724,6 +1723,20 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA512);
     CHECK_ENABLE_CAP_RV(rv);
+#if OPENSSL_VERSION_NUMBER >= 0x30100000L
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA512_224);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA512_256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_224);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_256);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_384);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_512);
+    CHECK_ENABLE_CAP_RV(rv);
+#endif
     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTS_EMPTY_IV, 1);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_REQUIRES_EMPTY_IV, 1);
@@ -1734,10 +1747,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* KDF108 KMAC Mode */
-#if 0
-    /* Only valid for OpenSSL 3.1 */
-    /* Call sequence is very close to regular kdf108, with no creation of fixed data */
-    #if OPENSSL_VERSION_NUMBER >= 0x30100000L
+#if OPENSSL_VERSION_NUMBER >= 0x30100000L
 	rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_KMAC, value);
 	CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_KMAC_128);
@@ -1752,7 +1762,6 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_LABEL_LEN, 8, 4096, 8);
     CHECK_ENABLE_CAP_RV(rv);
-    #endif
 #endif
 
     /* PBKDF */
@@ -1792,7 +1801,6 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_pbkdf_set_domain(ctx, ACVP_PBKDF_SALT_LEN, 128, 4096, 8);
     CHECK_ENABLE_CAP_RV(rv);
-#endif
 
     rv = acvp_cap_kdf_tls13_enable(ctx, &app_kdf_tls13_handler);
     CHECK_ENABLE_CAP_RV(rv);

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -2020,8 +2020,6 @@ static ACVP_RESULT acvp_build_kdf135_x942_register_cap(JSON_Object *cap_obj, ACV
     /* KDF type */
     json_object_set_value(cap_obj, "kdfType", json_value_init_array());
     tmp_arr = json_object_get_array(cap_obj, "kdfType");
-    tmp_val = json_value_init_object();
-    tmp_obj = json_value_get_object(tmp_val);
     switch (cap->type) {
     case ACVP_KDF_X942_KDF_TYPE_DER:
         json_array_append_string(tmp_arr, "DER");


### PR DESCRIPTION
- Enable KMAC SP800-108 KDF for 3.1.2, update harness to support testing
- Add missed HMAC modes for feedback mode
- remove unused memory alloc