### PR TITLE
Basis for reading provider versions

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -180,30 +180,7 @@ static void print_usage(int code) {
     printf("        ACV_OE_COMPILER\n\n");
 }
 
-static void print_version_info(void) {
-    printf("\nACVP library version(protocol version): %s(%s)\n\n", acvp_version(), acvp_protocol_version());
-    printf("        Runtime mode: yes\n");
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
-    if (FIPS_mode()) {
-        printf("           FIPS mode: yes\n");
-    } else {
-        printf("           FIPS mode: no\n");
-    }
-#else
-    if (EVP_default_properties_is_fips_enabled(NULL)) {
-        printf("           FIPS by default: yes\n");
-    } else {
-        printf("           FIPS by default: no\n");
-    }
-#endif
 
-#ifdef OPENSSL_VERSION_TEXT
-    printf("Compiled SSL version: %s\n", OPENSSL_VERSION_TEXT);
-#else
-    printf("Compiled SSL version: not detected\n");
-#endif
-    printf("  Linked SSL version: %s\n", OpenSSL_version(OPENSSL_VERSION));
-}
 
 static ko_longopt_t longopts[] = {
     { "version", ko_no_argument, 301 },
@@ -312,7 +289,7 @@ static int check_option_length(const char *opt, int c, int maxAllowed) {
 
 int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
     ketopt_t opt = KETOPT_INIT;
-    int c = 0, diff = 0, len = 0;
+    int c = 0, diff = 0, len = 0, print_ver = 0;
 
     cfg->empty_alg = 1;
 
@@ -325,8 +302,9 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
         switch (c) {
         case 'v':
         case 301:
-            print_version_info();
-            return 1;
+            /* Print version info AFTER other args are read, so we can see module runtime info better */
+            print_ver = 1;
+            break;
         case 'h':
         case 302:
             if (opt.arg) {
@@ -612,6 +590,11 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
             printf(ANSI_COLOR_RED "unknown option: %s\n" ANSI_COLOR_RESET, argv[c]);
         }
         printf("%s\n", ACVP_APP_HELP_MSG);
+        return 1;
+    }
+
+    if (print_ver) {
+        print_version_info(cfg->disable_fips == 0);
         return 1;
     }
 

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -25,6 +25,7 @@ extern "C"
 #define JSON_FILENAME_LENGTH 128
 #define JSON_STRING_LENGTH 32
 #define JSON_REQUEST_LENGTH 128
+#define PROVIDER_NAME_MAX_LEN 64
 #define ALG_STR_MAX_LEN 256 /* arbitrary */
 extern char value[JSON_STRING_LENGTH];
 
@@ -83,6 +84,7 @@ typedef struct app_config {
 } APP_CONFIG;
 
 
+void print_version_info(int fips_active);
 int ingest_cli(APP_CONFIG *cfg, int argc, char **argv);
 int app_setup_two_factor_auth(ACVP_CTX *ctx);
 unsigned int swap_uint_endian(unsigned int i);
@@ -144,12 +146,14 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case);
 int app_safe_primes_handler(ACVP_TEST_CASE *test_case);
 int app_lms_handler(ACVP_TEST_CASE *test_case);
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 int app_aes_handler_gmac(ACVP_TEST_CASE *test_case);
 ACVP_RESULT fips_sanity_check(void);
 const char *get_string_from_oid(unsigned char *oid, int oid_len);
 const char *get_ed_instance_param(ACVP_ED_CURVE curve, int is_prehash, int has_context);
 const char *get_ed_curve_string(ACVP_ED_CURVE curve);
+const char *get_provider_version(const char *provider_name);
+#if 0 /* Will use in a future release */
+int provider_ver_str_to_int(const char *str);
 #endif
 
 #ifdef __cplusplus

--- a/app/app_utils.c
+++ b/app/app_utils.c
@@ -637,7 +637,7 @@ end:
 #if 0 /* Will use in a future release */
 /* Converts a provider version string in the format MAJOR.MINOR.PATCH to an integer in the format (major * 1000000) + (minor * 10000) + patch */
 int provider_ver_str_to_int(const char *str) {
-    int major = 0, minor = 0, patch = 0, result = 0, rv = -1;
+    int major = 0, minor = 0, patch = 0, result = 0;
 
     if (!str) {
         return -1;


### PR DESCRIPTION
- Add code to parse FIPS provider version string, print out in version info
- add code to convert provider version string into an int, disabled for now on open source
- change version command output to be more useful (FIPS mode was not properly read previously, as default properties were not set before running the version command)
- Move version function out of app_cli into app_utils