### PR TITLE
Add option to use DRBG with prediction resistance on AND off

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -3465,7 +3465,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
 
 #if OPENSSL_VERSION_NUMBER < 0x30100000L
     /* Group number for these should be 0 */
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_RESEED_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
@@ -3580,7 +3580,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
 
 #if OPENSSL_VERSION_NUMBER < 0x30100000L
     /* Group number for these should be 0 */
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_RESEED_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
@@ -3694,7 +3694,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     /* Group number for these should be 0 */
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_DER_FUNC_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_RESEED_ENABLED, 1);
@@ -3751,7 +3751,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_DER_FUNC_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+    rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_RESEED_ENABLED, 1);
     CHECK_ENABLE_CAP_RV(rv);

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -706,6 +706,15 @@ typedef enum acvp_drbg_mode {
     ACVP_DRBG_AES_256
 } ACVP_DRBG_MODE;
 
+/** @enum ACVP_PRED_RESIST_MODE
+ * disabled == 0 and enabled == 1 for backwards compatibility
+ */
+typedef enum acvp_drbg_pred_resist_mode {
+    ACVP_DRBG_PRED_RESIST_NO = 0,
+    ACVP_DRBG_PRED_RESIST_YES,
+    ACVP_DRBG_PRED_RESIST_BOTH
+} ACVP_DRBG_PRED_RESIST_MODE;
+
 /** @enum ACVP_DRBG_PARM */
 typedef enum acvp_drbg_param {
     ACVP_DRBG_DER_FUNC_ENABLED = 0,

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -1310,8 +1310,8 @@ typedef struct acvp_drbg_mode_list_t {
 typedef struct acvp_drbg_capability {
     ACVP_CIPHER cipher;
     ACVP_PREREQ_LIST *prereq_vals;
-    int pred_resist_enabled;    // boolean
-    int reseed_implemented;     // boolean
+    ACVP_DRBG_PRED_RESIST_MODE pred_resist;
+    int reseed_implemented; // boolean
     ACVP_DRBG_MODE_LIST *drbg_cap_mode;
 } ACVP_DRBG_CAP;
 

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -978,7 +978,22 @@ static ACVP_RESULT acvp_build_drbg_register_cap(JSON_Object *cap_obj, ACVP_CAPS_
 
     json_object_set_value(cap_obj, "predResistanceEnabled", json_value_init_array());
     array = json_object_get_array(cap_obj, "predResistanceEnabled");
-    json_array_append_boolean(array, cap->pred_resist_enabled);
+    switch (cap->pred_resist) {
+    case ACVP_DRBG_PRED_RESIST_NO:
+        json_array_append_boolean(array, 0);
+        break;
+    case ACVP_DRBG_PRED_RESIST_YES:
+        json_array_append_boolean(array, 1);
+        break;
+    case ACVP_DRBG_PRED_RESIST_BOTH:
+        json_array_append_boolean(array, 1);
+        json_array_append_boolean(array, 0);
+        break;
+    default:
+        return ACVP_INTERNAL_ERR;
+        break;
+    }
+
     json_object_set_boolean(cap_obj, "reseedImplemented", cap->reseed_implemented);
 
     json_object_set_value(cap_obj, "capabilities", json_value_init_array());

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -3994,6 +3994,10 @@ static ACVP_RESULT acvp_validate_drbg_parm_value(ACVP_DRBG_PARM parm, int value)
     switch (parm) {
     case ACVP_DRBG_DER_FUNC_ENABLED:
     case ACVP_DRBG_PRED_RESIST_ENABLED:
+        if (value >= ACVP_DRBG_PRED_RESIST_NO && value <= ACVP_DRBG_PRED_RESIST_BOTH) {
+            retval = ACVP_SUCCESS;
+        }
+        break;
     case ACVP_DRBG_RESEED_ENABLED:
         retval = is_valid_tf_param(value);
         break;
@@ -4108,7 +4112,7 @@ ACVP_RESULT acvp_cap_drbg_set_parm(ACVP_CTX *ctx,
         grp->der_func_enabled = value;
         break;
     case ACVP_DRBG_PRED_RESIST_ENABLED:
-        cap_list->cap.drbg_cap->pred_resist_enabled = value;
+        cap_list->cap.drbg_cap->pred_resist = value;
         break;
     case ACVP_DRBG_RESEED_ENABLED:
         cap_list->cap.drbg_cap->reseed_implemented = value;

--- a/test/test_acvp_build_register.c
+++ b/test/test_acvp_build_register.c
@@ -402,7 +402,7 @@ static void add_drbg_details_good(void) {
                                      ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
-                                   ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+                                   ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
                                    ACVP_DRBG_RESEED_ENABLED, 1);
@@ -436,7 +436,7 @@ static void add_drbg_details_good(void) {
                                    ACVP_DRBG_DER_FUNC_ENABLED, 1);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, 0,
-                                   ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+                                   ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, 0,
                                    ACVP_DRBG_RESEED_ENABLED, 1);
@@ -480,7 +480,7 @@ static void add_drbg_details_good(void) {
                                    ACVP_DRBG_DER_FUNC_ENABLED, 1);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0,
-                                   ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+                                   ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0,
                                    ACVP_DRBG_RESEED_ENABLED, 0);

--- a/test/test_acvp_capabilities.c
+++ b/test/test_acvp_capabilities.c
@@ -1421,7 +1421,7 @@ Test(EnableCapDRBG, good_hash, .fini = teardown) {
                                      ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
-                                   ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+                                   ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
                                    ACVP_DRBG_RESEED_ENABLED, 1);
@@ -1461,7 +1461,7 @@ Test(EnableCapDRBG, good_hmac, .fini = teardown) {
                                    ACVP_DRBG_DER_FUNC_ENABLED, 1);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, 0,
-                                   ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+                                   ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, 0,
                                    ACVP_DRBG_RESEED_ENABLED, 1);
@@ -1517,7 +1517,7 @@ Test(EnableCapDRBG, good_ctr, .fini = teardown) {
                                    ACVP_DRBG_DER_FUNC_ENABLED, 1);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0,
-                                   ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+                                   ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0,
                                    ACVP_DRBG_RESEED_ENABLED, 0);

--- a/test/test_acvp_drbg.c
+++ b/test/test_acvp_drbg.c
@@ -33,7 +33,7 @@ static void setup(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
-            ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+            ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
@@ -75,7 +75,7 @@ static void setup(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, 0,
-            ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+            ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, 0,
@@ -129,7 +129,7 @@ static void setup(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0,
-            ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+            ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0,
@@ -156,7 +156,7 @@ static void setup_fail(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
-            ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+            ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
@@ -198,7 +198,7 @@ static void setup_fail(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, 0,
-            ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+            ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, 0,
@@ -252,7 +252,7 @@ static void setup_fail(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0,
-            ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+            ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0,
@@ -286,7 +286,7 @@ Test(DRBG_CAPABILITY, good) {
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
-            ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+            ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
@@ -328,7 +328,7 @@ Test(DRBG_CAPABILITY, good) {
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, 0,
-            ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+            ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_224, 0,
@@ -382,7 +382,7 @@ Test(DRBG_CAPABILITY, good) {
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0,
-            ACVP_DRBG_PRED_RESIST_ENABLED, 1);
+            ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0,


### PR DESCRIPTION
it is non breaking/backwards compatible with current API calls