### PR TITLE
Add mask function variable to test cases for rsa

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -2753,6 +2753,8 @@ static int enable_rsa(ACVP_CTX *ctx) {
     rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_B36, 4096,
                                         ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_TBLC2);
     CHECK_ENABLE_CAP_RV(rv);
+#endif
+
 #if OPENSSL_VERSION_NUMBER >= 0x30100000L
     rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_B36, 2048, ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_TBLC3);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2772,7 +2774,6 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_KEY_FORMAT, ACVP_RSA_KEY_FORMAT_STANDARD);
     CHECK_ENABLE_CAP_RV(rv);
-#endif
 
     /* Enable siggen */
     rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -1773,6 +1773,7 @@ typedef struct acvp_rsa_sig_tc_t {
     char *group_n;
     ACVP_HASH_ALG hash_alg;
     ACVP_RSA_SIG_TYPE sig_type;
+    ACVP_RSA_MASK_FUNCTION mask;
     unsigned int modulo;
     unsigned char *e;
     int e_len;

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -354,7 +354,9 @@
 #define ACVP_RSA_SIG_TYPE_PKCS1V15_STR  "pkcs1v1.5"
 #define ACVP_RSA_SIG_TYPE_PKCS1PSS_STR  "pss"
 
-#define ACVP_RSA_MASK_FUNC_STR_MGF1 "MGF1"
+#define ACVP_RSA_MASK_FUNC_STR_MGF1 "mgf1"
+#define ACVP_RSA_MASK_FUNC_STR_SHAKE128 "shake-128"
+#define ACVP_RSA_MASK_FUNC_STR_SHAKE256 "shake-256"
 
 #define ACVP_ALG_RSA                "RSA"
 #define ACVP_ALG_ECDSA              "ECDSA"

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -335,9 +335,9 @@ const char *acvp_lookup_rsa_mask_func_str(ACVP_RSA_MASK_FUNCTION func) {
     case ACVP_RSA_MASK_FUNCTION_MGF1:
         return ACVP_RSA_MASK_FUNC_STR_MGF1;
     case ACVP_RSA_MASK_FUNCTION_SHAKE_128:
-        return ACVP_ALG_SHAKE_128;
+        return ACVP_RSA_MASK_FUNC_STR_SHAKE128;
     case ACVP_RSA_MASK_FUNCTION_SHAKE_256:
-        return ACVP_ALG_SHAKE_256;
+        return ACVP_RSA_MASK_FUNCTION_SHAKE_256;
     case ACVP_RSA_MASK_FUNCTION_NONE:
     case ACVP_RSA_MASK_FUNCTION_MAX:
     default:


### PR DESCRIPTION
Also make FIPS186-5 registration block smaller to not exclude necessary rsa keygen values 