### PR TITLE
RSA Primitive updates

### DIFF
--- a/app/app_rsa.c
+++ b/app/app_rsa.c
@@ -17,6 +17,8 @@
 #include <openssl/param_build.h>
 #include "safe_lib.h"
 
+#define RSA_BUF_MAX 8192
+
 int rsa_current_tg = 0;
 BIGNUM *group_n = NULL;
 EVP_PKEY *group_pkey = NULL;
@@ -363,6 +365,117 @@ err:
 
     return rv;
 }
+#if 0 /* Disabled for now */
+int app_rsa_decprim_handler(ACVP_TEST_CASE *test_case) {
+ BIGNUM *e = NULL, *n = NULL, *d = NULL;
+    BIGNUM *p = NULL, *q = NULL, *dmp1 = NULL, *dmq1 = NULL, *iqmp = NULL;
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *pkey_ctx = NULL, *dec_ctx = NULL;
+    OSSL_PARAM_BLD *pbld = NULL;
+    OSSL_PARAM *params = NULL;
+    ACVP_RSA_PRIM_TC *tc;
+    int rv = 1;
+
+    tc = test_case->tc.rsa_prim;
+
+    pbld = OSSL_PARAM_BLD_new();
+    if (!pbld) {
+        printf("Error creating param_bld in RSA decprim\n");
+        goto err;
+    }
+
+    /* Handle common key components, then ones specific to CRT or standard key formats */
+    if (!tc->p || !tc->q || !tc->e || !tc->n || !tc->d) {
+        printf("Missing TC key components for RSA decprim\n");
+        goto err;
+    }
+
+    p = BN_bin2bn(tc->p, tc->p_len, NULL);
+    q = BN_bin2bn(tc->q, tc->q_len, NULL);
+    e = BN_bin2bn(tc->e, tc->e_len, NULL);
+    n = BN_bin2bn(tc->n, tc->n_len, NULL);
+    d = BN_bin2bn(tc->d, tc->d_len, NULL);
+    if (!p || !q || !e || !n || !d) {
+        printf("Failed to convert key components to bignum in RSA decprim\n");
+        goto err;
+    }
+    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_N, n);
+    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_E, e);
+    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_FACTOR1, p);
+    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_FACTOR2, q);
+    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_D, d);
+
+    if (tc->key_format == ACVP_RSA_KEY_FORMAT_CRT) {
+        if (!tc->dmp1 || !tc->dmq1 || !tc->iqmp) {
+            printf("Missing TC CRT key components for RSA decprim\n");
+            goto err;
+        }
+        dmp1 = BN_bin2bn(tc->dmp1, tc->dmp1_len, NULL);
+        dmq1 = BN_bin2bn(tc->dmq1, tc->dmq1_len, NULL);
+        iqmp = BN_bin2bn(tc->iqmp, tc->iqmp_len, NULL);
+        if (!dmp1 || !dmq1 || !iqmp) {
+            printf("Failed to convert CRT key components to bignum in RSA decprim\n");
+            goto err;
+        }
+        OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_EXPONENT1, dmp1);
+        OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_EXPONENT2, dmq1);
+        OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, iqmp);
+    }
+
+    params = OSSL_PARAM_BLD_to_param(pbld);
+    if (!params) {
+        printf("Error building params in RSA decprim\n");
+        goto err;
+    }
+
+    pkey_ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
+    if (EVP_PKEY_fromdata_init(pkey_ctx) != 1) {
+        printf("Error initializing pkey in RSA decprim ctx\n");
+        goto err;
+    }
+
+    if (EVP_PKEY_fromdata(pkey_ctx, &pkey, EVP_PKEY_KEYPAIR, params) != 1) {
+        printf("Error generating pkey in RSA decprim context\n");
+        goto err;
+    }
+
+    dec_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);
+    if (!dec_ctx) {
+        printf("Error creating decrypt ctx in RSA decprim\n");
+        goto err;
+    }
+
+    if (EVP_PKEY_decrypt_init(dec_ctx) != 1) {
+        printf("Error initializing decrypt ctx in RSA decprim\n");
+        goto err;
+    }
+
+    tc->pt_len = RSA_BUF_MAX;
+    if (EVP_PKEY_decrypt(dec_ctx, tc->pt, (size_t *)&tc->pt_len, tc->cipher, tc->cipher_len) == 1) {
+        tc->disposition = 1;
+    } else {
+        tc->disposition = 0;
+    }
+
+    rv = 0;
+err:
+    if (e) BN_free(e);
+    if (n) BN_free(n);
+    if (d) BN_free(d);
+    if (p) BN_free(p);
+    if (q) BN_free(q);
+    if (dmp1) BN_free(dmp1);
+    if (dmq1) BN_free(dmq1);
+    if (iqmp) BN_free(iqmp);
+    if (pbld) OSSL_PARAM_BLD_free(pbld);
+    if (params) OSSL_PARAM_free(params);
+    if (pkey_ctx) EVP_PKEY_CTX_free(pkey_ctx);
+    if (dec_ctx) EVP_PKEY_CTX_free(dec_ctx);
+    if (pkey) EVP_PKEY_free(pkey);
+    return rv;
+}
+
+#else
 
 int app_rsa_decprim_handler(ACVP_TEST_CASE *test_case) {
     if (!test_case) {
@@ -370,6 +483,8 @@ int app_rsa_decprim_handler(ACVP_TEST_CASE *test_case) {
     }
     return 1;
 }
+
+#endif
 
 int app_rsa_sigprim_handler(ACVP_TEST_CASE *test_case) {
     BIGNUM *e = NULL, *n = NULL, *d = NULL;
@@ -386,59 +501,89 @@ int app_rsa_sigprim_handler(ACVP_TEST_CASE *test_case) {
     tc = test_case->tc.rsa_prim;
     tc->disposition = 1;
 
-    if (!tc->e || !tc->n) {
-        printf("Missing arguments e|n\n");
-        goto err;
-    }
-
-    e = BN_bin2bn(tc->e, tc->e_len, NULL);
-    n = BN_bin2bn(tc->n, tc->n_len, NULL);
-    if (!e || !n) {
-        printf("Failed to convert e/n to bignum in RSA sigprim\n");
-        goto err;
-    }
-
-    if (!tc->p || !tc->q || !tc->dmp1 || !tc->dmq1 || !tc->iqmp) {
-        printf("Missing TC CRT key components\n");
-        goto err;
-    }
-    p = BN_bin2bn(tc->p, tc->p_len, NULL);
-    q = BN_bin2bn(tc->q, tc->q_len, NULL);
-    dmp1 = BN_bin2bn(tc->dmp1, tc->dmp1_len, NULL);
-    dmq1 = BN_bin2bn(tc->dmq1, tc->dmq1_len, NULL);
-    iqmp = BN_bin2bn(tc->iqmp, tc->iqmp_len, NULL);
-    if (!p || !q || !dmp1 || !dmq1 || !iqmp) {
-        printf("Failed to convert CRT components to bignum in RSA sigprim\n");
-        goto err;
-    }
-    bctx = BN_CTX_new();
-    d = BN_dup(n);
-    if (!bctx || !d) {
-        printf("Error generating d in RSA sigprim\n");
-        goto err;
-    }
-    BN_sub(d, d, p);
-    BN_sub(d, d, q);
-    BN_add_word(d, 1);
-    BN_mod_inverse(d, e, d, bctx);
-
-    tc->sig_len = tc->modulo;
-
     pbld = OSSL_PARAM_BLD_new();
     if (!pbld) {
         printf("Error creating param_bld in RSA sigprim\n");
         goto err;
     }
 
+    if (!tc->e || !tc->n) {
+        printf("Missing arguments e|n\n");
+        goto err;
+    }
+    e = BN_bin2bn(tc->e, tc->e_len, NULL);
+    n = BN_bin2bn(tc->n, tc->n_len, NULL);
+    if (!e || !n) {
+        printf("Failed to convert e/n to bignum in RSA sigprim\n");
+        goto err;
+    }
     OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_N, n);
     OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_E, e);
-    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_D, d);
+
+    if (!tc->p || !tc->q) {
+        printf("Missing TC key components\n");
+        goto err;
+    }
+    p = BN_bin2bn(tc->p, tc->p_len, NULL);
+    q = BN_bin2bn(tc->q, tc->q_len, NULL);
+    if (!p || !q) {
+        printf("Failed to convert key components to bignum in RSA sigprim\n");
+        goto err;
+    }
     OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_FACTOR1, p);
     OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_FACTOR2, q);
-    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_EXPONENT1, dmp1);
-    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_EXPONENT2, dmq1);
-    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, iqmp);
+
+    switch (tc->key_format) {
+    case ACVP_RSA_KEY_FORMAT_CRT:
+        if (!tc->dmp1 || !tc->dmq1 || !tc->iqmp) {
+            printf("Missing TC CRT key components\n");
+            goto err;
+        }
+        dmp1 = BN_bin2bn(tc->dmp1, tc->dmp1_len, NULL);
+        dmq1 = BN_bin2bn(tc->dmq1, tc->dmq1_len, NULL);
+        iqmp = BN_bin2bn(tc->iqmp, tc->iqmp_len, NULL);
+        if (!dmp1 || !dmq1 || !iqmp) {
+            printf("Failed to convert CRT components to bignum in RSA sigprim\n");
+            goto err;
+        }
+        /* d should be provided as part of a CRT key, but it is not, so calculate ourselves */
+        bctx = BN_CTX_new();
+        d = BN_dup(n);
+        if (!bctx || !d) {
+            printf("Error generating d in RSA sigprim\n");
+            goto err;
+        }
+        BN_sub(d, d, p);
+        BN_sub(d, d, q);
+        BN_add_word(d, 1);
+        BN_mod_inverse(d, e, d, bctx);
+        OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_EXPONENT1, dmp1);
+        OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_EXPONENT2, dmq1);
+        OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, iqmp);
+        break;
+    case ACVP_RSA_KEY_FORMAT_STANDARD:
+        if (!tc->d) {
+            printf("Missing argument d\n");
+            goto err;
+        }
+        d = BN_bin2bn(tc->d, tc->d_len, NULL);
+        if (!d) {
+            printf("Failed to convert d to bignum in RSA sigprim\n");
+            goto err;
+        }
+        break;
+    default:
+        printf("Invalid key format in RSA sigprim\n");
+        goto err;
+    }
+
+    OSSL_PARAM_BLD_push_BN(pbld, OSSL_PKEY_PARAM_RSA_D, d);
+
     params = OSSL_PARAM_BLD_to_param(pbld);
+    if (!params) {
+        printf("Error building params in RSA sigprim\n");
+        goto err;
+    }
 
     pkey_ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
     if (!pkey_ctx) {
@@ -467,6 +612,8 @@ int app_rsa_sigprim_handler(ACVP_TEST_CASE *test_case) {
         printf("Error setting padding in RSA context: %d\n", rv);
         goto err;
     }
+
+    tc->sig_len = tc->modulo;
     if (EVP_PKEY_sign(sign_ctx, tc->signature, (size_t *)&tc->sig_len, tc->msg, tc->msg_len) != 1) {
         tc->disposition = 0;
     }

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -1430,22 +1430,11 @@ static ACVP_RESULT acvp_build_rsa_prim_register_cap(JSON_Object *cap_obj, ACVP_C
         }
     }
 
-    if (cap_entry->cipher == ACVP_RSA_SIGPRIM) {
-        json_object_set_string(cap_obj, "pubExpMode",
-                               prim_cap->pub_exp_mode == ACVP_RSA_PUB_EXP_MODE_FIXED ?
-                               ACVP_RSA_PUB_EXP_MODE_FIXED_STR : ACVP_RSA_PUB_EXP_MODE_RANDOM_STR);
-        if (prim_cap->pub_exp_mode == ACVP_RSA_PUB_EXP_MODE_FIXED) {
-            json_object_set_string(cap_obj, "fixedPubExp", (const char *)prim_cap->fixed_pub_exp);
-        }
-    } else if (!prim_cap->revision) {
-        /* Unclear why this is an array, but its how the server is doing it */
-        json_object_set_value(cap_obj, "pubExpMode", json_value_init_array());
-        arr = json_object_get_array(cap_obj, "pubExpMode");
-        json_array_append_string(arr, prim_cap->pub_exp_mode == ACVP_RSA_PUB_EXP_MODE_FIXED ?
-                               ACVP_RSA_PUB_EXP_MODE_FIXED_STR : ACVP_RSA_PUB_EXP_MODE_RANDOM_STR);
-        if (prim_cap->pub_exp_mode == ACVP_RSA_PUB_EXP_MODE_FIXED) {
-            json_object_set_string(cap_obj, "fixedPubExp", (const char *)prim_cap->fixed_pub_exp);
-        }
+    json_object_set_string(cap_obj, "pubExpMode",
+                           prim_cap->pub_exp_mode == ACVP_RSA_PUB_EXP_MODE_FIXED ?
+                           ACVP_RSA_PUB_EXP_MODE_FIXED_STR : ACVP_RSA_PUB_EXP_MODE_RANDOM_STR);
+    if (prim_cap->pub_exp_mode == ACVP_RSA_PUB_EXP_MODE_FIXED) {
+        json_object_set_string(cap_obj, "fixedPubExp", (const char *)prim_cap->fixed_pub_exp);
     }
 
     return ACVP_SUCCESS;


### PR DESCRIPTION
- Fix pubExpMode for decryption primitive; it used to be an array on the server, now its just a string
- Add a disabled decryption primitive handler; works but OpenSSL does not have a bounds check needed to pass testing
- Update both the decryption primitive and signature primitive handlers to support both CRT AND standard format RSA keys
  - The logic hasn't changed due to this, its just the way the variables are fed into the contexts