### PR TITLE
Many small fixes

### DIFF
--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -59,6 +59,7 @@
 
 #define ACVP_CAP_MAX ACVP_ALG_MAX * 2 /* Arbitrary limit to the number of capability objects that
                                          can be registered via file */
+
 /********************************************************
  * ******************************************************
  * REVISIONS
@@ -170,7 +171,6 @@
 /* KAS_ECC */
 #define ACVP_REV_KAS_ECC             ACVP_REV_STR_1_0
 #define ACVP_REV_KAS_ECC_SSC         ACVP_REV_STR_SP800_56AR3
-
 
 /* KAS_FFC */
 #define ACVP_REV_KAS_FFC             ACVP_REV_STR_1_0
@@ -768,7 +768,7 @@
 #define ACVP_CMAC_MSGLEN_MAX       524288
 #define ACVP_CMAC_MSGLEN_MIN       0
 #define ACVP_CMAC_MACLEN_MAX       128       /**< 512 bits, 128 characters */
-#define ACVP_CMAC_MACLEN_MIN       32
+#define ACVP_CMAC_MACLEN_MIN       1		/** >= 1 byte, per ACVP spec */
 #define ACVP_CMAC_KEY_MAX       64        /**< 256 bits, 64 characters */
 
 #define ACVP_KMAC_MSG_BIT_MAX 65536
@@ -898,14 +898,14 @@
 #define ACVP_MAX_WAIT_TIME      10800 /* 3 hours */
 #define ACVP_RETRY_TIME         30
 #define ACVP_RETRY_MODIFIER_MAX 10
-#define ACVP_JWT_TOKEN_MAX      2048
+#define ACVP_JWT_TOKEN_MAX      4096 /* arbitrary, but 2048 too low in some cases */
 #define ACVP_ATTR_URL_MAX       2083 /* MS IE's limit - arbitrary */
 
 #define ACVP_SESSION_PARAMS_STR_LEN_MAX 256
 #define ACVP_REQUEST_STR_LEN_MAX 128
 #define ACVP_OE_STR_MAX 256
 #define ACVP_PATH_SEGMENT_DEFAULT ""
-#define ACVP_JSON_FILENAME_MAX 128
+#define ACVP_JSON_FILENAME_MAX 1024
 
 /* 
  * This should NOT be made longer than ACVP_JSON_FILENAME_MAX - 15

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -1216,7 +1216,6 @@ static ACVP_RESULT acvp_build_rsa_keygen_register_cap(JSON_Object *cap_obj, ACVP
     result = acvp_lookup_prereqVals(cap_obj, cap_entry);
     if (result != ACVP_SUCCESS) { return result; }
 
-
     JSON_Array *alg_specs_array = NULL;
     JSON_Value *alg_specs_val = NULL;
     JSON_Object *alg_specs_obj = NULL;

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -994,7 +994,6 @@ static ACVP_RESULT acvp_add_dsa_keygen_parm(ACVP_CTX *ctx,
     case ACVP_DSA_GENG:
     default:
         return ACVP_INVALID_ARG;
-
         break;
     }
 
@@ -1380,9 +1379,13 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         break;
     case ACVP_SYM_CIPH_AADLEN:
         switch (cipher) {
+        case ACVP_AES_CCM:
+            if (value >= 0 && value <= 524288) {
+                retval = ACVP_SUCCESS;
+            }
+            break;
         case ACVP_AES_GCM:
         case ACVP_AES_GCM_SIV:
-        case ACVP_AES_CCM:
         case ACVP_AES_ECB:
         case ACVP_AES_CBC:
         case ACVP_AES_CFB1:
@@ -2036,9 +2039,13 @@ static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG 
         }
         break;
     case ACVP_CMAC_AES:
+        if (pre_req == ACVP_PREREQ_SHA ||
+            pre_req == ACVP_PREREQ_AES) {
+            return ACVP_SUCCESS;
+        }
+        break;
     case ACVP_CMAC_TDES:
-        if (pre_req == ACVP_PREREQ_AES ||
-            pre_req == ACVP_PREREQ_SHA ||
+        if (pre_req == ACVP_PREREQ_SHA ||
             pre_req == ACVP_PREREQ_TDES) {
             return ACVP_SUCCESS;
         }
@@ -7690,7 +7697,6 @@ static ACVP_RESULT acvp_add_kas_ffc_prereq_val(ACVP_CTX *ctx, ACVP_KAS_FFC_CAP_M
                                                char *value) {
     ACVP_PREREQ_LIST *prereq_entry, *prereq_entry_2;
 
-    ACVP_LOG_INFO("KAS-FFC mode %d", mode);
     prereq_entry = calloc(1, sizeof(ACVP_PREREQ_LIST));
     if (!prereq_entry) {
         return ACVP_MALLOC_FAIL;
@@ -8757,7 +8763,7 @@ ACVP_RESULT acvp_cap_kda_twostep_set_parm(ACVP_CTX *ctx, ACVP_KDA_PARM param,
         break;
     case ACVP_KDA_TWOSTEP_COUNTER_LEN:
         if (value < 1 || value > ACVP_KDF108_KEYIN_BIT_MAX) {
-            printf("Invalid value provided for KDA twostep supported length");
+            ACVP_LOG_ERR("Invalid value provided for KDA twostep supported length");
             return ACVP_INVALID_ARG;
         }
         acvp_append_sl_list(&mode_obj->counter_lens, value);

--- a/src/acvp_cmac.c
+++ b/src/acvp_cmac.c
@@ -323,6 +323,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 rv = ACVP_UNSUPPORTED_OP;
                 goto err;
             }
+            verify = 0;
         }
 
         msglen = json_object_get_number(groupobj, "msgLen") / 8;

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -302,7 +302,8 @@ static ACVP_RESULT acvp_hash_shake_mct(ACVP_CTX *ctx,
          * ***********
          */
         for (i = 0; i <= ACVP_HASH_MCT_INNER; i++) {
-            uint16_t rightmost_out_bits = 0;
+            uint8_t   rob[2] = {0};
+            uint16_t *rightmost_out_bits = (uint16_t*) &rob;
 
             if (i != 0) {
                 /*
@@ -341,13 +342,15 @@ static ACVP_RESULT acvp_hash_shake_mct(ACVP_CTX *ctx,
 
             /* Get the right-most 16bits and convert to an integer */
 #if ACVP_HOST_LITTLE_ENDIAN || defined(__WIN32) || defined(__APPLE__)
-            rightmost_out_bits = SWAP_16(*(uint16_t *)(stc->md + stc->md_len - 2));
+            rob[0] = stc->md[stc->md_len-1];
+            rob[1] = stc->md[stc->md_len-2];
 #else
-            rightmost_out_bits = *(uint16_t *)(stc->md + stc->md_len - 2);
+            rob[0] = stc->md[stc->md_len-2];
+            rob[1] = stc->md[stc->md_len-1];
 #endif
 
             /* Calculate the next expected outputLen */
-            stc->xof_len = min_xof_bytes + (rightmost_out_bits % range);
+            stc->xof_len = min_xof_bytes + ((*rightmost_out_bits) % range);
         }
 
         /*

--- a/src/acvp_kas_ffc.c
+++ b/src/acvp_kas_ffc.c
@@ -86,7 +86,7 @@ static ACVP_RESULT acvp_kas_ffc_output_ssc_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_KAS_FFC_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->piut, stc->piutlen, tmp, ACVP_KAS_FFC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (Z)");
+            ACVP_LOG_ERR("hex conversion failure (IUT Pub)");
             goto end;
         }
         json_object_set_string(tc_rsp, "ephemeralPublicIut", tmp);
@@ -825,7 +825,7 @@ static ACVP_RESULT acvp_kas_ffc_ssc(ACVP_CTX *ctx,
         for (j = 0; j < t_cnt; j++) {
             const char *eps = NULL, *z = NULL, *epri = NULL, *epui = NULL;
 
-            ACVP_LOG_VERBOSE("Found new KAS-FFC Component test vector...");
+            ACVP_LOG_VERBOSE("Found new KAS-FFC SSC test vector...");
             testval = json_array_get_value(tests, j);
             testobj = json_value_get_object(testval);
             tc_id = json_object_get_number(testobj, "tcId");
@@ -836,8 +836,7 @@ static ACVP_RESULT acvp_kas_ffc_ssc(ACVP_CTX *ctx,
                 rv = ACVP_MISSING_ARG;
                 goto err;
             }
-            if (strnlen_s(eps, ACVP_KAS_FFC_STR_MAX + 1)
-                > ACVP_KAS_FFC_STR_MAX) {
+            if (strnlen_s(eps, ACVP_KAS_FFC_STR_MAX + 1) > ACVP_KAS_FFC_STR_MAX) {
                 ACVP_LOG_ERR("ephemeralPublicServer too long, max allowed=(%d)",
                              ACVP_KAS_FFC_STR_MAX);
                 rv = ACVP_INVALID_ARG;

--- a/src/acvp_kdf108.c
+++ b/src/acvp_kdf108.c
@@ -138,10 +138,10 @@ static ACVP_RESULT acvp_kdf108_init_tc(ACVP_KDF108_TC *stc,
         stc->fixed_data = calloc(ACVP_KDF108_FIXED_DATA_BYTE_MAX, sizeof(unsigned char));
         if (!stc->fixed_data) { return ACVP_MALLOC_FAIL; }
 
-        stc->iv = calloc(iv_len, sizeof(unsigned char));
-        if (!stc->iv) { return ACVP_MALLOC_FAIL; }
+        if (iv_len > 0 && iv != NULL) {
+		    stc->iv = calloc(iv_len, sizeof(unsigned char));
+		    if (!stc->iv) { return ACVP_MALLOC_FAIL; }
 
-        if (iv != NULL) {
             // Convert iv from hex string to binary
             rv = acvp_hexstr_to_bin(iv, stc->iv, iv_len, NULL);
             if (rv != ACVP_SUCCESS) return rv;

--- a/src/acvp_rsa_sig.c
+++ b/src/acvp_rsa_sig.c
@@ -473,6 +473,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
                     }
                     memcpy_s(signature + padding, mod/4, tmp_signature, json_siglen);
                 } else {
+                    padding = 0;
                     memcpy_s(signature, mod/4, tmp_signature, json_siglen);
                 }
 

--- a/src/acvp_safe_primes.c
+++ b/src/acvp_safe_primes.c
@@ -259,7 +259,7 @@ ACVP_RESULT acvp_safe_primes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             rv = ACVP_MISSING_ARG;
             goto err;
         }
-        json_object_set_number(r_gobj, "tg_id", tg_id);
+        json_object_set_number(r_gobj, "tgId", tg_id);
         json_object_set_value(r_gobj, "tests", json_value_init_array());
         r_tarr = json_object_get_array(r_gobj, "tests");
 

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -923,7 +923,7 @@ ACVP_RESULT acvp_transport_get(ACVP_CTX *ctx,
             len += snprintf(full_url+len, rem_space, "%s", escaped_value);
             rem_space = max_url - len;
 
-            curl_free(escaped_value);
+            curl_free(escaped_value); escaped_value = NULL;
             if (param->next == NULL || rem_space <= 0) break;
             param = param->next;
         }

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -352,15 +352,15 @@ const char *acvp_lookup_rsa_mask_func_str(ACVP_RSA_MASK_FUNCTION func) {
 const char *acvp_lookup_rsa_randpq_name(int value) {
     switch (value) {
     case ACVP_RSA_KEYGEN_B32:
-        return ACVP_RSA_RANDPQ_STR_B32;
+        return ACVP_RSA_RANDPQ_STR_B32; // "provRP"
     case ACVP_RSA_KEYGEN_B33:
-        return ACVP_RSA_RANDPQ_STR_B33;
+        return ACVP_RSA_RANDPQ_STR_B33; // "probRP"
     case ACVP_RSA_KEYGEN_B34:
-        return ACVP_RSA_RANDPQ_STR_B34;
+        return ACVP_RSA_RANDPQ_STR_B34; // "provPC"
     case ACVP_RSA_KEYGEN_B35:
-        return ACVP_RSA_RANDPQ_STR_B35;
+        return ACVP_RSA_RANDPQ_STR_B35; // "bothPC"
     case ACVP_RSA_KEYGEN_B36:
-        return ACVP_RSA_RANDPQ_STR_B36;
+        return ACVP_RSA_RANDPQ_STR_B36; // "probPC"
     case ACVP_RSA_KEYGEN_PROVABLE:
         return ACVP_RSA_RANDPQ_STR_PROVABLE;
     case ACVP_RSA_KEYGEN_PROBABLE:


### PR DESCRIPTION
Many fixes/cleanup to comments, extra CRLFs, and some to data output

I have addressed several data validation issues where libacvp differed from ACVP protocol min/max values.  I've altered max values for some buffers/arrays (e.g. filename max length to better accommodate windows long filenames) and increased some fields marked "arbitrary" where they length proved insufficient in some cases.

I have been compiling libacvp on a wide variety of systems, include small/embedded/IOT, and along the way I've made minor fixes to address compiler warnings and hardware/compiler "quirks".  One operational environment failed Hash/Shake MCT testing, and it is due to a compiler's misinterpretation of the Rightmost Outer Bits (ROB) calculation.  I've change it to be explicit and avoid "pointer math".

I'm happy to change/amend as needed.  I have more "feature" oriented changes in future pull requests.