### PR TITLE
Functional Enhancements (v2)

### DIFF
--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -1046,7 +1046,6 @@ typedef enum acvp_sym_cipher_parameter {
     ACVP_SYM_CIPH_PARM_DULEN_MATCHES_PAYLOADLEN
 } ACVP_SYM_CIPH_PARM;
 
-
 /** @enum ACVP_SYM_CIPH_DOMAIN_PARM */
 typedef enum acvp_sym_cipher_domain_parameter {
     ACVP_SYM_CIPH_DOMAIN_IVLEN = 1,
@@ -1396,7 +1395,6 @@ typedef struct acvp_kdf135_x963_tc_t {
     unsigned char *shared_info;
     unsigned char *key_data;
 } ACVP_KDF135_X963_TC;
-
 
 /**
  * @struct ACVP_KDF108_TC
@@ -4578,6 +4576,19 @@ ACVP_RESULT acvp_upload_vectors_from_file(ACVP_CTX *ctx, const char *rsp_filenam
  * @return ACVP_RESULT
  */
 ACVP_RESULT acvp_run_vectors_from_file(ACVP_CTX *ctx, const char *req_filename, const char *rsp_filename);
+
+/**
+ * @brief Runs a set of tests from vector sets that were saved to a file and saves the results in a
+ *        different file.  This function attempts to be a "universal" parser for vector request files
+ *        from all sources (at least libacvp and acvpproxy).
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param req_filename Name of the file that contains the unprocessed vector sets
+ * @param rsp_filename Name of the file to save vector set test results to
+ *
+ * @return ACVP_RESULT
+ */
+ACVP_RESULT acvp_run_vectors_from_file_offline(ACVP_CTX *ctx, const char *req_filename, const char *rsp_filename);
 
 /**
  * @brief performs an HTTP PUT on a given libacvp JSON file to the ACV server

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -57,7 +57,7 @@
 
 #define ACVP_ALG_MAX ACVP_CIPHER_END - 1  /* Used by alg_tbl[] */
 
-#define ACVP_CAP_MAX ACVP_ALG_MAX * 2 /* Arbitrary limit to the number of capability objects that
+#define ACVP_CAP_MAX ACVP_ALG_MAX * 3 /* Arbitrary limit to the number of capability objects that
                                          can be registered via file */
 
 /********************************************************
@@ -1881,6 +1881,8 @@ ACVP_RESULT acvp_transport_put(ACVP_CTX *ctx, const char *endpoint, const char *
 
 ACVP_RESULT acvp_transport_delete(ACVP_CTX *ctx, const char *endpoint);
 
+ACVP_RESULT acvp_retrieve_health_status(ACVP_CTX *ctx);
+
 ACVP_RESULT acvp_retrieve_vector_set(ACVP_CTX *ctx, char *vsid_url);
 
 ACVP_RESULT acvp_retrieve_vector_set_result(ACVP_CTX *ctx, const char *vsid_url);
@@ -2100,8 +2102,14 @@ ACVP_KDF108_MAC_MODE_VAL read_mac_mode(const char *str);
 ACVP_KDF108_FIXED_DATA_ORDER_VAL read_ctr_location(const char *str);
 ACVP_KDF108_MODE read_mode(const char *str);
 
+// Default behavior, always prepend "," to data to form a proper array entry
 ACVP_RESULT acvp_json_serialize_to_file_pretty_a(const JSON_Value *value, const char *filename);
-ACVP_RESULT acvp_json_serialize_to_file_pretty_w(const JSON_Value *value, const char *filename);
+// Specialized behavior; do not prefix "," to data b/c it is not going into an array
+ACVP_RESULT acvp_json_serialize_to_file_pretty_a_raw(const JSON_Value *value, const char *filename);
 
+// Default behavior, always prefix a "[" to mark the start of a new file
+ACVP_RESULT acvp_json_serialize_to_file_pretty_w(const JSON_Value *value, const char *filename);
+// Specialized behavior; do not prefix "[" but output this data without modification
+ACVP_RESULT acvp_json_serialize_to_file_pretty_w_raw(const JSON_Value *value, const char *filename);
 
 #endif

--- a/safe_c_stub/include/safe_mem_lib.h
+++ b/safe_c_stub/include/safe_mem_lib.h
@@ -37,6 +37,11 @@
 #include <stdint.h>
 #include "safe_lib_errno.h"
 
+/* Some environments (AIX) complain about this not being defined */
+#ifndef SIZE_MAX
+#   define SIZE_MAX (18446744073709551615UL)
+#endif
+
 /* Defining the RSIZE_MAX macro */
 #ifndef RSIZE_MAX
 #define RSIZE_MAX         SIZE_MAX/2

--- a/safe_c_stub/src/safe_str_stub.c
+++ b/safe_c_stub/src/safe_str_stub.c
@@ -40,7 +40,6 @@
 
 #define SAFEC_STUB_UNUSED(x) (void)(x)
 
-
 /*
  * strcmp_s()
  *

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1097,8 +1097,9 @@ ACVP_RESULT acvp_run_vectors_from_file(ACVP_CTX *ctx, const char *req_filename, 
     /* If no vsIds found, try to get it from the filename */
     if (vs_cnt == 0) {
         int vsid;
+        int len = strnlen_s(req_filename, ACVP_JSON_FILENAME_MAX);
         char* start = strstr(req_filename, "vs");
-        if (!start || (0 == (vsid = atoi(start+2)))) {
+        if (!start || (start >= len+2) || (0 == (vsid = atoi(start+2)))) {
             ACVP_LOG_WARN("No vsId in file or filename; cannot proceed");
             goto end;
         }

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -1850,13 +1850,52 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
             break;
         }
         break;
-    case ACVP_CIPHER_START:
     case ACVP_AES_ECB:
     case ACVP_AES_CBC:
-    case ACVP_AES_CFB1:
-    case ACVP_AES_CFB8:
     case ACVP_AES_CFB128:
     case ACVP_AES_OFB:
+        switch (parm) {
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
+            if (min >= 0 && max <= 65536) {
+                retval = ACVP_SUCCESS;
+            }
+            break;
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        default:
+            break;
+        }
+        break;
+    case ACVP_AES_CFB1:
+        switch (parm) {
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
+            if (min >= 0 && max <= 128) {
+                retval = ACVP_SUCCESS;
+            }
+            break;
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        default:
+            break;
+        }
+        break;
+    case ACVP_AES_CFB8:
+        switch (parm) {
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
+            if (min >= 0 && max <= 256) {
+                retval = ACVP_SUCCESS;
+            }
+            break;
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        default:
+            break;
+        }
+        break;
+    case ACVP_CIPHER_START:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:

--- a/src/acvp_ecdsa.c
+++ b/src/acvp_ecdsa.c
@@ -208,7 +208,6 @@ ACVP_RESULT acvp_det_ecdsa_siggen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     return acvp_ecdsa_kat_handler_internal(ctx, obj, ACVP_DET_ECDSA_SIGGEN);
 }
 
-
 ACVP_RESULT acvp_ecdsa_sigver_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     return acvp_ecdsa_kat_handler_internal(ctx, obj, ACVP_ECDSA_SIGVER);
 }

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -715,6 +715,28 @@ ACVP_RESULT acvp_transport_post(ACVP_CTX *ctx,
 #endif
 }
 
+/*
+ * This is the top level function used within libacvp to retrieve
+ * the health status from the ACVP server.
+ */
+ACVP_RESULT acvp_retrieve_health_status(ACVP_CTX *ctx) {
+#ifdef ACVP_OFFLINE 
+    ACVP_LOG_ERR("Curl not linked, exiting function"); 
+    return ACVP_TRANSPORT_FAIL;
+#else
+    ACVP_RESULT rv = 0;
+    char url[ACVP_ATTR_URL_MAX + 1] = {0};
+
+    rv = sanity_check_ctx(ctx);
+    if (ACVP_SUCCESS != rv) return rv;
+
+    snprintf(url, ACVP_ATTR_URL_MAX,
+            "https://%s/health",
+            ctx->server_name);
+
+    return acvp_network_action(ctx, ACVP_NET_GET, url, NULL, 0);
+#endif
+}
 
 /*
  * This is the top level function used within libacvp to retrieve

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -1563,11 +1563,9 @@ ACVP_RESULT acvp_json_serialize_to_file_pretty_a_work(const JSON_Value *value, c
             fclose(fp);
             return ACVP_JSON_ERR;
         }
-        if (!first) {  // Do not add "," before this data
-        if (fputs(", ", fp) == EOF) {
+        if (!first && (fputs(", ", fp) == EOF)) {  // If first, do *not* add "," before this data
             return_code = ACVP_JSON_ERR;
             goto end;
-        }
         }
         if (fputs(serialized_string, fp) == EOF) {
             return_code = ACVP_JSON_ERR;

--- a/src/acvp_util.c
+++ b/src/acvp_util.c
@@ -1539,7 +1539,7 @@ int acvp_is_domain_already_set(ACVP_JSON_DOMAIN_OBJ *domain) {
     return domain->min + domain->max + domain->increment;
 }
 
-ACVP_RESULT acvp_json_serialize_to_file_pretty_a(const JSON_Value *value, const char *filename) {
+ACVP_RESULT acvp_json_serialize_to_file_pretty_a_work(const JSON_Value *value, const char *filename, int first) {
     ACVP_RESULT return_code = ACVP_SUCCESS;
     FILE *fp = NULL;
     char *serialized_string = NULL; 
@@ -1563,9 +1563,11 @@ ACVP_RESULT acvp_json_serialize_to_file_pretty_a(const JSON_Value *value, const 
             fclose(fp);
             return ACVP_JSON_ERR;
         }
+        if (!first) {  // Do not add "," before this data
         if (fputs(", ", fp) == EOF) {
             return_code = ACVP_JSON_ERR;
             goto end;
+        }
         }
         if (fputs(serialized_string, fp) == EOF) {
             return_code = ACVP_JSON_ERR;
@@ -1579,7 +1581,18 @@ end:
     return return_code;
 }
 
-ACVP_RESULT acvp_json_serialize_to_file_pretty_w(const JSON_Value *value, const char *filename) {
+ACVP_RESULT acvp_json_serialize_to_file_pretty_a(const JSON_Value *value, const char *filename) {
+    return acvp_json_serialize_to_file_pretty_a_work(value, filename, 0);
+}
+
+ACVP_RESULT acvp_json_serialize_to_file_pretty_a_raw(const JSON_Value *value, const char *filename) {
+    return acvp_json_serialize_to_file_pretty_a_work(value, filename, 1);
+}
+
+static ACVP_RESULT acvp_json_serialize_to_file_pretty_w_work(
+        const JSON_Value *value, 
+        const char *filename, 
+        int leading_bracket) { 
     ACVP_RESULT return_code = ACVP_SUCCESS;
     FILE *fp = NULL;
     char *serialized_string = NULL;
@@ -1600,9 +1613,11 @@ ACVP_RESULT acvp_json_serialize_to_file_pretty_w(const JSON_Value *value, const 
         json_free_serialized_string(serialized_string);
         return ACVP_JSON_ERR;
     }
+    if (leading_bracket) {
     if (fputs("[ ", fp) == EOF) {
         return_code = ACVP_JSON_ERR;
         goto end;
+    }
     }
     if (fputs(serialized_string, fp) == EOF) {
         json_free_serialized_string(serialized_string);
@@ -1614,6 +1629,14 @@ end:
     }
     json_free_serialized_string(serialized_string);
     return return_code;
+}
+
+ACVP_RESULT acvp_json_serialize_to_file_pretty_w(const JSON_Value *value, const char *filename) {
+    return acvp_json_serialize_to_file_pretty_w_work(value, filename, 1);
+}
+
+ACVP_RESULT acvp_json_serialize_to_file_pretty_w_raw(const JSON_Value *value, const char *filename) {
+    return acvp_json_serialize_to_file_pretty_w_work(value, filename, 0);
 }
 
 void acvp_sleep(int seconds) {

--- a/src/parson.c
+++ b/src/parson.c
@@ -65,8 +65,12 @@
 #define IS_NUMBER_INVALID(x) (((x) * 0.0) != 0.0)
 #endif
 
-static JSON_Malloc_Function parson_malloc = malloc;
-static JSON_Free_Function parson_free = free;
+/* Wrappers for stdlib functions; quiets warning on MSVC compiler */
+static void *stdlib_malloc(size_t sz) { return malloc(sz); }
+static void stdlib_free(void* ptr) { if (ptr) free(ptr); }
+
+static JSON_Malloc_Function parson_malloc = stdlib_malloc;
+static JSON_Free_Function parson_free = stdlib_free;
 
 static int parson_escape_slashes = 1;
 
@@ -282,7 +286,7 @@ static int is_valid_utf8(const char *string, size_t string_len) {
 }
 
 static int is_decimal(const char *string, size_t length) {
-    char xX[3] = "xX\0";
+    char xX[3] = { 'x', 'X', 0x00 };
 
     if (length > 1 && string[0] == '0' && string[1] != '.') {
         return 0;


### PR DESCRIPTION
Enhance vector processing -- 
1) Modify main vector processor to extract vsId from filename if not found in file.  Proxy-style files do not have vsId in the file, and libacvp requires vsId for processing.  If a vsId does not exist in the file, the filename will be searched for "vs" followed by digits, which will be interpreted as a vsId.  This was an early patch for proxy-style files that works well enough.

2) New function to process vectors that specifically supports acvpproxy-style vector files.  It is a 1st attempt at a "universal" vector file processor.  The function is named "offline" because it ignores the header (jwt, vsid, etc) and gets right to processing whatever it finds. It will process an array of algorithms (libacvp-style) or a single algorithm (acvpproxy style).  It is resilient to the occasional degenerate case of a naked (non-arrayed) json object. It is called "offline" since we're not tracking any of the session data.  The function is probably not usable (and indeed isn't required) in the case of a single-command full-round-trip testing session. That said, I have not blocked it off with ACVP_OFFLINE.  

Add domain-type for PT length in symmetric ciphers -- Protocol allows domains, libacvp allowed only value arrays.

Add ACVP "health check" function -- An easy way to verify stable communications to an ACVP server without invoking any vector processing

Minor other tweaks and typos
