### PR TITLE
Addition for AES-FPE and Update to DSA

### DIFF
--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -168,6 +168,8 @@ typedef enum acvp_cipher {
     ACVP_AES_KWP,
     ACVP_AES_GMAC,
     ACVP_AES_XPN,
+    ACVP_AES_FF1,
+    ACVP_AES_FF3,
     ACVP_TDES_ECB,
     ACVP_TDES_CBC,
     ACVP_TDES_CBCI,
@@ -297,7 +299,9 @@ typedef enum acvp_alg_type_aes {
     ACVP_SUB_AES_XPN,
     ACVP_SUB_AES_KW,
     ACVP_SUB_AES_KWP,
-    ACVP_SUB_AES_GMAC
+    ACVP_SUB_AES_GMAC,
+    ACVP_SUB_AES_FF1,
+    ACVP_SUB_AES_FF3
 } ACVP_SUB_AES;
 
 /** @enum ACVP_SUB_TDES */
@@ -1061,7 +1065,9 @@ typedef enum acvp_sym_cipher_parameter {
     ACVP_SYM_CIPH_PARM_IVGEN_SRC,
     ACVP_SYM_CIPH_PARM_SALT_SRC,
     ACVP_SYM_CIPH_PARM_CONFORMANCE,
-    ACVP_SYM_CIPH_PARM_DULEN_MATCHES_PAYLOADLEN
+    ACVP_SYM_CIPH_PARM_DULEN_MATCHES_PAYLOADLEN,
+    ACVP_SYM_CIPH_PARM_ALPHABET,
+    ACVP_SYM_CIPH_PARM_RADIX
 } ACVP_SYM_CIPH_PARM;
 
 /** @enum ACVP_SYM_CIPH_DOMAIN_PARM */
@@ -1069,7 +1075,8 @@ typedef enum acvp_sym_cipher_domain_parameter {
     ACVP_SYM_CIPH_DOMAIN_IVLEN = 1,
     ACVP_SYM_CIPH_DOMAIN_PTLEN,
     ACVP_SYM_CIPH_DOMAIN_AADLEN,
-    ACVP_SYM_CIPH_DOMAIN_DULEN
+    ACVP_SYM_CIPH_DOMAIN_DULEN,
+    ACVP_SYM_CIPH_DOMAIN_TWEAKLEN
 } ACVP_SYM_CIPH_DOMAIN_PARM;
 
 /** @enum ACVP_SYM_CIPH_TWEAK_MODE */
@@ -1250,6 +1257,10 @@ typedef struct acvp_sym_cipher_tc_t {
     unsigned int data_unit_len; /**< for AES-XTS rev 2.0, the amount of data that can be
                                  * processed at once may be lower than the total payload
                                  * size. By default it will = payloadLen. */
+    unsigned int radix;
+    unsigned int fpe_len;
+    char* fpe_in;
+    char* fpe_out;
 } ACVP_SYM_CIPHER_TC;
 
 /**
@@ -2855,6 +2866,31 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
                                          ACVP_CIPHER cipher,
                                          ACVP_SYM_CIPH_PARM parm,
                                          int length);
+
+/**
+ * @brief acvp_cap_sym_cipher_set_parm_string() allows an application to specify character-based
+ *        operational parameters to be used for a given cipher during a test session with the ACVP
+ *        server.
+ *
+ *        This function should be called to enable crypto capabilities for symmetric ciphers that
+ *        will be tested by the ACVP server. This includes AES and 3DES.  
+ *
+ *        This function may be called multiple times to specify more than one crypto parameter
+ *        value for the cipher. The ACVP_CIPHER value passed to this function should already have
+ *        been setup by invoking acvp_enable_sym_cipher_cap() for that cipher earlier.
+ *
+ * @param ctx Pointer to ACVP_CTX that was previously created by calling acvp_create_test_session.
+ * @param cipher ACVP_CIPHER enum value identifying the crypto capability.
+ * @param parm ACVP_SYM_CIPH_PARM enum value identifying the algorithm parameter that is being
+ *        specified. An example would be the supported plaintext length of the algorithm.
+ * @param value A null-terminated character string containing the data for the parameter
+ *
+ * @return ACVP_RESULT
+ */
+ACVP_RESULT acvp_cap_sym_cipher_set_parm_string(ACVP_CTX *ctx,
+                                                ACVP_CIPHER cipher,
+                                                ACVP_SYM_CIPH_PARM parm,
+                                                char* value);
 
 /**
  * @brief acvp_cap_sym_cipher_set_domain allow an application to specify length-based operational

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -240,6 +240,8 @@
 #define ACVP_ALG_AES_KWP             "ACVP-AES-KWP"
 #define ACVP_ALG_AES_GMAC            "ACVP-AES-GMAC"
 #define ACVP_ALG_AES_XPN             "ACVP-AES-XPN"
+#define ACVP_ALG_AES_FF1             "ACVP-AES-FF1"
+#define ACVP_ALG_AES_FF3             "ACVP-AES-FF3-1"
 #define ACVP_ALG_TDES_OFB            "ACVP-TDES-OFB"
 #define ACVP_ALG_TDES_OFBI           "ACVP-TDES-OFBI"
 #define ACVP_ALG_TDES_CFB1           "ACVP-TDES-CFB1"
@@ -514,6 +516,15 @@
 #define ACVP_AES_RFC3686_IVGEN_STR "ivGenMode"
 #define ACVP_RFC3686_STR "RFC3686"
 
+#define ACVP_AES_FPE_RADIX_MIN 2
+#define ACVP_AES_FPE_RADIX_MAX 64
+#define ACVP_AES_FPE_PT_BIT_MIN 16                              /**< 16 bits */
+#define ACVP_AES_FPE_PT_MIN (ACVP_AES_FPE_PT_BIT_MIN >> 2)      /**< 4 characters */
+#define ACVP_AES_FPE_PT_BYTE_MIN (ACVP_AES_FPE_PT_BIT_MIN >> 3) /**< 2 bytes */
+#define ACVP_AES_FPE_PT_BYTE_MAX 65535  /**< Arbitrary, 2^32 for FF1, based on radix for FF3 */
+#define ACVP_AES_FPE_TWEAK_MIN 0
+#define ACVP_AES_FPE_TWEAK_MAX 128
+#define ACVP_AES_FPE_TWEAK_INC 8
 
 /**
  * Accepted length ranges for DRBG.
@@ -1185,6 +1196,8 @@ typedef struct acvp_sym_cipher_capability {
     ACVP_JSON_DOMAIN_OBJ du_len;
 
     int kw_mode;
+    unsigned int radix;
+    char* alphabet;
 } ACVP_SYM_CIPHER_CAP;
 
 typedef struct acvp_hash_capability {

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -99,6 +99,8 @@
 #define ACVP_REV_AES_KWP             ACVP_REV_STR_1_0
 #define ACVP_REV_AES_GMAC            ACVP_REV_STR_1_0
 #define ACVP_REV_AES_XPN             ACVP_REV_STR_1_0
+#define ACVP_REV_AES_FF1             ACVP_REV_STR_1_0
+#define ACVP_REV_AES_FF3             ACVP_REV_STR_1_0
 
 /* TDES */
 #define ACVP_REV_TDES_OFB            ACVP_REV_STR_1_0

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -678,6 +678,7 @@ ACVP_RESULT acvp_free_test_session(ACVP_CTX *ctx) {
                 acvp_cap_free_sl(cap_entry->cap.sym_cap->aadlen);
                 acvp_cap_free_sl(cap_entry->cap.sym_cap->taglen);
                 acvp_cap_free_sl(cap_entry->cap.sym_cap->tweak);
+                free(cap_entry->cap.sym_cap->alphabet);
                 free(cap_entry->cap.sym_cap);
                 break;
             case ACVP_HASH_TYPE:

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -81,6 +81,8 @@ ACVP_ALG_HANDLER alg_tbl[ACVP_ALG_MAX] = {
     { ACVP_AES_KWP,           &acvp_aes_kat_handler,              ACVP_ALG_AES_KWP,           NULL, ACVP_REV_AES_KWP, {ACVP_SUB_AES_KWP}},
     { ACVP_AES_GMAC,          &acvp_aes_kat_handler,              ACVP_ALG_AES_GMAC,          NULL, ACVP_REV_AES_GMAC, {ACVP_SUB_AES_GMAC}},
     { ACVP_AES_XPN,           &acvp_aes_kat_handler,              ACVP_ALG_AES_XPN ,          NULL, ACVP_REV_AES_XPN, {ACVP_SUB_AES_XPN}},
+    { ACVP_AES_FF1,           &acvp_aes_kat_handler,             ACVP_ALG_AES_FF1,           NULL, ACVP_REV_AES_FF1, {ACVP_SUB_AES_FF1}},
+    { ACVP_AES_FF3,           &acvp_aes_kat_handler,             ACVP_ALG_AES_FF3,           NULL, ACVP_REV_AES_FF3, {ACVP_SUB_AES_FF3}},
     { ACVP_TDES_ECB,          &acvp_des_kat_handler,              ACVP_ALG_TDES_ECB,          NULL, ACVP_REV_TDES_ECB, {ACVP_SUB_TDES_ECB}},
     { ACVP_TDES_CBC,          &acvp_des_kat_handler,              ACVP_ALG_TDES_CBC,          NULL, ACVP_REV_TDES_CBC, {ACVP_SUB_TDES_CBC}},
     { ACVP_TDES_CBCI,         &acvp_des_kat_handler,              ACVP_ALG_TDES_CBCI,         NULL, ACVP_REV_TDES_CBCI, {ACVP_SUB_TDES_CBCI}},

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -1044,6 +1044,18 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
     ACVP_RESULT retval = ACVP_INVALID_ARG;
 
     switch (parm) {
+    case ACVP_SYM_CIPH_PARM_RADIX:
+        switch (cipher) {
+        case ACVP_AES_FF1:
+        case ACVP_AES_FF3:
+            if (value >= ACVP_AES_FPE_RADIX_MIN && value <= ACVP_AES_FPE_RADIX_MAX) {
+                retval = ACVP_SUCCESS;
+            }
+            break;
+        default:
+            break;
+        }
+        break;
     case ACVP_SYM_CIPH_KEYLEN:
         switch (cipher) {
         case ACVP_AES_GCM:
@@ -1064,6 +1076,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_AES_KWP:
         case ACVP_AES_GMAC:
         case ACVP_AES_XPN:
+        case ACVP_AES_FF1:
+        case ACVP_AES_FF3:
             if (value == 128 || value == 192 || value == 256) {
                 retval = ACVP_SUCCESS;
             }
@@ -1199,6 +1213,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_AES_XTS:
         case ACVP_AES_KW:
         case ACVP_AES_KWP:
+        case ACVP_AES_FF1:
+        case ACVP_AES_FF3:
         case ACVP_TDES_ECB:
         case ACVP_TDES_CBC:
         case ACVP_TDES_CBCI:
@@ -1330,6 +1346,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_AES_KW:
         case ACVP_AES_KWP:
         case ACVP_AES_XPN:
+        case ACVP_AES_FF1:
+        case ACVP_AES_FF3:
         case ACVP_TDES_ECB:
         case ACVP_TDES_CBCI:
         case ACVP_TDES_OFBI:
@@ -1461,6 +1479,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_AES_XTS:
         case ACVP_AES_KW:
         case ACVP_AES_KWP:
+        case ACVP_AES_FF1:
+        case ACVP_AES_FF3:
         case ACVP_TDES_ECB:
         case ACVP_TDES_CBC:
         case ACVP_TDES_CBCI:
@@ -1564,6 +1584,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         break;
     case ACVP_SYM_CIPH_PTLEN:
         switch(cipher) {
+        case ACVP_AES_FF1:
+        case ACVP_AES_FF3:
         case ACVP_AES_GMAC:
             break;
         case ACVP_CIPHER_START:
@@ -1900,6 +1922,44 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
             break;
         }
         break;
+    case ACVP_AES_FF1:
+        switch (parm) {
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
+            if (min >= ACVP_AES_FPE_PT_BYTE_MIN && 
+                max <= ACVP_AES_FPE_PT_BYTE_MAX) {
+                retval = ACVP_SUCCESS;
+            }
+            break;
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
+            if (min >= ACVP_AES_FPE_TWEAK_MIN && 
+                max <= ACVP_AES_FPE_TWEAK_MAX &&
+                increment == ACVP_AES_FPE_TWEAK_INC) {
+                retval = ACVP_SUCCESS;
+            }
+            break;
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        default:
+            break;
+        }
+        break;
+    case ACVP_AES_FF3:
+        switch (parm) {
+        case ACVP_SYM_CIPH_DOMAIN_PTLEN:
+            if (min >= ACVP_AES_FPE_PT_BYTE_MIN && 
+                max <= ACVP_AES_FPE_PT_BYTE_MAX) {
+                retval = ACVP_SUCCESS;
+            }
+            break;
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
+        case ACVP_SYM_CIPH_DOMAIN_IVLEN:
+        case ACVP_SYM_CIPH_DOMAIN_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        default:
+            break;
+        }
+        break;
     case ACVP_TDES_CTR:
     case ACVP_TDES_KW:
         switch (parm) {
@@ -2083,6 +2143,8 @@ static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG 
     case ACVP_AES_XTS:
     case ACVP_AES_GMAC:
     case ACVP_AES_XPN:
+    case ACVP_AES_FF1:
+    case ACVP_AES_FF3:
         if (pre_req == ACVP_PREREQ_AES ||
             pre_req == ACVP_PREREQ_DRBG) {
             return ACVP_SUCCESS;
@@ -2467,6 +2529,8 @@ ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
     case ACVP_AES_XPN:
+    case ACVP_AES_FF1:
+    case ACVP_AES_FF3:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:
@@ -2649,6 +2713,20 @@ ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
         symcap->du_len.max = max;
         symcap->du_len.increment = increment;
         break;
+    case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
+        if (cipher != ACVP_AES_FF1) {
+            ACVP_LOG_ERR("Tweak Length may only be set for AES-FF1.");
+            return ACVP_INVALID_ARG;
+        }
+        rv = acvp_validate_sym_cipher_domain_value(cipher, parm, min, max, increment);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("Unable to validate given domain value (cipher=%d, param=%d)", cipher, parm);
+            return ACVP_INVALID_ARG;
+        }
+        symcap->tweak_len.min = min;
+        symcap->tweak_len.max = max;
+        symcap->tweak_len.increment = increment;
+        break;
     default:
         ACVP_LOG_ERR("Invalid parameter for symmetric cipher");
         return ACVP_INVALID_ARG;
@@ -2704,6 +2782,18 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
     case ACVP_TDES_CFBP64:
     case ACVP_TDES_CTR:
     case ACVP_TDES_KW:
+        break;
+    case ACVP_AES_FF1:
+    case ACVP_AES_FF3:
+        switch (parm) {
+        case ACVP_SYM_CIPH_KEYLEN:
+        case ACVP_SYM_CIPH_PARM_DIR:
+        case ACVP_SYM_CIPH_PARM_RADIX:
+            break;
+        default:
+            ACVP_LOG_ERR("Invalid parameter 'parm' for AES-FPE; try domain-type for all others.\n");
+            return ACVP_INVALID_ARG;
+        }
         break;
     case ACVP_CIPHER_START:
     case ACVP_HASH_SHA1:
@@ -2923,6 +3013,13 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
             ACVP_LOG_ERR("Invalid parameter 'value' for parm ACVP_SYM_CIPH_PARM_DULEN_MATCHES_PAYLOADLEN");
             return ACVP_INVALID_ARG;
         }
+    case ACVP_SYM_CIPH_PARM_RADIX:
+        if (cipher != ACVP_AES_FF1 && cipher != ACVP_AES_FF3) {
+            ACVP_LOG_ERR("ACVP_SYM_CIPH_PARM_RADIX can only be set for AES-FF1 and AES-FF3");
+            return ACVP_INVALID_ARG;
+        }
+        cap->cap.sym_cap->radix = value;
+        return ACVP_SUCCESS;
     case ACVP_SYM_CIPH_KEYLEN:
     case ACVP_SYM_CIPH_TAGLEN:
     case ACVP_SYM_CIPH_IVLEN:
@@ -2990,6 +3087,185 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
     return ACVP_SUCCESS;
 }
 
+ACVP_RESULT acvp_cap_sym_cipher_set_parm_string(ACVP_CTX *ctx,
+                                                ACVP_CIPHER cipher,
+                                                ACVP_SYM_CIPH_PARM parm,
+                                                char* value) {
+    ACVP_CAPS_LIST *cap = NULL;
+    ACVP_SYM_CIPHER_CAP *sym_cap = NULL;
+    int len = 0;
+
+    if (!ctx) {
+        return ACVP_NO_CTX;
+    }
+
+    switch (cipher) {
+    case ACVP_AES_FF1:
+    case ACVP_AES_FF3:
+        break;
+    case ACVP_CIPHER_START:
+    case ACVP_AES_GCM:
+    case ACVP_AES_GCM_SIV:
+    case ACVP_AES_CCM:
+    case ACVP_AES_ECB:
+    case ACVP_AES_CBC:
+    case ACVP_AES_CBC_CS1:
+    case ACVP_AES_CBC_CS2:
+    case ACVP_AES_CBC_CS3:
+    case ACVP_AES_CFB1:
+    case ACVP_AES_CFB8:
+    case ACVP_AES_CFB128:
+    case ACVP_AES_OFB:
+    case ACVP_AES_CTR:
+    case ACVP_AES_XTS:
+    case ACVP_AES_KW:
+    case ACVP_AES_KWP:
+    case ACVP_AES_GMAC:
+    case ACVP_AES_XPN:
+    case ACVP_TDES_ECB:
+    case ACVP_TDES_CBC:
+    case ACVP_TDES_CBCI:
+    case ACVP_TDES_OFB:
+    case ACVP_TDES_OFBI:
+    case ACVP_TDES_CFB1:
+    case ACVP_TDES_CFB8:
+    case ACVP_TDES_CFB64:
+    case ACVP_TDES_CFBP1:
+    case ACVP_TDES_CFBP8:
+    case ACVP_TDES_CFBP64:
+    case ACVP_TDES_CTR:
+    case ACVP_TDES_KW:
+    case ACVP_HASH_SHA1:
+    case ACVP_HASH_SHA224:
+    case ACVP_HASH_SHA256:
+    case ACVP_HASH_SHA384:
+    case ACVP_HASH_SHA512:
+    case ACVP_HASH_SHA512_224:
+    case ACVP_HASH_SHA512_256:
+    case ACVP_HASH_SHA3_224:
+    case ACVP_HASH_SHA3_256:
+    case ACVP_HASH_SHA3_384:
+    case ACVP_HASH_SHA3_512:
+    case ACVP_HASH_SHAKE_128:
+    case ACVP_HASH_SHAKE_256:
+    case ACVP_HASHDRBG:
+    case ACVP_HMACDRBG:
+    case ACVP_CTRDRBG:
+    case ACVP_HMAC_SHA1:
+    case ACVP_HMAC_SHA2_224:
+    case ACVP_HMAC_SHA2_256:
+    case ACVP_HMAC_SHA2_384:
+    case ACVP_HMAC_SHA2_512:
+    case ACVP_HMAC_SHA2_512_224:
+    case ACVP_HMAC_SHA2_512_256:
+    case ACVP_HMAC_SHA3_224:
+    case ACVP_HMAC_SHA3_256:
+    case ACVP_HMAC_SHA3_384:
+    case ACVP_HMAC_SHA3_512:
+    case ACVP_CMAC_AES:
+    case ACVP_CMAC_TDES:
+    case ACVP_KMAC_128:
+    case ACVP_KMAC_256:
+    case ACVP_DSA_KEYGEN:
+    case ACVP_DSA_PQGGEN:
+    case ACVP_DSA_PQGVER:
+    case ACVP_DSA_SIGGEN:
+    case ACVP_DSA_SIGVER:
+    case ACVP_RSA_KEYGEN:
+    case ACVP_RSA_SIGGEN:
+    case ACVP_RSA_SIGVER:
+    case ACVP_RSA_SIGPRIM:
+    case ACVP_RSA_DECPRIM:
+    case ACVP_ECDSA_KEYGEN:
+    case ACVP_ECDSA_KEYVER:
+    case ACVP_ECDSA_SIGGEN:
+    case ACVP_ECDSA_SIGVER:
+    case ACVP_KDF135_SNMP:
+    case ACVP_KDF135_SSH:
+    case ACVP_KDF135_SRTP:
+    case ACVP_KDF135_IKEV2:
+    case ACVP_KDF135_IKEV1:
+    case ACVP_KDF135_X942:
+    case ACVP_KDF135_X963:
+    case ACVP_KDF108:
+    case ACVP_PBKDF:
+    case ACVP_KDF_TLS12:
+    case ACVP_KDF_TLS13:
+    case ACVP_KAS_ECC_CDH:
+    case ACVP_KAS_ECC_COMP:
+    case ACVP_KAS_ECC_NOCOMP:
+    case ACVP_KAS_ECC_SSC:
+    case ACVP_KAS_FFC_COMP:
+    case ACVP_KAS_FFC_NOCOMP:
+    case ACVP_KDA_ONESTEP:
+    case ACVP_KDA_TWOSTEP:
+    case ACVP_KDA_HKDF:
+    case ACVP_KAS_FFC_SSC:
+    case ACVP_KAS_IFC_SSC:
+    case ACVP_KTS_IFC:
+    case ACVP_SAFE_PRIMES_KEYGEN:
+    case ACVP_SAFE_PRIMES_KEYVER:
+    case ACVP_LMS_SIGGEN:
+    case ACVP_LMS_SIGVER:
+    case ACVP_LMS_KEYGEN:
+    case ACVP_CIPHER_END:
+    default:
+        return ACVP_INVALID_ARG;
+    }
+
+    /*
+     * Locate this cipher in the caps array
+     */
+    cap = acvp_locate_cap_entry(ctx, cipher);
+    if (!cap) {
+        ACVP_LOG_ERR("Cap entry not found, use acvp_cap_sym_cipher_enable() first.");
+        return ACVP_NO_CAP;
+    }
+
+    sym_cap = cap->cap.sym_cap;
+    if (!sym_cap) {
+        return ACVP_NO_CAP;
+    }
+
+    /*
+     * Check is this is a non-length related value.
+     */
+    switch (parm) {
+    case ACVP_SYM_CIPH_PARM_ALPHABET:
+        len = strnlen_s(value, ACVP_AES_FPE_RADIX_MAX+1);
+        if (len < ACVP_AES_FPE_RADIX_MIN) {
+            ACVP_LOG_ERR("Parameter for alphabet out of range (len=%d, range=%d..%d)", 
+                          len, ACVP_AES_FPE_RADIX_MIN, ACVP_AES_FPE_RADIX_MAX);
+            return ACVP_INVALID_ARG;
+        }
+        sym_cap->alphabet = calloc(len + 1, sizeof(char));
+        strcpy_s(sym_cap->alphabet, len + 1, value);
+        break;
+    case ACVP_SYM_CIPH_KW_MODE:
+    case ACVP_SYM_CIPH_PARM_DIR:
+    case ACVP_SYM_CIPH_PARM_KO:
+    case ACVP_SYM_CIPH_PARM_PERFORM_CTR:
+    case ACVP_SYM_CIPH_PARM_CTR_INCR:
+    case ACVP_SYM_CIPH_PARM_CTR_OVRFLW:
+    case ACVP_SYM_CIPH_PARM_IVGEN_SRC:
+    case ACVP_SYM_CIPH_PARM_IVGEN_MODE:
+    case ACVP_SYM_CIPH_PARM_SALT_SRC:
+    case ACVP_SYM_CIPH_PARM_CONFORMANCE:
+    case ACVP_SYM_CIPH_PARM_DULEN_MATCHES_PAYLOADLEN:
+    case ACVP_SYM_CIPH_KEYLEN:
+    case ACVP_SYM_CIPH_TAGLEN:
+    case ACVP_SYM_CIPH_IVLEN:
+    case ACVP_SYM_CIPH_PTLEN:
+    case ACVP_SYM_CIPH_TWEAK:
+    case ACVP_SYM_CIPH_AADLEN:
+    default:
+        ACVP_LOG_ERR("Invalid param");
+        return ACVP_INVALID_ARG;
+    }
+
+    return ACVP_SUCCESS;
+}
+
 /*
  * This function is called by the application to register a crypto
  * capability for symmetric ciphers, along with a handler that the
@@ -3034,6 +3310,8 @@ ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
     case ACVP_AES_KWP:
     case ACVP_AES_GMAC:
     case ACVP_AES_XPN:
+    case ACVP_AES_FF1:
+    case ACVP_AES_FF3:
     case ACVP_TDES_ECB:
     case ACVP_TDES_CBC:
     case ACVP_TDES_CBCI:

--- a/src/acvp_dsa.c
+++ b/src/acvp_dsa.c
@@ -60,7 +60,6 @@ static ACVP_RESULT acvp_dsa_siggen_init_tc(ACVP_CTX *ctx,
 
     stc->tg_id = tg_id;
     stc->tc_id = tc_id;
-
     stc->l = l;
     stc->n = n;
     stc->sha = sha;
@@ -98,6 +97,8 @@ static ACVP_RESULT acvp_dsa_siggen_init_tc(ACVP_CTX *ctx,
 
 static ACVP_RESULT acvp_dsa_sigver_init_tc(ACVP_CTX *ctx,
                                            ACVP_DSA_TC *stc,
+                                           int tg_id,
+                                           unsigned int tc_id,
                                            int l,
                                            int n,
                                            ACVP_HASH_ALG sha,
@@ -110,6 +111,8 @@ static ACVP_RESULT acvp_dsa_sigver_init_tc(ACVP_CTX *ctx,
                                            const char *msg) {
     ACVP_RESULT rv;
 
+    stc->tg_id = tg_id;
+    stc->tc_id = tc_id;
     stc->l = l;
     stc->n = n;
     stc->sha = sha;
@@ -178,6 +181,8 @@ static ACVP_RESULT acvp_dsa_sigver_init_tc(ACVP_CTX *ctx,
 
 static ACVP_RESULT acvp_dsa_pqgver_init_tc(ACVP_CTX *ctx,
                                            ACVP_DSA_TC *stc,
+                                           int tg_id,
+                                           unsigned int tc_id,
                                            int l,
                                            int n,
                                            int c,
@@ -191,6 +196,8 @@ static ACVP_RESULT acvp_dsa_pqgver_init_tc(ACVP_CTX *ctx,
                                            unsigned int pqg) {
     ACVP_RESULT rv;
 
+    stc->tg_id = tg_id;
+    stc->tc_id = tc_id;
     stc->l = l;
     stc->n = n;
     stc->c = c;
@@ -261,16 +268,20 @@ static ACVP_RESULT acvp_dsa_pqgver_init_tc(ACVP_CTX *ctx,
 
 static ACVP_RESULT acvp_dsa_pqggen_init_tc(ACVP_CTX *ctx,
                                            ACVP_DSA_TC *stc,
-                                           unsigned int gpq,
-                                           const char *idx,
+                                           int tg_id,
+                                           unsigned int tc_id,
                                            int l,
                                            int n,
+                                           unsigned int gpq,
+                                           const char *idx,
                                            ACVP_HASH_ALG sha,
                                            const char *p,
                                            const char *q,
                                            const char *seed) {
     ACVP_RESULT rv;
 
+    stc->tg_id = tg_id;
+    stc->tc_id = tc_id;
     stc->l = l;
     stc->n = n;
     stc->sha = sha;
@@ -664,7 +675,8 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
                                     ACVP_TEST_CASE tc,
                                     ACVP_CAPS_LIST *cap,
                                     JSON_Array *r_tarr,
-                                    JSON_Object *groupobj) {
+                                    JSON_Object *groupobj,
+                                    int tg_id) {
     const char *idx = NULL;
     JSON_Array *tests;
     JSON_Value *testval;
@@ -817,7 +829,7 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
             r_tobj = json_value_get_object(r_tval);
             json_object_set_number(r_tobj, "tcId", tc_id);
 
-            rv = acvp_dsa_pqggen_init_tc(ctx, stc, gpq, idx, l, n, sha, p, q, seed);
+            rv = acvp_dsa_pqggen_init_tc(ctx, stc, tg_id, tc_id, l, n, gpq, idx, sha, p, q, seed);
             if (rv != ACVP_SUCCESS) {
                 acvp_dsa_release_tc(stc);
                 json_value_free(r_tval);
@@ -859,7 +871,7 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
             json_object_set_number(r_tobj, "tcId", tc_id);
 
             /* Process the current DSA test vector... */
-            rv = acvp_dsa_pqggen_init_tc(ctx, stc, gpq, idx, l, n, sha, p, q, seed);
+            rv = acvp_dsa_pqggen_init_tc(ctx, stc, tg_id, tc_id, l, n, gpq, idx, sha, p, q, seed);
             if (rv != ACVP_SUCCESS) {
                 acvp_dsa_release_tc(stc);
                 json_value_free(r_tval);
@@ -1071,7 +1083,8 @@ static ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
                                     ACVP_TEST_CASE tc,
                                     ACVP_CAPS_LIST *cap,
                                     JSON_Array *r_tarr,
-                                    JSON_Object *groupobj) {
+                                    JSON_Object *groupobj,
+                                    int tg_id) {
     const char *idx = NULL;
     const char *g = NULL, *pqmode = NULL, *gmode = NULL, *seed = NULL;
     JSON_Array *tests;
@@ -1230,7 +1243,7 @@ static ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
          * Setup the test case data that will be passed down to
          * the crypto module.
          */
-        rv = acvp_dsa_pqgver_init_tc(ctx, stc, l, n, c, idx, sha, p, q, g, h, seed, gpq);
+        rv = acvp_dsa_pqgver_init_tc(ctx, stc, tg_id, tc_id, l, n, c, idx, sha, p, q, g, h, seed, gpq);
         if (rv != ACVP_SUCCESS) {
             acvp_dsa_release_tc(stc);
             return rv;
@@ -1269,7 +1282,8 @@ static ACVP_RESULT acvp_dsa_sigver_handler(ACVP_CTX *ctx,
                                     ACVP_TEST_CASE tc,
                                     ACVP_CAPS_LIST *cap,
                                     JSON_Array *r_tarr,
-                                    JSON_Object *groupobj) {
+                                    JSON_Object *groupobj,
+                                    int tg_id) {
     const char *msg = NULL, *r = NULL, *s = NULL, *y = NULL, *g = NULL;
     JSON_Array *tests;
     JSON_Value *testval;
@@ -1391,7 +1405,7 @@ static ACVP_RESULT acvp_dsa_sigver_handler(ACVP_CTX *ctx,
          * Setup the test case data that will be passed down to
          * the crypto module.
          */
-        rv = acvp_dsa_sigver_init_tc(ctx, stc, l, n, sha, p, q, g, r, s, y, msg);
+        rv = acvp_dsa_sigver_init_tc(ctx, stc, tg_id, tc_id, l, n, sha, p, q, g, r, s, y, msg);
         if (rv != ACVP_SUCCESS) {
             acvp_dsa_release_tc(stc);
             return rv;
@@ -1519,7 +1533,7 @@ static ACVP_RESULT acvp_dsa_pqgver_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
 
         ACVP_LOG_VERBOSE("    Test group: %d", i);
 
-        rv = acvp_dsa_pqgver_handler(ctx, tc, cap, r_tarr, groupobj);
+        rv = acvp_dsa_pqgver_handler(ctx, tc, cap, r_tarr, groupobj, tgId);
         if (rv != ACVP_SUCCESS) {
             goto err;
         }
@@ -1640,7 +1654,7 @@ static ACVP_RESULT acvp_dsa_pqggen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
 
         ACVP_LOG_VERBOSE("    Test group: %d", i);
 
-        rv = acvp_dsa_pqggen_handler(ctx, tc, cap, r_tarr, groupobj);
+        rv = acvp_dsa_pqggen_handler(ctx, tc, cap, r_tarr, groupobj, tgId);
         if (rv != ACVP_SUCCESS) {
             goto err;
         }
@@ -1988,7 +2002,7 @@ static ACVP_RESULT acvp_dsa_sigver_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
 
         ACVP_LOG_VERBOSE("    Test group: %d", i);
 
-        rv = acvp_dsa_sigver_handler(ctx, tc, cap, r_tarr, groupobj);
+        rv = acvp_dsa_sigver_handler(ctx, tc, cap, r_tarr, groupobj, tgId);
         if (rv != ACVP_SUCCESS) {
             goto err;
         }


### PR DESCRIPTION
Two commits -- 
Add tgId and tcId values to all DSA TCs
Add support for AES-FF1 and AES-FF3

AES was validated for Demo vectors against the following library:
https://github.com/mysto/clang-fpe