### PR TITLE
Support kdf-components-snmp-1.0

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -1414,7 +1414,6 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf_tls12_set_parm(ctx, ACVP_KDF_TLS12_HASH_ALG, ACVP_SHA512);
     CHECK_ENABLE_CAP_RV(rv);
 
-#if 0
     rv = acvp_cap_kdf135_snmp_enable(ctx, &app_kdf135_snmp_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, value);
@@ -1427,7 +1426,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kdf135_snmp_set_engid(ctx, ACVP_KDF135_SNMP, ENGID2);
     CHECK_ENABLE_CAP_RV(rv);
-#endif
+
     rv = acvp_cap_kdf135_ssh_enable(ctx, &app_kdf135_ssh_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, value);


### PR DESCRIPTION
Support kdf-components-snmp-1.0

```
 libacvp/app/acvp_app -r kdf-components-snmp-1.0/prompt.json -p kdf-components-snmp-1.0/actResults.json -a
```
[actResult.json](https://github.com/user-attachments/files/16453863/actResult.json)
[prompt.json](https://github.com/user-attachments/files/16453864/prompt.json)
