### PR TITLE
Update UTs to work with new app structure

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -43,9 +43,6 @@ char *key_file;
 const char *path_segment;
 const char *api_context;
 
-//TODO: This shouldnt need to be set
-char value[JSON_STRING_LENGTH];
-
 #define CHECK_ENABLE_CAP_RV(rv) \
     if (rv != ACVP_SUCCESS) { \
         printf("Failed to register capability with libacvp (rv=%d: %s)\n", rv, acvp_lookup_error_string(rv)); \

--- a/app/app_utils.c
+++ b/app/app_utils.c
@@ -14,6 +14,9 @@
 #include "app_lcl.h"
 #include "safe_lib.h"
 
+//TODO: This shouldnt need to be set
+char value[JSON_STRING_LENGTH];
+
 void print_version_info(APP_CONFIG *cfg) {
     printf("\n ACVP library version: %s\n", acvp_version());
     printf("ACVP protocol version: %s\n\n", acvp_protocol_version());

--- a/app/implementations/openssl/3/registrations/fp_30X.c
+++ b/app/implementations/openssl/3/registrations/fp_30X.c
@@ -32,7 +32,6 @@ static int enable_hmac(ACVP_CTX *ctx);
 static int enable_kmac(ACVP_CTX *ctx);
 static int enable_rsa(ACVP_CTX *ctx);
 static int enable_ecdsa(ACVP_CTX *ctx);
-static int enable_eddsa(ACVP_CTX *ctx);
 static int enable_drbg(ACVP_CTX *ctx);
 static int enable_kas_ecc(ACVP_CTX *ctx);
 static int enable_kas_ifc(ACVP_CTX *ctx);
@@ -52,7 +51,6 @@ ACVP_RESULT register_capabilities_fp_30X(ACVP_CTX *ctx, APP_CONFIG *cfg) {
     if (cfg->kdf || cfg->testall) { if ((rv = enable_kdf(ctx))) goto end; }
     if (cfg->rsa || cfg->testall) { if ((rv = enable_rsa(ctx))) goto end; }
     if (cfg->ecdsa || cfg->testall) { if ((rv = enable_ecdsa(ctx))) goto end; }
-    if (cfg->eddsa || cfg->testall) { if ((rv = enable_eddsa(ctx))) goto end; }
     if (cfg->drbg || cfg->testall) { if ((rv = enable_drbg(ctx))) goto end; }
     if (cfg->kas_ecc || cfg->testall) { if ((rv = enable_kas_ecc(ctx))) goto end; }
     if (cfg->kas_ifc || cfg->testall) { if ((rv = enable_kas_ifc(ctx))) goto end; }
@@ -1816,34 +1814,6 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
 
 end:
 
-    return rv;
-}
-
-static int enable_eddsa(ACVP_CTX *ctx) {
-    ACVP_RESULT rv = ACVP_SUCCESS;
-
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_SIGGEN, &app_eddsa_handler);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_SUPPORTS_PREHASH, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_SUPPORTS_PURE, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_SIGVER, &app_eddsa_handler);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_SUPPORTS_PREHASH, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_SUPPORTS_PURE, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-end:
     return rv;
 }
 

--- a/app/implementations/openssl/3/registrations/non_fips.c
+++ b/app/implementations/openssl/3/registrations/non_fips.c
@@ -36,7 +36,6 @@ static int enable_hmac(ACVP_CTX *ctx);
 static int enable_kmac(ACVP_CTX *ctx);
 static int enable_rsa(ACVP_CTX *ctx);
 static int enable_ecdsa(ACVP_CTX *ctx);
-static int enable_eddsa(ACVP_CTX *ctx);
 static int enable_drbg(ACVP_CTX *ctx);
 static int enable_kas_ecc(ACVP_CTX *ctx);
 static int enable_kas_ifc(ACVP_CTX *ctx);
@@ -56,7 +55,6 @@ ACVP_RESULT register_capabilities_non_fips(ACVP_CTX *ctx, APP_CONFIG *cfg) {
     if (cfg->kdf || cfg->testall) { if ((rv = enable_kdf(ctx))) goto end; }
     if (cfg->rsa || cfg->testall) { if ((rv = enable_rsa(ctx))) goto end; }
     if (cfg->ecdsa || cfg->testall) { if ((rv = enable_ecdsa(ctx))) goto end; }
-    if (cfg->eddsa || cfg->testall) { if ((rv = enable_eddsa(ctx))) goto end; }
     if (cfg->drbg || cfg->testall) { if ((rv = enable_drbg(ctx))) goto end; }
     if (cfg->kas_ecc || cfg->testall) { if ((rv = enable_kas_ecc(ctx))) goto end; }
     if (cfg->kas_ifc || cfg->testall) { if ((rv = enable_kas_ifc(ctx))) goto end; }
@@ -1850,34 +1848,6 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
 end:
 
     return rv;
-}
-
-static int enable_eddsa(ACVP_CTX *ctx) {
-    ACVP_RESULT rv = ACVP_SUCCESS;
-
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_SIGGEN, &app_eddsa_handler);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_SUPPORTS_PREHASH, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_SUPPORTS_PURE, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_SIGVER, &app_eddsa_handler);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_SUPPORTS_PREHASH, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_SUPPORTS_PURE, 1);
-    CHECK_ENABLE_CAP_RV(rv);
-end:
-        return rv;
 }
 
 static int enable_drbg(ACVP_CTX *ctx) {

--- a/app/totp/hmac_sha256.c
+++ b/app/totp/hmac_sha256.c
@@ -47,8 +47,8 @@ size_t hmac_sha256(const void* key,
   size_t sz;
   int i;
 
-  memset_s (k, sizeof(k), 0, sizeof(k));
-  memset_s (k_ipad, sizeof(k_ipad), 0x36, sizeof(k_ipad));
+  memset_s(k, sizeof(k), 0, sizeof(k));
+  memset_s(k_ipad, sizeof(k_ipad), 0x36, sizeof(k_ipad));
   memset_s(k_opad, sizeof(k_opad), 0x5c, sizeof(k_opad));
 
   if (keylen > SHA256_BLOCK_SIZE) {

--- a/configure
+++ b/configure
@@ -12197,8 +12197,12 @@ if test "x$disable_app" = "xno" ; then
     IUT_LDFLAGS="$iut_ldflags $iut_lflag"
 
 
-    # Tell the automake files which IUT we are using. Only one of these should ever be enabled.
-     if test "x$acvp_app_iut" = "xjent"; then
+fi
+
+# Tell the automake files which IUT we are using. Only one of these should ever be enabled.
+# NOTE: These must called here even if not building the app for the sake of autoconf sanity
+#       AM_CONDITIONAL should never be...conditionally called
+ if test "x$acvp_app_iut" = "xjent"; then
   APP_IUT_JENT_TRUE=
   APP_IUT_JENT_FALSE='#'
 else
@@ -12206,7 +12210,7 @@ else
   APP_IUT_JENT_FALSE=
 fi
 
-     if test "x$acvp_app_iut" = "xopenssl_1"; then
+ if test "x$acvp_app_iut" = "xopenssl_1"; then
   APP_IUT_OPENSSL_1_TRUE=
   APP_IUT_OPENSSL_1_FALSE='#'
 else
@@ -12214,7 +12218,7 @@ else
   APP_IUT_OPENSSL_1_FALSE=
 fi
 
-     if test "x$acvp_app_iut" = "xopenssl_3"; then
+ if test "x$acvp_app_iut" = "xopenssl_3"; then
   APP_IUT_OPENSSL_3_TRUE=
   APP_IUT_OPENSSL_3_FALSE='#'
 else
@@ -12222,7 +12226,6 @@ else
   APP_IUT_OPENSSL_3_FALSE=
 fi
 
-fi
 
 # Set the flags needed for curl/murl library
 if test "x$libcurldir" != "x" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -329,11 +329,14 @@ if test "x$disable_app" = "xno" ; then
     AC_SUBST([IUT_CFLAGS], "$iut_cflags")
     AC_SUBST([IUT_LDFLAGS], "$iut_ldflags $iut_lflag")
 
-    # Tell the automake files which IUT we are using. Only one of these should ever be enabled.
-    AM_CONDITIONAL([APP_IUT_JENT], [test "x$acvp_app_iut" = "xjent"])
-    AM_CONDITIONAL([APP_IUT_OPENSSL_1], [test "x$acvp_app_iut" = "xopenssl_1"])
-    AM_CONDITIONAL([APP_IUT_OPENSSL_3], [test "x$acvp_app_iut" = "xopenssl_3"])
 fi
+
+# Tell the automake files which IUT we are using. Only one of these should ever be enabled.
+# NOTE: These must called here even if not building the app for the sake of autoconf sanity
+#       AM_CONDITIONAL should never be...conditionally called
+AM_CONDITIONAL([APP_IUT_JENT], [test "x$acvp_app_iut" = "xjent"])
+AM_CONDITIONAL([APP_IUT_OPENSSL_1], [test "x$acvp_app_iut" = "xopenssl_1"])
+AM_CONDITIONAL([APP_IUT_OPENSSL_3], [test "x$acvp_app_iut" = "xopenssl_3"])
 
 # Set the flags needed for curl/murl library
 if test "x$libcurldir" != "x" ; then

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -45,40 +45,56 @@ tmp_ldflags += $(LIBCURL_LDFLAGS)
 endif
 
 if ! APP_NOT_SUPPORTED
-runtest_SOURCES += app_common.c \
-      test_app_aes.c \
-      test_app_cmac.c \
-      test_app_des.c \
-      test_app_drbg.c \
-      test_app_ecdsa.c \
-      test_app_hmac.c \
-      test_app_kas_ecc.c \
-      test_app_kas_ffc.c \
-      test_app_kas_ifc.c \
-      test_app_rsa_keygen.c \
-      test_app_rsa_sig.c \
-      test_app_sha.c \
-      test_app_safe_primes.c \
-      test_app_kda.c \
-      test_app_kmac.c
 
-APP_LINK = ../app/acvp_app-app_utils.o \
-           ../app/acvp_app-app_sha.o \
-           ../app/acvp_app-app_hmac.o \
-           ../app/acvp_app-app_aes.o \
-           ../app/acvp_app-app_des.o \
-           ../app/acvp_app-app_cmac.o \
-           ../app/acvp_app-app_kdf.o \
-           ../app/acvp_app-app_dsa.o \
-           ../app/acvp_app-app_kas.o \
-           ../app/acvp_app-app_rsa.o \
-           ../app/acvp_app-app_ecdsa.o \
-           ../app/acvp_app-app_drbg.o \
-           ../app/acvp_app-app_kda.o \
-           ../app/acvp_app-app_kmac.o
+APP_LINK = ../app/acvp_app-app_cli.o \
+           ../app/acvp_app-app_utils.o \
+           ../app/totp/acvp_app-hmac_sha256.o \
+           ../app/totp/acvp_app-sha256.o \
+           ../app/totp/acvp_app-totp.o
 
-tmp_cflags += $(SSL_CFLAGS) $(FOM_CFLAGS) -I../app
-tmp_ldflags += $(SSL_LDFLAGS) $(FOM_LDFLAGS)
+runtest_SOURCES += app_common.c
+
+if APP_IUT_OPENSSL_3
+runtest_SOURCES += implementations/openssl/3/test_iut_aes.c \
+                   implementations/openssl/3/test_iut_cmac.c \
+                   implementations/openssl/3/test_iut_des.c \
+                   implementations/openssl/3/test_iut_drbg.c \
+                   implementations/openssl/3/test_iut_ecdsa.c \
+                   implementations/openssl/3/test_iut_hmac.c \
+                   implementations/openssl/3/test_iut_kas_ecc.c \
+                   implementations/openssl/3/test_iut_kas_ffc.c \
+                   implementations/openssl/3/test_iut_kas_ifc.c \
+                   implementations/openssl/3/test_iut_rsa_keygen.c \
+                   implementations/openssl/3/test_iut_rsa_sig.c \
+                   implementations/openssl/3/test_iut_hash.c \
+                   implementations/openssl/3/test_iut_safe_primes.c \
+                   implementations/openssl/3/test_iut_kda.c \
+                   implementations/openssl/3/test_iut_kmac.c
+
+APP_LINK += ../app/implementations/openssl/3/acvp_app-iut.o \
+            ../app/implementations/openssl/3/acvp_app-iut_utils.o \
+            ../app/implementations/openssl/3/registrations/acvp_app-fp_30X.o \
+            ../app/implementations/openssl/3/registrations/acvp_app-fp_312.o \
+            ../app/implementations/openssl/3/registrations/acvp_app-non_fips.o \
+            ../app/implementations/openssl/3/acvp_app-iut_hash.o \
+            ../app/implementations/openssl/3/acvp_app-iut_hmac.o \
+            ../app/implementations/openssl/3/acvp_app-iut_aes.o \
+            ../app/implementations/openssl/3/acvp_app-iut_des.o \
+            ../app/implementations/openssl/3/acvp_app-iut_cmac.o \
+            ../app/implementations/openssl/3/acvp_app-iut_kdf.o \
+            ../app/implementations/openssl/3/acvp_app-iut_dsa.o \
+            ../app/implementations/openssl/3/acvp_app-iut_kas.o \
+            ../app/implementations/openssl/3/acvp_app-iut_rsa.o \
+            ../app/implementations/openssl/3/acvp_app-iut_ecdsa.o \
+            ../app/implementations/openssl/3/acvp_app-iut_drbg.o \
+            ../app/implementations/openssl/3/acvp_app-iut_kda.o \
+            ../app/implementations/openssl/3/acvp_app-iut_kmac.o
+
+endif
+
+
+tmp_cflags += $(IUT_CFLAGS) -I../app
+tmp_ldflags += $(IUT_LDFLAGS)
 endif
 
 runtest_CFLAGS = ${tmp_cflags}

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -128,26 +128,45 @@ noinst_PROGRAMS = runtest$(EXEEXT)
 
 @LIB_NOT_SUPPORTED_FALSE@am__append_2 = $(LIBCURL_CFLAGS)
 @LIB_NOT_SUPPORTED_FALSE@am__append_3 = $(LIBCURL_LDFLAGS)
-@APP_NOT_SUPPORTED_FALSE@am__append_4 = app_common.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_aes.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_cmac.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_des.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_drbg.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_ecdsa.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_hmac.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_kas_ecc.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_kas_ffc.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_kas_ifc.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_rsa_keygen.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_rsa_sig.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_sha.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_safe_primes.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_kda.c \
-@APP_NOT_SUPPORTED_FALSE@      test_app_kmac.c
+@APP_NOT_SUPPORTED_FALSE@am__append_4 = app_common.c
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@am__append_5 = implementations/openssl/3/test_iut_aes.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_cmac.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_des.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_drbg.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_ecdsa.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_hmac.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_kas_ecc.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_kas_ffc.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_kas_ifc.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_rsa_keygen.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_rsa_sig.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_hash.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_safe_primes.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_kda.c \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@                   implementations/openssl/3/test_iut_kmac.c
 
-@APP_NOT_SUPPORTED_FALSE@am__append_5 = $(SSL_CFLAGS) $(FOM_CFLAGS) -I../app
-@APP_NOT_SUPPORTED_FALSE@am__append_6 = $(SSL_LDFLAGS) $(FOM_LDFLAGS)
-@APP_NOT_SUPPORTED_FALSE@am__append_7 = app_common.h
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@am__append_6 = ../app/implementations/openssl/3/acvp_app-iut.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_utils.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/registrations/acvp_app-fp_30X.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/registrations/acvp_app-fp_312.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/registrations/acvp_app-non_fips.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_hash.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_hmac.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_aes.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_des.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_cmac.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_kdf.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_dsa.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_kas.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_rsa.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_ecdsa.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_drbg.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_kda.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_kmac.o
+
+@APP_NOT_SUPPORTED_FALSE@am__append_7 = $(IUT_CFLAGS) -I../app
+@APP_NOT_SUPPORTED_FALSE@am__append_8 = $(IUT_LDFLAGS)
+@APP_NOT_SUPPORTED_FALSE@am__append_9 = app_common.h
 subdir = test
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
@@ -177,11 +196,21 @@ am__runtest_SOURCES_DIST = ut_common.c create_session.c \
 	test_acvp_ecdsa.c test_acvp_kas_ecc.c test_acvp_kas_ifc.c \
 	test_acvp_kts_ifc.c test_acvp_kas_ffc.c \
 	test_acvp_safe_primes.c test_acvp_kda.c test_acvp_kmac.c \
-	app_common.c test_app_aes.c test_app_cmac.c test_app_des.c \
-	test_app_drbg.c test_app_ecdsa.c test_app_hmac.c \
-	test_app_kas_ecc.c test_app_kas_ffc.c test_app_kas_ifc.c \
-	test_app_rsa_keygen.c test_app_rsa_sig.c test_app_sha.c \
-	test_app_safe_primes.c test_app_kda.c test_app_kmac.c
+	app_common.c implementations/openssl/3/test_iut_aes.c \
+	implementations/openssl/3/test_iut_cmac.c \
+	implementations/openssl/3/test_iut_des.c \
+	implementations/openssl/3/test_iut_drbg.c \
+	implementations/openssl/3/test_iut_ecdsa.c \
+	implementations/openssl/3/test_iut_hmac.c \
+	implementations/openssl/3/test_iut_kas_ecc.c \
+	implementations/openssl/3/test_iut_kas_ffc.c \
+	implementations/openssl/3/test_iut_kas_ifc.c \
+	implementations/openssl/3/test_iut_rsa_keygen.c \
+	implementations/openssl/3/test_iut_rsa_sig.c \
+	implementations/openssl/3/test_iut_hash.c \
+	implementations/openssl/3/test_iut_safe_primes.c \
+	implementations/openssl/3/test_iut_kda.c \
+	implementations/openssl/3/test_iut_kmac.c
 @LIB_NOT_SUPPORTED_FALSE@am__objects_1 =  \
 @LIB_NOT_SUPPORTED_FALSE@	runtest-create_session.$(OBJEXT) \
 @LIB_NOT_SUPPORTED_FALSE@	runtest-test_acvp_utils.$(OBJEXT) \
@@ -218,24 +247,25 @@ am__runtest_SOURCES_DIST = ut_common.c create_session.c \
 @LIB_NOT_SUPPORTED_FALSE@	runtest-test_acvp_safe_primes.$(OBJEXT) \
 @LIB_NOT_SUPPORTED_FALSE@	runtest-test_acvp_kda.$(OBJEXT) \
 @LIB_NOT_SUPPORTED_FALSE@	runtest-test_acvp_kmac.$(OBJEXT)
-@APP_NOT_SUPPORTED_FALSE@am__objects_2 = runtest-app_common.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_aes.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_cmac.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_des.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_drbg.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_ecdsa.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_hmac.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_kas_ecc.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_kas_ffc.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_kas_ifc.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_rsa_keygen.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_rsa_sig.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_sha.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_safe_primes.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_kda.$(OBJEXT) \
-@APP_NOT_SUPPORTED_FALSE@	runtest-test_app_kmac.$(OBJEXT)
+@APP_NOT_SUPPORTED_FALSE@am__objects_2 = runtest-app_common.$(OBJEXT)
+am__dirstamp = $(am__leading_dot)dirstamp
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@am__objects_3 = implementations/openssl/3/runtest-test_iut_aes.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_cmac.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_des.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_drbg.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_ecdsa.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_hmac.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_kas_ecc.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_kas_ffc.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_kas_ifc.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_rsa_keygen.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_rsa_sig.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_hash.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_safe_primes.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_kda.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@	implementations/openssl/3/runtest-test_iut_kmac.$(OBJEXT)
 am_runtest_OBJECTS = runtest-ut_common.$(OBJEXT) $(am__objects_1) \
-	$(am__objects_2)
+	$(am__objects_2) $(am__objects_3)
 runtest_OBJECTS = $(am_runtest_OBJECTS)
 @APP_NOT_SUPPORTED_FALSE@runtest_DEPENDENCIES = $(APP_LINK)
 AM_V_lt = $(am__v_lt_@AM_V@)
@@ -296,22 +326,22 @@ am__depfiles_remade = ./$(DEPDIR)/runtest-app_common.Po \
 	./$(DEPDIR)/runtest-test_acvp_safe_primes.Po \
 	./$(DEPDIR)/runtest-test_acvp_transport.Po \
 	./$(DEPDIR)/runtest-test_acvp_utils.Po \
-	./$(DEPDIR)/runtest-test_app_aes.Po \
-	./$(DEPDIR)/runtest-test_app_cmac.Po \
-	./$(DEPDIR)/runtest-test_app_des.Po \
-	./$(DEPDIR)/runtest-test_app_drbg.Po \
-	./$(DEPDIR)/runtest-test_app_ecdsa.Po \
-	./$(DEPDIR)/runtest-test_app_hmac.Po \
-	./$(DEPDIR)/runtest-test_app_kas_ecc.Po \
-	./$(DEPDIR)/runtest-test_app_kas_ffc.Po \
-	./$(DEPDIR)/runtest-test_app_kas_ifc.Po \
-	./$(DEPDIR)/runtest-test_app_kda.Po \
-	./$(DEPDIR)/runtest-test_app_kmac.Po \
-	./$(DEPDIR)/runtest-test_app_rsa_keygen.Po \
-	./$(DEPDIR)/runtest-test_app_rsa_sig.Po \
-	./$(DEPDIR)/runtest-test_app_safe_primes.Po \
-	./$(DEPDIR)/runtest-test_app_sha.Po \
-	./$(DEPDIR)/runtest-ut_common.Po
+	./$(DEPDIR)/runtest-ut_common.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_aes.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_cmac.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_des.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_drbg.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_ecdsa.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hash.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hmac.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ecc.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ffc.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ifc.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kda.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kmac.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_keygen.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_sig.Po \
+	implementations/openssl/3/$(DEPDIR)/runtest-test_iut_safe_primes.Po
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
@@ -520,32 +550,24 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-runtest_SOURCES = ut_common.c $(am__append_1) $(am__append_4)
+runtest_SOURCES = ut_common.c $(am__append_1) $(am__append_4) \
+	$(am__append_5)
 tmp_cflags = -g -O0 -Wall -DNO_SSL_DL $(SAFEC_CFLAGS) \
 	$(CRITERION_CFLAGS) $(LIBACVP_CFLAGS) -I../include \
-	$(am__append_2) $(am__append_5)
+	$(am__append_2) $(am__append_7)
 tmp_ldflags = $(CRITERION_LDFLAGS) $(SAFEC_LDFLAGS) $(LIBACVP_LDFLAGS) \
-	$(am__append_3) $(am__append_6)
-@APP_NOT_SUPPORTED_FALSE@APP_LINK = ../app/acvp_app-app_utils.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_sha.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_hmac.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_aes.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_des.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_cmac.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_kdf.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_dsa.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_kas.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_rsa.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_ecdsa.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_drbg.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_kda.o \
-@APP_NOT_SUPPORTED_FALSE@           ../app/acvp_app-app_kmac.o
-
+	$(am__append_3) $(am__append_8)
+@APP_NOT_SUPPORTED_FALSE@APP_LINK = ../app/acvp_app-app_cli.o \
+@APP_NOT_SUPPORTED_FALSE@	../app/acvp_app-app_utils.o \
+@APP_NOT_SUPPORTED_FALSE@	../app/totp/acvp_app-hmac_sha256.o \
+@APP_NOT_SUPPORTED_FALSE@	../app/totp/acvp_app-sha256.o \
+@APP_NOT_SUPPORTED_FALSE@	../app/totp/acvp_app-totp.o \
+@APP_NOT_SUPPORTED_FALSE@	$(am__append_6)
 runtest_CFLAGS = ${tmp_cflags}
 runtest_LDFLAGS = ${tmp_ldflags}
 @APP_NOT_SUPPORTED_FALSE@runtest_LDADD = $(APP_LINK)
 runtestdir = 
-runtest_HEADERS = ut_common.h $(am__append_7)
+runtest_HEADERS = ut_common.h $(am__append_9)
 all: all-am
 
 .SUFFIXES:
@@ -588,6 +610,57 @@ clean-noinstPROGRAMS:
 	list=`for p in $$list; do echo "$$p"; done | sed 's/$(EXEEXT)$$//'`; \
 	echo " rm -f" $$list; \
 	rm -f $$list
+implementations/openssl/3/$(am__dirstamp):
+	@$(MKDIR_P) implementations/openssl/3
+	@: > implementations/openssl/3/$(am__dirstamp)
+implementations/openssl/3/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) implementations/openssl/3/$(DEPDIR)
+	@: > implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_aes.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_cmac.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_des.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_drbg.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_ecdsa.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_hmac.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_kas_ecc.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_kas_ffc.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_kas_ifc.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_rsa_keygen.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_rsa_sig.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_hash.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_safe_primes.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_kda.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/runtest-test_iut_kmac.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
 
 runtest$(EXEEXT): $(runtest_OBJECTS) $(runtest_DEPENDENCIES) $(EXTRA_runtest_DEPENDENCIES) 
 	@rm -f runtest$(EXEEXT)
@@ -595,6 +668,7 @@ runtest$(EXEEXT): $(runtest_OBJECTS) $(runtest_DEPENDENCIES) $(EXTRA_runtest_DEP
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
+	-rm -f implementations/openssl/3/*.$(OBJEXT)
 
 distclean-compile:
 	-rm -f *.tab.c
@@ -635,22 +709,22 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_acvp_safe_primes.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_acvp_transport.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_acvp_utils.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_aes.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_cmac.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_des.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_drbg.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_ecdsa.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_hmac.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_kas_ecc.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_kas_ffc.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_kas_ifc.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_kda.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_kmac.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_rsa_keygen.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_rsa_sig.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_safe_primes.Po@am__quote@ # am--include-marker
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-test_app_sha.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/runtest-ut_common.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_aes.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_cmac.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_des.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_drbg.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_ecdsa.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hash.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hmac.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ecc.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ffc.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ifc.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kda.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kmac.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_keygen.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_sig.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/runtest-test_iut_safe_primes.Po@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
 	@$(MKDIR_P) $(@D)
@@ -1200,215 +1274,215 @@ runtest-app_common.obj: app_common.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-app_common.obj `if test -f 'app_common.c'; then $(CYGPATH_W) 'app_common.c'; else $(CYGPATH_W) '$(srcdir)/app_common.c'; fi`
 
-runtest-test_app_aes.o: test_app_aes.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_aes.o -MD -MP -MF $(DEPDIR)/runtest-test_app_aes.Tpo -c -o runtest-test_app_aes.o `test -f 'test_app_aes.c' || echo '$(srcdir)/'`test_app_aes.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_aes.Tpo $(DEPDIR)/runtest-test_app_aes.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_aes.c' object='runtest-test_app_aes.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_aes.o: implementations/openssl/3/test_iut_aes.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_aes.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_aes.Tpo -c -o implementations/openssl/3/runtest-test_iut_aes.o `test -f 'implementations/openssl/3/test_iut_aes.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_aes.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_aes.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_aes.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_aes.c' object='implementations/openssl/3/runtest-test_iut_aes.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_aes.o `test -f 'test_app_aes.c' || echo '$(srcdir)/'`test_app_aes.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_aes.o `test -f 'implementations/openssl/3/test_iut_aes.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_aes.c
 
-runtest-test_app_aes.obj: test_app_aes.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_aes.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_aes.Tpo -c -o runtest-test_app_aes.obj `if test -f 'test_app_aes.c'; then $(CYGPATH_W) 'test_app_aes.c'; else $(CYGPATH_W) '$(srcdir)/test_app_aes.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_aes.Tpo $(DEPDIR)/runtest-test_app_aes.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_aes.c' object='runtest-test_app_aes.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_aes.obj: implementations/openssl/3/test_iut_aes.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_aes.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_aes.Tpo -c -o implementations/openssl/3/runtest-test_iut_aes.obj `if test -f 'implementations/openssl/3/test_iut_aes.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_aes.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_aes.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_aes.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_aes.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_aes.c' object='implementations/openssl/3/runtest-test_iut_aes.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_aes.obj `if test -f 'test_app_aes.c'; then $(CYGPATH_W) 'test_app_aes.c'; else $(CYGPATH_W) '$(srcdir)/test_app_aes.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_aes.obj `if test -f 'implementations/openssl/3/test_iut_aes.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_aes.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_aes.c'; fi`
 
-runtest-test_app_cmac.o: test_app_cmac.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_cmac.o -MD -MP -MF $(DEPDIR)/runtest-test_app_cmac.Tpo -c -o runtest-test_app_cmac.o `test -f 'test_app_cmac.c' || echo '$(srcdir)/'`test_app_cmac.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_cmac.Tpo $(DEPDIR)/runtest-test_app_cmac.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_cmac.c' object='runtest-test_app_cmac.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_cmac.o: implementations/openssl/3/test_iut_cmac.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_cmac.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_cmac.Tpo -c -o implementations/openssl/3/runtest-test_iut_cmac.o `test -f 'implementations/openssl/3/test_iut_cmac.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_cmac.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_cmac.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_cmac.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_cmac.c' object='implementations/openssl/3/runtest-test_iut_cmac.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_cmac.o `test -f 'test_app_cmac.c' || echo '$(srcdir)/'`test_app_cmac.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_cmac.o `test -f 'implementations/openssl/3/test_iut_cmac.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_cmac.c
 
-runtest-test_app_cmac.obj: test_app_cmac.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_cmac.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_cmac.Tpo -c -o runtest-test_app_cmac.obj `if test -f 'test_app_cmac.c'; then $(CYGPATH_W) 'test_app_cmac.c'; else $(CYGPATH_W) '$(srcdir)/test_app_cmac.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_cmac.Tpo $(DEPDIR)/runtest-test_app_cmac.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_cmac.c' object='runtest-test_app_cmac.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_cmac.obj: implementations/openssl/3/test_iut_cmac.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_cmac.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_cmac.Tpo -c -o implementations/openssl/3/runtest-test_iut_cmac.obj `if test -f 'implementations/openssl/3/test_iut_cmac.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_cmac.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_cmac.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_cmac.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_cmac.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_cmac.c' object='implementations/openssl/3/runtest-test_iut_cmac.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_cmac.obj `if test -f 'test_app_cmac.c'; then $(CYGPATH_W) 'test_app_cmac.c'; else $(CYGPATH_W) '$(srcdir)/test_app_cmac.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_cmac.obj `if test -f 'implementations/openssl/3/test_iut_cmac.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_cmac.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_cmac.c'; fi`
 
-runtest-test_app_des.o: test_app_des.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_des.o -MD -MP -MF $(DEPDIR)/runtest-test_app_des.Tpo -c -o runtest-test_app_des.o `test -f 'test_app_des.c' || echo '$(srcdir)/'`test_app_des.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_des.Tpo $(DEPDIR)/runtest-test_app_des.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_des.c' object='runtest-test_app_des.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_des.o: implementations/openssl/3/test_iut_des.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_des.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_des.Tpo -c -o implementations/openssl/3/runtest-test_iut_des.o `test -f 'implementations/openssl/3/test_iut_des.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_des.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_des.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_des.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_des.c' object='implementations/openssl/3/runtest-test_iut_des.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_des.o `test -f 'test_app_des.c' || echo '$(srcdir)/'`test_app_des.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_des.o `test -f 'implementations/openssl/3/test_iut_des.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_des.c
 
-runtest-test_app_des.obj: test_app_des.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_des.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_des.Tpo -c -o runtest-test_app_des.obj `if test -f 'test_app_des.c'; then $(CYGPATH_W) 'test_app_des.c'; else $(CYGPATH_W) '$(srcdir)/test_app_des.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_des.Tpo $(DEPDIR)/runtest-test_app_des.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_des.c' object='runtest-test_app_des.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_des.obj: implementations/openssl/3/test_iut_des.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_des.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_des.Tpo -c -o implementations/openssl/3/runtest-test_iut_des.obj `if test -f 'implementations/openssl/3/test_iut_des.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_des.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_des.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_des.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_des.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_des.c' object='implementations/openssl/3/runtest-test_iut_des.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_des.obj `if test -f 'test_app_des.c'; then $(CYGPATH_W) 'test_app_des.c'; else $(CYGPATH_W) '$(srcdir)/test_app_des.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_des.obj `if test -f 'implementations/openssl/3/test_iut_des.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_des.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_des.c'; fi`
 
-runtest-test_app_drbg.o: test_app_drbg.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_drbg.o -MD -MP -MF $(DEPDIR)/runtest-test_app_drbg.Tpo -c -o runtest-test_app_drbg.o `test -f 'test_app_drbg.c' || echo '$(srcdir)/'`test_app_drbg.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_drbg.Tpo $(DEPDIR)/runtest-test_app_drbg.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_drbg.c' object='runtest-test_app_drbg.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_drbg.o: implementations/openssl/3/test_iut_drbg.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_drbg.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_drbg.Tpo -c -o implementations/openssl/3/runtest-test_iut_drbg.o `test -f 'implementations/openssl/3/test_iut_drbg.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_drbg.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_drbg.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_drbg.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_drbg.c' object='implementations/openssl/3/runtest-test_iut_drbg.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_drbg.o `test -f 'test_app_drbg.c' || echo '$(srcdir)/'`test_app_drbg.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_drbg.o `test -f 'implementations/openssl/3/test_iut_drbg.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_drbg.c
 
-runtest-test_app_drbg.obj: test_app_drbg.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_drbg.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_drbg.Tpo -c -o runtest-test_app_drbg.obj `if test -f 'test_app_drbg.c'; then $(CYGPATH_W) 'test_app_drbg.c'; else $(CYGPATH_W) '$(srcdir)/test_app_drbg.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_drbg.Tpo $(DEPDIR)/runtest-test_app_drbg.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_drbg.c' object='runtest-test_app_drbg.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_drbg.obj: implementations/openssl/3/test_iut_drbg.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_drbg.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_drbg.Tpo -c -o implementations/openssl/3/runtest-test_iut_drbg.obj `if test -f 'implementations/openssl/3/test_iut_drbg.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_drbg.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_drbg.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_drbg.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_drbg.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_drbg.c' object='implementations/openssl/3/runtest-test_iut_drbg.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_drbg.obj `if test -f 'test_app_drbg.c'; then $(CYGPATH_W) 'test_app_drbg.c'; else $(CYGPATH_W) '$(srcdir)/test_app_drbg.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_drbg.obj `if test -f 'implementations/openssl/3/test_iut_drbg.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_drbg.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_drbg.c'; fi`
 
-runtest-test_app_ecdsa.o: test_app_ecdsa.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_ecdsa.o -MD -MP -MF $(DEPDIR)/runtest-test_app_ecdsa.Tpo -c -o runtest-test_app_ecdsa.o `test -f 'test_app_ecdsa.c' || echo '$(srcdir)/'`test_app_ecdsa.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_ecdsa.Tpo $(DEPDIR)/runtest-test_app_ecdsa.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_ecdsa.c' object='runtest-test_app_ecdsa.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_ecdsa.o: implementations/openssl/3/test_iut_ecdsa.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_ecdsa.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_ecdsa.Tpo -c -o implementations/openssl/3/runtest-test_iut_ecdsa.o `test -f 'implementations/openssl/3/test_iut_ecdsa.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_ecdsa.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_ecdsa.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_ecdsa.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_ecdsa.c' object='implementations/openssl/3/runtest-test_iut_ecdsa.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_ecdsa.o `test -f 'test_app_ecdsa.c' || echo '$(srcdir)/'`test_app_ecdsa.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_ecdsa.o `test -f 'implementations/openssl/3/test_iut_ecdsa.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_ecdsa.c
 
-runtest-test_app_ecdsa.obj: test_app_ecdsa.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_ecdsa.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_ecdsa.Tpo -c -o runtest-test_app_ecdsa.obj `if test -f 'test_app_ecdsa.c'; then $(CYGPATH_W) 'test_app_ecdsa.c'; else $(CYGPATH_W) '$(srcdir)/test_app_ecdsa.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_ecdsa.Tpo $(DEPDIR)/runtest-test_app_ecdsa.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_ecdsa.c' object='runtest-test_app_ecdsa.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_ecdsa.obj: implementations/openssl/3/test_iut_ecdsa.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_ecdsa.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_ecdsa.Tpo -c -o implementations/openssl/3/runtest-test_iut_ecdsa.obj `if test -f 'implementations/openssl/3/test_iut_ecdsa.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_ecdsa.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_ecdsa.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_ecdsa.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_ecdsa.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_ecdsa.c' object='implementations/openssl/3/runtest-test_iut_ecdsa.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_ecdsa.obj `if test -f 'test_app_ecdsa.c'; then $(CYGPATH_W) 'test_app_ecdsa.c'; else $(CYGPATH_W) '$(srcdir)/test_app_ecdsa.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_ecdsa.obj `if test -f 'implementations/openssl/3/test_iut_ecdsa.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_ecdsa.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_ecdsa.c'; fi`
 
-runtest-test_app_hmac.o: test_app_hmac.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_hmac.o -MD -MP -MF $(DEPDIR)/runtest-test_app_hmac.Tpo -c -o runtest-test_app_hmac.o `test -f 'test_app_hmac.c' || echo '$(srcdir)/'`test_app_hmac.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_hmac.Tpo $(DEPDIR)/runtest-test_app_hmac.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_hmac.c' object='runtest-test_app_hmac.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_hmac.o: implementations/openssl/3/test_iut_hmac.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_hmac.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hmac.Tpo -c -o implementations/openssl/3/runtest-test_iut_hmac.o `test -f 'implementations/openssl/3/test_iut_hmac.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_hmac.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hmac.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hmac.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_hmac.c' object='implementations/openssl/3/runtest-test_iut_hmac.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_hmac.o `test -f 'test_app_hmac.c' || echo '$(srcdir)/'`test_app_hmac.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_hmac.o `test -f 'implementations/openssl/3/test_iut_hmac.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_hmac.c
 
-runtest-test_app_hmac.obj: test_app_hmac.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_hmac.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_hmac.Tpo -c -o runtest-test_app_hmac.obj `if test -f 'test_app_hmac.c'; then $(CYGPATH_W) 'test_app_hmac.c'; else $(CYGPATH_W) '$(srcdir)/test_app_hmac.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_hmac.Tpo $(DEPDIR)/runtest-test_app_hmac.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_hmac.c' object='runtest-test_app_hmac.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_hmac.obj: implementations/openssl/3/test_iut_hmac.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_hmac.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hmac.Tpo -c -o implementations/openssl/3/runtest-test_iut_hmac.obj `if test -f 'implementations/openssl/3/test_iut_hmac.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_hmac.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_hmac.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hmac.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hmac.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_hmac.c' object='implementations/openssl/3/runtest-test_iut_hmac.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_hmac.obj `if test -f 'test_app_hmac.c'; then $(CYGPATH_W) 'test_app_hmac.c'; else $(CYGPATH_W) '$(srcdir)/test_app_hmac.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_hmac.obj `if test -f 'implementations/openssl/3/test_iut_hmac.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_hmac.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_hmac.c'; fi`
 
-runtest-test_app_kas_ecc.o: test_app_kas_ecc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_kas_ecc.o -MD -MP -MF $(DEPDIR)/runtest-test_app_kas_ecc.Tpo -c -o runtest-test_app_kas_ecc.o `test -f 'test_app_kas_ecc.c' || echo '$(srcdir)/'`test_app_kas_ecc.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_kas_ecc.Tpo $(DEPDIR)/runtest-test_app_kas_ecc.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_kas_ecc.c' object='runtest-test_app_kas_ecc.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_kas_ecc.o: implementations/openssl/3/test_iut_kas_ecc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_kas_ecc.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ecc.Tpo -c -o implementations/openssl/3/runtest-test_iut_kas_ecc.o `test -f 'implementations/openssl/3/test_iut_kas_ecc.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_kas_ecc.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ecc.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ecc.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_kas_ecc.c' object='implementations/openssl/3/runtest-test_iut_kas_ecc.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_kas_ecc.o `test -f 'test_app_kas_ecc.c' || echo '$(srcdir)/'`test_app_kas_ecc.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_kas_ecc.o `test -f 'implementations/openssl/3/test_iut_kas_ecc.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_kas_ecc.c
 
-runtest-test_app_kas_ecc.obj: test_app_kas_ecc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_kas_ecc.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_kas_ecc.Tpo -c -o runtest-test_app_kas_ecc.obj `if test -f 'test_app_kas_ecc.c'; then $(CYGPATH_W) 'test_app_kas_ecc.c'; else $(CYGPATH_W) '$(srcdir)/test_app_kas_ecc.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_kas_ecc.Tpo $(DEPDIR)/runtest-test_app_kas_ecc.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_kas_ecc.c' object='runtest-test_app_kas_ecc.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_kas_ecc.obj: implementations/openssl/3/test_iut_kas_ecc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_kas_ecc.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ecc.Tpo -c -o implementations/openssl/3/runtest-test_iut_kas_ecc.obj `if test -f 'implementations/openssl/3/test_iut_kas_ecc.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_kas_ecc.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_kas_ecc.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ecc.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ecc.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_kas_ecc.c' object='implementations/openssl/3/runtest-test_iut_kas_ecc.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_kas_ecc.obj `if test -f 'test_app_kas_ecc.c'; then $(CYGPATH_W) 'test_app_kas_ecc.c'; else $(CYGPATH_W) '$(srcdir)/test_app_kas_ecc.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_kas_ecc.obj `if test -f 'implementations/openssl/3/test_iut_kas_ecc.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_kas_ecc.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_kas_ecc.c'; fi`
 
-runtest-test_app_kas_ffc.o: test_app_kas_ffc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_kas_ffc.o -MD -MP -MF $(DEPDIR)/runtest-test_app_kas_ffc.Tpo -c -o runtest-test_app_kas_ffc.o `test -f 'test_app_kas_ffc.c' || echo '$(srcdir)/'`test_app_kas_ffc.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_kas_ffc.Tpo $(DEPDIR)/runtest-test_app_kas_ffc.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_kas_ffc.c' object='runtest-test_app_kas_ffc.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_kas_ffc.o: implementations/openssl/3/test_iut_kas_ffc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_kas_ffc.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ffc.Tpo -c -o implementations/openssl/3/runtest-test_iut_kas_ffc.o `test -f 'implementations/openssl/3/test_iut_kas_ffc.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_kas_ffc.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ffc.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ffc.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_kas_ffc.c' object='implementations/openssl/3/runtest-test_iut_kas_ffc.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_kas_ffc.o `test -f 'test_app_kas_ffc.c' || echo '$(srcdir)/'`test_app_kas_ffc.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_kas_ffc.o `test -f 'implementations/openssl/3/test_iut_kas_ffc.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_kas_ffc.c
 
-runtest-test_app_kas_ffc.obj: test_app_kas_ffc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_kas_ffc.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_kas_ffc.Tpo -c -o runtest-test_app_kas_ffc.obj `if test -f 'test_app_kas_ffc.c'; then $(CYGPATH_W) 'test_app_kas_ffc.c'; else $(CYGPATH_W) '$(srcdir)/test_app_kas_ffc.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_kas_ffc.Tpo $(DEPDIR)/runtest-test_app_kas_ffc.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_kas_ffc.c' object='runtest-test_app_kas_ffc.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_kas_ffc.obj: implementations/openssl/3/test_iut_kas_ffc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_kas_ffc.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ffc.Tpo -c -o implementations/openssl/3/runtest-test_iut_kas_ffc.obj `if test -f 'implementations/openssl/3/test_iut_kas_ffc.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_kas_ffc.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_kas_ffc.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ffc.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ffc.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_kas_ffc.c' object='implementations/openssl/3/runtest-test_iut_kas_ffc.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_kas_ffc.obj `if test -f 'test_app_kas_ffc.c'; then $(CYGPATH_W) 'test_app_kas_ffc.c'; else $(CYGPATH_W) '$(srcdir)/test_app_kas_ffc.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_kas_ffc.obj `if test -f 'implementations/openssl/3/test_iut_kas_ffc.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_kas_ffc.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_kas_ffc.c'; fi`
 
-runtest-test_app_kas_ifc.o: test_app_kas_ifc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_kas_ifc.o -MD -MP -MF $(DEPDIR)/runtest-test_app_kas_ifc.Tpo -c -o runtest-test_app_kas_ifc.o `test -f 'test_app_kas_ifc.c' || echo '$(srcdir)/'`test_app_kas_ifc.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_kas_ifc.Tpo $(DEPDIR)/runtest-test_app_kas_ifc.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_kas_ifc.c' object='runtest-test_app_kas_ifc.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_kas_ifc.o: implementations/openssl/3/test_iut_kas_ifc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_kas_ifc.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ifc.Tpo -c -o implementations/openssl/3/runtest-test_iut_kas_ifc.o `test -f 'implementations/openssl/3/test_iut_kas_ifc.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_kas_ifc.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ifc.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ifc.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_kas_ifc.c' object='implementations/openssl/3/runtest-test_iut_kas_ifc.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_kas_ifc.o `test -f 'test_app_kas_ifc.c' || echo '$(srcdir)/'`test_app_kas_ifc.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_kas_ifc.o `test -f 'implementations/openssl/3/test_iut_kas_ifc.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_kas_ifc.c
 
-runtest-test_app_kas_ifc.obj: test_app_kas_ifc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_kas_ifc.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_kas_ifc.Tpo -c -o runtest-test_app_kas_ifc.obj `if test -f 'test_app_kas_ifc.c'; then $(CYGPATH_W) 'test_app_kas_ifc.c'; else $(CYGPATH_W) '$(srcdir)/test_app_kas_ifc.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_kas_ifc.Tpo $(DEPDIR)/runtest-test_app_kas_ifc.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_kas_ifc.c' object='runtest-test_app_kas_ifc.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_kas_ifc.obj: implementations/openssl/3/test_iut_kas_ifc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_kas_ifc.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ifc.Tpo -c -o implementations/openssl/3/runtest-test_iut_kas_ifc.obj `if test -f 'implementations/openssl/3/test_iut_kas_ifc.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_kas_ifc.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_kas_ifc.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ifc.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ifc.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_kas_ifc.c' object='implementations/openssl/3/runtest-test_iut_kas_ifc.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_kas_ifc.obj `if test -f 'test_app_kas_ifc.c'; then $(CYGPATH_W) 'test_app_kas_ifc.c'; else $(CYGPATH_W) '$(srcdir)/test_app_kas_ifc.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_kas_ifc.obj `if test -f 'implementations/openssl/3/test_iut_kas_ifc.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_kas_ifc.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_kas_ifc.c'; fi`
 
-runtest-test_app_rsa_keygen.o: test_app_rsa_keygen.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_rsa_keygen.o -MD -MP -MF $(DEPDIR)/runtest-test_app_rsa_keygen.Tpo -c -o runtest-test_app_rsa_keygen.o `test -f 'test_app_rsa_keygen.c' || echo '$(srcdir)/'`test_app_rsa_keygen.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_rsa_keygen.Tpo $(DEPDIR)/runtest-test_app_rsa_keygen.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_rsa_keygen.c' object='runtest-test_app_rsa_keygen.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_rsa_keygen.o: implementations/openssl/3/test_iut_rsa_keygen.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_rsa_keygen.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_keygen.Tpo -c -o implementations/openssl/3/runtest-test_iut_rsa_keygen.o `test -f 'implementations/openssl/3/test_iut_rsa_keygen.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_rsa_keygen.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_keygen.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_keygen.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_rsa_keygen.c' object='implementations/openssl/3/runtest-test_iut_rsa_keygen.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_rsa_keygen.o `test -f 'test_app_rsa_keygen.c' || echo '$(srcdir)/'`test_app_rsa_keygen.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_rsa_keygen.o `test -f 'implementations/openssl/3/test_iut_rsa_keygen.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_rsa_keygen.c
 
-runtest-test_app_rsa_keygen.obj: test_app_rsa_keygen.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_rsa_keygen.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_rsa_keygen.Tpo -c -o runtest-test_app_rsa_keygen.obj `if test -f 'test_app_rsa_keygen.c'; then $(CYGPATH_W) 'test_app_rsa_keygen.c'; else $(CYGPATH_W) '$(srcdir)/test_app_rsa_keygen.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_rsa_keygen.Tpo $(DEPDIR)/runtest-test_app_rsa_keygen.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_rsa_keygen.c' object='runtest-test_app_rsa_keygen.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_rsa_keygen.obj: implementations/openssl/3/test_iut_rsa_keygen.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_rsa_keygen.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_keygen.Tpo -c -o implementations/openssl/3/runtest-test_iut_rsa_keygen.obj `if test -f 'implementations/openssl/3/test_iut_rsa_keygen.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_rsa_keygen.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_rsa_keygen.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_keygen.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_keygen.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_rsa_keygen.c' object='implementations/openssl/3/runtest-test_iut_rsa_keygen.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_rsa_keygen.obj `if test -f 'test_app_rsa_keygen.c'; then $(CYGPATH_W) 'test_app_rsa_keygen.c'; else $(CYGPATH_W) '$(srcdir)/test_app_rsa_keygen.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_rsa_keygen.obj `if test -f 'implementations/openssl/3/test_iut_rsa_keygen.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_rsa_keygen.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_rsa_keygen.c'; fi`
 
-runtest-test_app_rsa_sig.o: test_app_rsa_sig.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_rsa_sig.o -MD -MP -MF $(DEPDIR)/runtest-test_app_rsa_sig.Tpo -c -o runtest-test_app_rsa_sig.o `test -f 'test_app_rsa_sig.c' || echo '$(srcdir)/'`test_app_rsa_sig.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_rsa_sig.Tpo $(DEPDIR)/runtest-test_app_rsa_sig.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_rsa_sig.c' object='runtest-test_app_rsa_sig.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_rsa_sig.o: implementations/openssl/3/test_iut_rsa_sig.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_rsa_sig.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_sig.Tpo -c -o implementations/openssl/3/runtest-test_iut_rsa_sig.o `test -f 'implementations/openssl/3/test_iut_rsa_sig.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_rsa_sig.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_sig.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_sig.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_rsa_sig.c' object='implementations/openssl/3/runtest-test_iut_rsa_sig.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_rsa_sig.o `test -f 'test_app_rsa_sig.c' || echo '$(srcdir)/'`test_app_rsa_sig.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_rsa_sig.o `test -f 'implementations/openssl/3/test_iut_rsa_sig.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_rsa_sig.c
 
-runtest-test_app_rsa_sig.obj: test_app_rsa_sig.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_rsa_sig.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_rsa_sig.Tpo -c -o runtest-test_app_rsa_sig.obj `if test -f 'test_app_rsa_sig.c'; then $(CYGPATH_W) 'test_app_rsa_sig.c'; else $(CYGPATH_W) '$(srcdir)/test_app_rsa_sig.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_rsa_sig.Tpo $(DEPDIR)/runtest-test_app_rsa_sig.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_rsa_sig.c' object='runtest-test_app_rsa_sig.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_rsa_sig.obj: implementations/openssl/3/test_iut_rsa_sig.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_rsa_sig.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_sig.Tpo -c -o implementations/openssl/3/runtest-test_iut_rsa_sig.obj `if test -f 'implementations/openssl/3/test_iut_rsa_sig.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_rsa_sig.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_rsa_sig.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_sig.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_sig.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_rsa_sig.c' object='implementations/openssl/3/runtest-test_iut_rsa_sig.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_rsa_sig.obj `if test -f 'test_app_rsa_sig.c'; then $(CYGPATH_W) 'test_app_rsa_sig.c'; else $(CYGPATH_W) '$(srcdir)/test_app_rsa_sig.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_rsa_sig.obj `if test -f 'implementations/openssl/3/test_iut_rsa_sig.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_rsa_sig.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_rsa_sig.c'; fi`
 
-runtest-test_app_sha.o: test_app_sha.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_sha.o -MD -MP -MF $(DEPDIR)/runtest-test_app_sha.Tpo -c -o runtest-test_app_sha.o `test -f 'test_app_sha.c' || echo '$(srcdir)/'`test_app_sha.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_sha.Tpo $(DEPDIR)/runtest-test_app_sha.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_sha.c' object='runtest-test_app_sha.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_hash.o: implementations/openssl/3/test_iut_hash.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_hash.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hash.Tpo -c -o implementations/openssl/3/runtest-test_iut_hash.o `test -f 'implementations/openssl/3/test_iut_hash.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_hash.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hash.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hash.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_hash.c' object='implementations/openssl/3/runtest-test_iut_hash.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_sha.o `test -f 'test_app_sha.c' || echo '$(srcdir)/'`test_app_sha.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_hash.o `test -f 'implementations/openssl/3/test_iut_hash.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_hash.c
 
-runtest-test_app_sha.obj: test_app_sha.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_sha.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_sha.Tpo -c -o runtest-test_app_sha.obj `if test -f 'test_app_sha.c'; then $(CYGPATH_W) 'test_app_sha.c'; else $(CYGPATH_W) '$(srcdir)/test_app_sha.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_sha.Tpo $(DEPDIR)/runtest-test_app_sha.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_sha.c' object='runtest-test_app_sha.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_hash.obj: implementations/openssl/3/test_iut_hash.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_hash.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hash.Tpo -c -o implementations/openssl/3/runtest-test_iut_hash.obj `if test -f 'implementations/openssl/3/test_iut_hash.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_hash.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_hash.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hash.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hash.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_hash.c' object='implementations/openssl/3/runtest-test_iut_hash.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_sha.obj `if test -f 'test_app_sha.c'; then $(CYGPATH_W) 'test_app_sha.c'; else $(CYGPATH_W) '$(srcdir)/test_app_sha.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_hash.obj `if test -f 'implementations/openssl/3/test_iut_hash.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_hash.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_hash.c'; fi`
 
-runtest-test_app_safe_primes.o: test_app_safe_primes.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_safe_primes.o -MD -MP -MF $(DEPDIR)/runtest-test_app_safe_primes.Tpo -c -o runtest-test_app_safe_primes.o `test -f 'test_app_safe_primes.c' || echo '$(srcdir)/'`test_app_safe_primes.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_safe_primes.Tpo $(DEPDIR)/runtest-test_app_safe_primes.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_safe_primes.c' object='runtest-test_app_safe_primes.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_safe_primes.o: implementations/openssl/3/test_iut_safe_primes.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_safe_primes.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_safe_primes.Tpo -c -o implementations/openssl/3/runtest-test_iut_safe_primes.o `test -f 'implementations/openssl/3/test_iut_safe_primes.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_safe_primes.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_safe_primes.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_safe_primes.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_safe_primes.c' object='implementations/openssl/3/runtest-test_iut_safe_primes.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_safe_primes.o `test -f 'test_app_safe_primes.c' || echo '$(srcdir)/'`test_app_safe_primes.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_safe_primes.o `test -f 'implementations/openssl/3/test_iut_safe_primes.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_safe_primes.c
 
-runtest-test_app_safe_primes.obj: test_app_safe_primes.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_safe_primes.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_safe_primes.Tpo -c -o runtest-test_app_safe_primes.obj `if test -f 'test_app_safe_primes.c'; then $(CYGPATH_W) 'test_app_safe_primes.c'; else $(CYGPATH_W) '$(srcdir)/test_app_safe_primes.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_safe_primes.Tpo $(DEPDIR)/runtest-test_app_safe_primes.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_safe_primes.c' object='runtest-test_app_safe_primes.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_safe_primes.obj: implementations/openssl/3/test_iut_safe_primes.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_safe_primes.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_safe_primes.Tpo -c -o implementations/openssl/3/runtest-test_iut_safe_primes.obj `if test -f 'implementations/openssl/3/test_iut_safe_primes.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_safe_primes.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_safe_primes.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_safe_primes.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_safe_primes.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_safe_primes.c' object='implementations/openssl/3/runtest-test_iut_safe_primes.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_safe_primes.obj `if test -f 'test_app_safe_primes.c'; then $(CYGPATH_W) 'test_app_safe_primes.c'; else $(CYGPATH_W) '$(srcdir)/test_app_safe_primes.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_safe_primes.obj `if test -f 'implementations/openssl/3/test_iut_safe_primes.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_safe_primes.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_safe_primes.c'; fi`
 
-runtest-test_app_kda.o: test_app_kda.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_kda.o -MD -MP -MF $(DEPDIR)/runtest-test_app_kda.Tpo -c -o runtest-test_app_kda.o `test -f 'test_app_kda.c' || echo '$(srcdir)/'`test_app_kda.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_kda.Tpo $(DEPDIR)/runtest-test_app_kda.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_kda.c' object='runtest-test_app_kda.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_kda.o: implementations/openssl/3/test_iut_kda.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_kda.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kda.Tpo -c -o implementations/openssl/3/runtest-test_iut_kda.o `test -f 'implementations/openssl/3/test_iut_kda.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_kda.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kda.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kda.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_kda.c' object='implementations/openssl/3/runtest-test_iut_kda.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_kda.o `test -f 'test_app_kda.c' || echo '$(srcdir)/'`test_app_kda.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_kda.o `test -f 'implementations/openssl/3/test_iut_kda.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_kda.c
 
-runtest-test_app_kda.obj: test_app_kda.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_kda.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_kda.Tpo -c -o runtest-test_app_kda.obj `if test -f 'test_app_kda.c'; then $(CYGPATH_W) 'test_app_kda.c'; else $(CYGPATH_W) '$(srcdir)/test_app_kda.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_kda.Tpo $(DEPDIR)/runtest-test_app_kda.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_kda.c' object='runtest-test_app_kda.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_kda.obj: implementations/openssl/3/test_iut_kda.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_kda.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kda.Tpo -c -o implementations/openssl/3/runtest-test_iut_kda.obj `if test -f 'implementations/openssl/3/test_iut_kda.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_kda.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_kda.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kda.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kda.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_kda.c' object='implementations/openssl/3/runtest-test_iut_kda.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_kda.obj `if test -f 'test_app_kda.c'; then $(CYGPATH_W) 'test_app_kda.c'; else $(CYGPATH_W) '$(srcdir)/test_app_kda.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_kda.obj `if test -f 'implementations/openssl/3/test_iut_kda.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_kda.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_kda.c'; fi`
 
-runtest-test_app_kmac.o: test_app_kmac.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_kmac.o -MD -MP -MF $(DEPDIR)/runtest-test_app_kmac.Tpo -c -o runtest-test_app_kmac.o `test -f 'test_app_kmac.c' || echo '$(srcdir)/'`test_app_kmac.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_kmac.Tpo $(DEPDIR)/runtest-test_app_kmac.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_kmac.c' object='runtest-test_app_kmac.o' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_kmac.o: implementations/openssl/3/test_iut_kmac.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_kmac.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kmac.Tpo -c -o implementations/openssl/3/runtest-test_iut_kmac.o `test -f 'implementations/openssl/3/test_iut_kmac.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_kmac.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kmac.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kmac.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_kmac.c' object='implementations/openssl/3/runtest-test_iut_kmac.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_kmac.o `test -f 'test_app_kmac.c' || echo '$(srcdir)/'`test_app_kmac.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_kmac.o `test -f 'implementations/openssl/3/test_iut_kmac.c' || echo '$(srcdir)/'`implementations/openssl/3/test_iut_kmac.c
 
-runtest-test_app_kmac.obj: test_app_kmac.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT runtest-test_app_kmac.obj -MD -MP -MF $(DEPDIR)/runtest-test_app_kmac.Tpo -c -o runtest-test_app_kmac.obj `if test -f 'test_app_kmac.c'; then $(CYGPATH_W) 'test_app_kmac.c'; else $(CYGPATH_W) '$(srcdir)/test_app_kmac.c'; fi`
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/runtest-test_app_kmac.Tpo $(DEPDIR)/runtest-test_app_kmac.Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='test_app_kmac.c' object='runtest-test_app_kmac.obj' libtool=no @AMDEPBACKSLASH@
+implementations/openssl/3/runtest-test_iut_kmac.obj: implementations/openssl/3/test_iut_kmac.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/runtest-test_iut_kmac.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kmac.Tpo -c -o implementations/openssl/3/runtest-test_iut_kmac.obj `if test -f 'implementations/openssl/3/test_iut_kmac.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_kmac.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_kmac.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kmac.Tpo implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kmac.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/test_iut_kmac.c' object='implementations/openssl/3/runtest-test_iut_kmac.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o runtest-test_app_kmac.obj `if test -f 'test_app_kmac.c'; then $(CYGPATH_W) 'test_app_kmac.c'; else $(CYGPATH_W) '$(srcdir)/test_app_kmac.c'; fi`
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(runtest_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/runtest-test_iut_kmac.obj `if test -f 'implementations/openssl/3/test_iut_kmac.c'; then $(CYGPATH_W) 'implementations/openssl/3/test_iut_kmac.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/test_iut_kmac.c'; fi`
 
 mostlyclean-libtool:
 	-rm -f *.lo
@@ -1555,6 +1629,8 @@ clean-generic:
 distclean-generic:
 	-test -z "$(CONFIG_CLEAN_FILES)" || rm -f $(CONFIG_CLEAN_FILES)
 	-test . = "$(srcdir)" || test -z "$(CONFIG_CLEAN_VPATH_FILES)" || rm -f $(CONFIG_CLEAN_VPATH_FILES)
+	-rm -f implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+	-rm -f implementations/openssl/3/$(am__dirstamp)
 
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
@@ -1601,22 +1677,22 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/runtest-test_acvp_safe_primes.Po
 	-rm -f ./$(DEPDIR)/runtest-test_acvp_transport.Po
 	-rm -f ./$(DEPDIR)/runtest-test_acvp_utils.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_aes.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_cmac.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_des.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_drbg.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_ecdsa.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_hmac.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_kas_ecc.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_kas_ffc.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_kas_ifc.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_kda.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_kmac.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_rsa_keygen.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_rsa_sig.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_safe_primes.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_sha.Po
 	-rm -f ./$(DEPDIR)/runtest-ut_common.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_aes.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_cmac.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_des.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_drbg.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_ecdsa.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hash.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hmac.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ecc.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ffc.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ifc.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kda.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kmac.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_keygen.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_sig.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_safe_primes.Po
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -1698,22 +1774,22 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/runtest-test_acvp_safe_primes.Po
 	-rm -f ./$(DEPDIR)/runtest-test_acvp_transport.Po
 	-rm -f ./$(DEPDIR)/runtest-test_acvp_utils.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_aes.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_cmac.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_des.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_drbg.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_ecdsa.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_hmac.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_kas_ecc.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_kas_ffc.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_kas_ifc.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_kda.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_kmac.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_rsa_keygen.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_rsa_sig.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_safe_primes.Po
-	-rm -f ./$(DEPDIR)/runtest-test_app_sha.Po
 	-rm -f ./$(DEPDIR)/runtest-ut_common.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_aes.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_cmac.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_des.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_drbg.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_ecdsa.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hash.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_hmac.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ecc.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ffc.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kas_ifc.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kda.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_kmac.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_keygen.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_rsa_sig.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/runtest-test_iut_safe_primes.Po
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 

--- a/test/app_common.c
+++ b/test/app_common.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2021, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/test/create_session.c
+++ b/test/create_session.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2019, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,7 +11,7 @@
 
 #include "ut_common.h"
 
-ACVP_CTX *ctx;
+static ACVP_CTX *ctx;
 
 Test(CreateSession, properly) {
     ACVP_RESULT rv;

--- a/test/implementations/openssl/3/iut_common.h
+++ b/test/implementations/openssl/3/iut_common.h
@@ -8,12 +8,9 @@
  * https://github.com/cisco/libacvp/LICENSE
  */
 
-#ifndef ACVP_UT_APP_COMMON_H
-#define ACVP_UT_APP_COMMON_H
+#ifndef ACVP_UT_IUT_COMMON_H
+#define ACVP_UT_IUT_COMMON_H
 
-#include "app_lcl.h"
-
-ACVP_RESULT totp(char **token, int token_max);
-void dummy_call(void);
+#include "implementations/openssl/3/iut.h"
 
 #endif

--- a/test/implementations/openssl/3/test_iut_aes.c
+++ b/test/implementations/openssl/3/test_iut_aes.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2020, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,12 +10,13 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_SYM_CIPHER_TC *aes_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 int initialize_aes_tc(ACVP_SYM_CIPHER_TC *aes_tc, int alg_id, char *pt, 
                       int pt_len, char *ct, int ct_len, char *key, int key_len, char *aad,

--- a/test/implementations/openssl/3/test_iut_cmac.c
+++ b/test/implementations/openssl/3/test_iut_cmac.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2020, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,13 +14,14 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 #include "acvp/acvp.h"
 
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_CMAC_TC *cmac_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 int initialize_cmac_tc(ACVP_CMAC_TC *cmac_tc,
                        int alg_id, char *mac,

--- a/test/implementations/openssl/3/test_iut_des.c
+++ b/test/implementations/openssl/3/test_iut_des.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2020, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,12 +10,13 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_SYM_CIPHER_TC *des_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 int initialize_des_tc(ACVP_SYM_CIPHER_TC *des_tc, int alg_id, char *pt, 
                       int pt_len, char *ct, int ct_len, char *key, int key_len,

--- a/test/implementations/openssl/3/test_iut_drbg.c
+++ b/test/implementations/openssl/3/test_iut_drbg.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2023, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,14 +10,13 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_DRBG_TC *drbg_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 void free_drbg_tc(ACVP_DRBG_TC *stc) {
     if (stc->drb) free(stc->drb);
@@ -392,5 +391,3 @@ Test(APP_DRBG_HANDLER, no_perso) {
     free_drbg_tc(drbg_tc);
     free(test_case);
 }
-
-#endif

--- a/test/implementations/openssl/3/test_iut_ecdsa.c
+++ b/test/implementations/openssl/3/test_iut_ecdsa.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2023, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,14 +14,13 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_ECDSA_TC *ecdsa_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 int initialize_ecdsa_tc(ACVP_CIPHER cipher,
                         ACVP_ECDSA_TC *stc,
@@ -381,6 +380,3 @@ Test(APP_ECDSA_HANDLER, missing_sigver_qx_qy) {
     if (test_case) free(test_case);
     free(ecdsa_tc);
 }
-
-#endif
-

--- a/test/implementations/openssl/3/test_iut_hash.c
+++ b/test/implementations/openssl/3/test_iut_hash.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2019, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,12 +14,13 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_HASH_TC *hash_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 int initialize_sha_tc(ACVP_HASH_TC *hash_tc, int alg_id, char *msg, int msg_len, int test_type, int corrupt) {
     memset(hash_tc, 0x0, sizeof(ACVP_HASH_TC));

--- a/test/implementations/openssl/3/test_iut_hmac.c
+++ b/test/implementations/openssl/3/test_iut_hmac.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2020, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,12 +14,13 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_HMAC_TC *hmac_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 int initialize_hmac_tc(ACVP_HMAC_TC *hmac_tc, int alg_id, char *msg, int msg_len, char *key, int key_len, int corrupt) {
     memset(hmac_tc, 0x0, sizeof(ACVP_HMAC_TC));

--- a/test/implementations/openssl/3/test_iut_kas_ecc.c
+++ b/test/implementations/openssl/3/test_iut_kas_ecc.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2023, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,14 +14,13 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_KAS_ECC_TC *kas_ecc_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 void free_kas_ecc_tc(ACVP_KAS_ECC_TC *stc) {
     if (stc->chash) free(stc->chash);
@@ -358,6 +357,3 @@ Test(APP_KAS_ECC_HANDLER, missing_piy) {
     free_kas_ecc_tc(kas_ecc_tc);
     free(test_case);
 }
-
-#endif
-

--- a/test/implementations/openssl/3/test_iut_kas_ffc.c
+++ b/test/implementations/openssl/3/test_iut_kas_ffc.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2023, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,14 +14,15 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_KAS_FFC_TC *kas_ffc_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined OPENSSL_NO_DSA
+#if !defined OPENSSL_NO_DSA
 
 void free_kas_ffc_tc(ACVP_KAS_FFC_TC *stc) {
     if (stc->piut) free(stc->piut);

--- a/test/implementations/openssl/3/test_iut_kas_ifc.c
+++ b/test/implementations/openssl/3/test_iut_kas_ifc.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2023, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,16 +14,14 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
-
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 
 /* Note: currently tests KAS1 only, and only basic key formats */
 
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_TEST_CASE *test_case;
 ACVP_KAS_IFC_TC *kas_ifc_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 void free_kas_ifc_tc(ACVP_KAS_IFC_TC *stc) {
     if (stc->server_n) free(stc->server_n);
@@ -744,6 +742,3 @@ Test(APP_KAS_IFC_HANDLER, missing_buf_serv_pt_z) {
     free_kas_ifc_tc(kas_ifc_tc);
     free(test_case);
 }
-
-#endif
-

--- a/test/implementations/openssl/3/test_iut_kda.c
+++ b/test/implementations/openssl/3/test_iut_kda.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2021, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,13 +10,13 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_TEST_CASE *test_case;
 ACVP_KDA_HKDF_TC *kda_hkdf_tc;
 ACVP_KDA_ONESTEP_TC *kda_onestep_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 void free_kda_hkdf_tc(ACVP_KDA_HKDF_TC *stc) {
     if (stc->salt) free(stc->salt);

--- a/test/implementations/openssl/3/test_iut_kmac.c
+++ b/test/implementations/openssl/3/test_iut_kmac.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2023, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,15 +10,14 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 #include "acvp/acvp.h"
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_KMAC_TC *kmac_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 int initialize_kmac_tc(ACVP_KMAC_TC *kmac_tc, int alg_id, ACVP_KMAC_TESTTYPE type,
                        int xof, int custom_is_hex, char *mac, int mac_len, char *msg, char *key,
@@ -231,5 +230,3 @@ Test(APP_KMAC_HANDLER, mem_not_allocated) {
     free(kmac_tc);
     free(test_case);
 }
-
-#endif

--- a/test/implementations/openssl/3/test_iut_rsa_keygen.c
+++ b/test/implementations/openssl/3/test_iut_rsa_keygen.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2023, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,14 +14,13 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_RSA_KEYGEN_TC *rsa_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 void free_rsa_keygen_tc(ACVP_RSA_KEYGEN_TC *stc) {
     if (stc->e) { free(stc->e); }
@@ -390,6 +389,3 @@ Test(APP_RSA_KEYGEN_HANDLER, unallocated_ans_bufs) {
     free_rsa_keygen_tc(rsa_tc);
     free(test_case);
 }
-
-#endif
-

--- a/test/implementations/openssl/3/test_iut_rsa_sig.c
+++ b/test/implementations/openssl/3/test_iut_rsa_sig.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2019, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,12 +14,13 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_RSA_SIG_TC *rsa_sig_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 void free_rsa_sig_tc(ACVP_RSA_SIG_TC *stc) {
     if (stc->msg) { free(stc->msg); }

--- a/test/implementations/openssl/3/test_iut_safe_primes.c
+++ b/test/implementations/openssl/3/test_iut_safe_primes.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2023, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,14 +10,15 @@
 
 #include "ut_common.h"
 #include "app_common.h"
+#include "iut_common.h"
 #include "acvp/acvp_lcl.h"
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined OPENSSL_NO_DSA
+#if !defined OPENSSL_NO_DSA
 
-ACVP_CTX *ctx;
-ACVP_TEST_CASE *test_case;
+static ACVP_CTX *ctx;
+static ACVP_TEST_CASE *test_case;
 ACVP_SAFE_PRIMES_TC *safe_primes_tc;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 void free_safe_primes_tc(ACVP_SAFE_PRIMES_TC *stc) {
     if (stc->x) free(stc->x);

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2021, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,15 +12,14 @@
 #include "ut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
+static ACVP_CTX *ctx;
 static char filename[] = "filename";
 static char cvalue[] = "same";
-char *test_server = "demo.acvts.nist.gov";
-char *api_context = "acvp/";
-char *path_segment = "acvp/v1/";
-char *uri = "login";
-int port = 443;
-ACVP_RESULT rv;
+static char *test_server = "demo.acvts.nist.gov";
+static char *api_context = "acvp/";
+static char *path_segment = "acvp/v1/";
+static int port = 443;
+static ACVP_RESULT rv;
 
 static void setup(void) {
     setup_empty_ctx(&ctx);

--- a/test/test_acvp_capabilities.c
+++ b/test/test_acvp_capabilities.c
@@ -11,9 +11,9 @@
 
 #include "ut_common.h"
 
-ACVP_CTX *ctx;
+static ACVP_CTX *ctx;
 char cvalue[] = "same";
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 
 static void teardown(void) {
     if (ctx) teardown_ctx(&ctx);

--- a/test/test_acvp_dsa.c
+++ b/test/test_acvp_dsa.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2020, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,7 +12,7 @@
 #include "ut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
+static ACVP_CTX *ctx;
 static char cvalue[] = "same";
 
 static void setup_pqggen(void)

--- a/test/test_acvp_hmac.c
+++ b/test/test_acvp_hmac.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2019, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,7 +12,7 @@
 #include "ut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
+static ACVP_CTX *ctx;
 static char cvalue[] = "same";
 static JSON_Object *obj = NULL;
 static JSON_Value *val = NULL;

--- a/test/test_acvp_kdf135_snmp.c
+++ b/test/test_acvp_kdf135_snmp.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2019, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,7 +12,7 @@
 #include "ut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
+static ACVP_CTX *ctx;
 static char cvalue[] = "same";
 
 /*

--- a/test/test_acvp_kdf135_ssh.c
+++ b/test/test_acvp_kdf135_ssh.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2019, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,7 +12,7 @@
 #include "ut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
+static ACVP_CTX *ctx;
 static char cvalue[] = "same";
 
 /*

--- a/test/test_acvp_kdf135_x963.c
+++ b/test/test_acvp_kdf135_x963.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2019, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,7 +12,7 @@
 #include "ut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
+static ACVP_CTX *ctx;
 static char cvalue[] = "same";
 
 /*

--- a/test/test_acvp_operating_env.c
+++ b/test/test_acvp_operating_env.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2021, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,16 +12,8 @@
 #include "ut_common.h"
 #include "acvp/acvp_lcl.h"
 
-char *server;
-int port;
-char *ca_chain_file;
-char *cert_file;
-char *key_file;
-char *path_segment;
-char *api_context;
 static ACVP_CTX *ctx = NULL;
-ACVP_RESULT rv;
-
+static ACVP_RESULT rv;
 
 static void setup(void) {
     setup_empty_ctx(&ctx);

--- a/test/test_acvp_transport.c
+++ b/test/test_acvp_transport.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2021, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,7 +14,7 @@
 
 char *vsid_url = "/acvp/v1/testSessions/0/vectorSets/0";
 ACVP_CTX *ctx = NULL;
-ACVP_RESULT rv;
+static ACVP_RESULT rv;
 char *reg = "{}";
 char *little_reg = "[{\"acvVersion\": \"0.5\"},{\"algorithms\": [{\"algorithm\": \"SHA-1\",\"inBit\": false,\n"
                    "                \"inEmpty\": true\n"
@@ -51,13 +51,13 @@ char *login_reg = "[\n"
                   "    }\n"
                   "]";
 
-char *server;
-int port;
-char *ca_chain_file;
-char *cert_file;
-char *key_file;
-char *path_segment;
-char *api_context;
+static char *server;
+static int port;
+static char *ca_chain_file;
+static char *cert_file;
+static char *key_file;
+static char *path_segment;
+static char *api_context;
 
 /*
  * Read the operational parameters from the various environment

--- a/test/test_acvp_utils.c
+++ b/test/test_acvp_utils.c
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2020, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,7 +12,7 @@
 #include "ut_common.h"
 #include "acvp/acvp_lcl.h"
 
-ACVP_CTX *ctx;
+static ACVP_CTX *ctx;
 
 /*
  * Try to pass variety of parms to acvp_log_msg

--- a/test/ut_common.h
+++ b/test/ut_common.h
@@ -1,6 +1,6 @@
 /** @file */
 /*
- * Copyright (c) 2019, Cisco Systems, Inc.
+ * Copyright (c) 2024, Cisco Systems, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,6 +8,8 @@
  * https://github.com/cisco/libacvp/LICENSE
  */
 
+#ifndef ACVP_UT_COMMON_H
+#define ACVP_UT_COMMON_H
 
 #include <string.h>
 #include <stdio.h>
@@ -17,8 +19,8 @@
 #include "safe_lib.h"
 #include "acvp/acvp.h"
 
-int counter_set;
-int counter_fail;
+extern int counter_set;
+extern int counter_fail;
 
 void teardown_ctx(ACVP_CTX **ctx);
 ACVP_RESULT progress(char *msg, ACVP_LOG_LVL level);
@@ -46,3 +48,5 @@ unsigned int dummy_totp(char **token, int token_max);
                                   "TestStringTooLongTestStringTooLongTestStringTooLongTestStringTooLong"\
                                   "TestStringTooLongTestStringTooLongTestStringTooLongTestStringTooLong"\
                                   "TestStringTooLongTestStringTooLongTestStringTooLongTestStringTooLong"
+
+#endif


### PR DESCRIPTION
- App UTs now mirror new app structure, with each IuT getting its own folder for UTs. 
- Now that fno-common is default in newer compilers, address lots of multiple-definition errors by making UT variables static scope and adding missing header guards.
- remove references to OPENSSL_VERSION_NUMBER from UTs
- Misc. fixes and cleanup in several app places
- UTs now all working properly with new app structure