### PR TITLE
proj: add simple nix flake & direnv integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726969270,
+        "narHash": "sha256-8fnFlXBgM/uSvBlLWjZ0Z0sOdRBesyNdH0+esxqizGc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "23cbb250f3bf4f516a2d0bf03c51a30900848075",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" ];
+      perSystem = { config, self', pkgs, lib, system, ... }:
+        let
+          devDeps = with pkgs; [ gcc gdb gnumake criterion doxygen ];
+          buildDeps = with pkgs; [ curl openssl ];
+
+          libacvp = pkgs.stdenv.mkDerivation {
+            pname = "libacvp";
+            version = "2.1.1";
+            src = ./.;
+
+            nativeBuildInputs = buildDeps;
+
+            configureFlags = [
+              "--with-ssl-dir=${pkgs.openssl.dev}"
+              "--with-libcurl-dir=${pkgs.curl.dev}"
+            ];
+          };
+        in rec {
+          _module.args.pkgs = import inputs.nixpkgs { inherit system; };
+
+          packages.default = libacvp;
+
+          devShells.default =
+            pkgs.mkShell { nativeBuildInputs = devDeps ++ buildDeps; };
+        };
+    };
+}


### PR DESCRIPTION
I imagine you folks won't want to maintain this in-repo but I figured by opening/closing a PR I could at least make this discoverable to anyone else that may want to build this repo w/ Nix, or as an input to a NixOS flake.

Supports building w/ nix and providing a development shell with direnv integration.

```
nix build .# && ./result/bin/acvp_app --help
```