### PR TITLE
Enhance RSA KeyGen to add/enhance support for all modes

### DIFF
--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -969,11 +969,11 @@ typedef enum acvp_rsa_keygen_mode_t {
     ACVP_RSA_KEYGEN_B35,
     ACVP_RSA_KEYGEN_B36,
     /* These generally match the above ones, but the terminology has changed for FIPS 186-5 */
-    ACVP_RSA_KEYGEN_PROVABLE,
-    ACVP_RSA_KEYGEN_PROBABLE,
-    ACVP_RSA_KEYGEN_PROV_W_PROV_AUX,
-    ACVP_RSA_KEYGEN_PROB_W_PROV_AUX,
-    ACVP_RSA_KEYGEN_PROB_W_PROB_AUX,
+    ACVP_RSA_KEYGEN_PROVABLE,         // B.3.2
+    ACVP_RSA_KEYGEN_PROBABLE,         // B.3.3
+    ACVP_RSA_KEYGEN_PROV_W_PROV_AUX,  // B.3.4
+    ACVP_RSA_KEYGEN_PROB_W_PROV_AUX,  // B.3.5
+    ACVP_RSA_KEYGEN_PROB_W_PROB_AUX,  // B.3.6
     ACVP_RSA_KEYGEN_MAX
 } ACVP_RSA_KEYGEN_MODE;
 

--- a/safe_c_stub/src/safe_mem_stub.c
+++ b/safe_c_stub/src/safe_mem_stub.c
@@ -62,7 +62,7 @@ errno_t memzero_s(void *dest, rsize_t dmax)
  *
  * Emulate subset of the functionality of memcpy_s() with memcpy()
  */
- #ifndef __WIN32
+#ifndef __WIN32
 errno_t memcpy_s (void *dest, rsize_t dmax, const void *src, rsize_t slen) {
     if (!src || !dest) return (ESNULLP);
     if (slen > dmax) return (ESLEMAX);
@@ -91,7 +91,7 @@ errno_t memcmp_s (const void *dest, rsize_t dmax, const void *src, rsize_t slen,
  *
  * Emulate memmove_s without constraint handling
  */
- #ifndef __WIN32
+#ifndef __WIN32
 errno_t memmove_s (void *dest, rsize_t dmax, const void *src, rsize_t smax)
 {
 

--- a/src/acvp_rsa_keygen.c
+++ b/src/acvp_rsa_keygen.c
@@ -161,14 +161,6 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
         
         if (stc->rand_pq == ACVP_RSA_KEYGEN_B36 ||
             stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
-		    rv = acvp_bin_to_hexstr(stc->xp, stc->xp_len, tmp, ACVP_RSA_EXP_LEN_MAX);
-		    if (rv != ACVP_SUCCESS) {
-		        ACVP_LOG_ERR("hex conversion failure (xp)");
-		        goto err;
-		    }
-		    json_object_set_string(tc_rsp, "xP", (const char *)tmp);
-		    memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
-
 		    rv = acvp_bin_to_hexstr(stc->xp1, stc->xp1_len, tmp, ACVP_RSA_EXP_LEN_MAX);
 		    if (rv != ACVP_SUCCESS) {
 		        ACVP_LOG_ERR("hex conversion failure (xp1)");
@@ -183,14 +175,6 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
 		        goto err;
 		    }
 		    json_object_set_string(tc_rsp, "xP2", (const char *)tmp);
-		    memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
-
-		    rv = acvp_bin_to_hexstr(stc->xq, stc->xq_len, tmp, ACVP_RSA_EXP_LEN_MAX);
-		    if (rv != ACVP_SUCCESS) {
-		        ACVP_LOG_ERR("hex conversion failure (xq)");
-		        goto err;
-		    }
-		    json_object_set_string(tc_rsp, "xQ", (const char *)tmp);
 		    memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
 
 		    rv = acvp_bin_to_hexstr(stc->xq1, stc->xq1_len, tmp, ACVP_RSA_EXP_LEN_MAX);
@@ -306,8 +290,9 @@ static ACVP_RESULT acvp_rsa_keygen_init_tc(ACVP_CTX *ctx,
         stc->xq2 = calloc(ACVP_RSA_EXP_BYTE_MAX, sizeof(unsigned char));
         if (!stc->xq2) { return ACVP_MALLOC_FAIL; }
     }
-    if (rand_pq == ACVP_RSA_KEYGEN_B36 || 
-		rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
+    if (info_gen_by_server && 
+        (rand_pq == ACVP_RSA_KEYGEN_B36 || 
+         rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX)) {
         rv = acvp_hexstr_to_bin(xp, stc->xp, ACVP_RSA_EXP_BYTE_MAX, &(stc->xp_len));
         if (rv != ACVP_SUCCESS) {
             ACVP_LOG_ERR("Hex conversion failure (xp)");

--- a/src/acvp_rsa_keygen.c
+++ b/src/acvp_rsa_keygen.c
@@ -27,15 +27,25 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
     ACVP_RESULT rv = ACVP_SUCCESS;
     char *tmp = NULL;
 
-    if ((stc->rand_pq == ACVP_RSA_KEYGEN_B33 || stc->rand_pq == ACVP_RSA_KEYGEN_PROBABLE) && stc->test_type == ACVP_RSA_TESTTYPE_KAT) {
+    if (stc->test_type == ACVP_RSA_TESTTYPE_KAT) {  // KAT type is only applicable to B.3.3 (Probable)
         json_object_set_boolean(tc_rsp, "testPassed", stc->test_disposition);
-        goto err;
+        return ACVP_SUCCESS;
     }
 
     tmp = calloc(ACVP_RSA_EXP_LEN_MAX + 1, sizeof(char));
     if (!tmp) {
-        ACVP_LOG_ERR("Unable to malloc in acvp_kdf135 tpm_output_tc");
+        ACVP_LOG_ERR("Unable to malloc in acvp_rsa_keygen rsa_output_tc");
         return ACVP_MALLOC_FAIL;
+    }
+
+    // (E, P, Q, N, D) for all 
+    if (stc->pub_exp_mode == ACVP_RSA_PUB_EXP_MODE_RANDOM && !stc->info_gen_by_server) {
+        rv = acvp_bin_to_hexstr(stc->e, stc->e_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("hex conversion failure (e)");
+            goto err;
+        }
+        json_object_set_string(tc_rsp, "e", (const char *)tmp);
     }
 
     rv = acvp_bin_to_hexstr(stc->p, stc->p_len, tmp, ACVP_RSA_EXP_LEN_MAX);
@@ -62,99 +72,143 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
     json_object_set_string(tc_rsp, "n", (const char *)tmp);
     memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
 
-    rv = acvp_bin_to_hexstr(stc->d, stc->d_len, tmp, ACVP_RSA_EXP_LEN_MAX);
-    if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (d)");
-        goto err;
-    }
-    json_object_set_string(tc_rsp, "d", (const char *)tmp);
-    memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
-
-    rv = acvp_bin_to_hexstr(stc->e, stc->e_len, tmp, ACVP_RSA_EXP_LEN_MAX);
-    if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (e)");
-        goto err;
-    }
-    json_object_set_string(tc_rsp, "e", (const char *)tmp);
-
-    if (stc->rand_pq == ACVP_RSA_KEYGEN_B36 || stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
-        rv = acvp_bin_to_hexstr(stc->xp, stc->xp_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+    if (stc->key_format == ACVP_RSA_KEY_FORMAT_CRT) {
+        rv = acvp_bin_to_hexstr(stc->dmp1, stc->d_len, tmp, ACVP_RSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (xp)");
+            ACVP_LOG_ERR("hex conversion failure (dmp1)");
             goto err;
         }
-        json_object_set_string(tc_rsp, "xP", (const char *)tmp);
+        json_object_set_string(tc_rsp, "dmp1", (const char *)tmp);
         memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
-
-        rv = acvp_bin_to_hexstr(stc->xp1, stc->xp1_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+        rv = acvp_bin_to_hexstr(stc->dmq1, stc->d_len, tmp, ACVP_RSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (xp1)");
+            ACVP_LOG_ERR("hex conversion failure (dmq1)");
             goto err;
         }
-        json_object_set_string(tc_rsp, "xP1", (const char *)tmp);
+        json_object_set_string(tc_rsp, "dmq1", (const char *)tmp);
         memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
-
-        rv = acvp_bin_to_hexstr(stc->xp2, stc->xp2_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+        rv = acvp_bin_to_hexstr(stc->iqmp, stc->d_len, tmp, ACVP_RSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (xp2)");
+            ACVP_LOG_ERR("hex conversion failure (iqmp)");
             goto err;
         }
-        json_object_set_string(tc_rsp, "xP2", (const char *)tmp);
-        memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
-
-        rv = acvp_bin_to_hexstr(stc->xq, stc->xq_len, tmp, ACVP_RSA_EXP_LEN_MAX);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (xq)");
-            goto err;
-        }
-        json_object_set_string(tc_rsp, "xQ", (const char *)tmp);
-        memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
-
-        rv = acvp_bin_to_hexstr(stc->xq1, stc->xq1_len, tmp, ACVP_RSA_EXP_LEN_MAX);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (xq1)");
-            goto err;
-        }
-        json_object_set_string(tc_rsp, "xQ1", (const char *)tmp);
-        memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
-
-        rv = acvp_bin_to_hexstr(stc->xq2, stc->xq2_len, tmp, ACVP_RSA_EXP_LEN_MAX);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (xq2)");
-            goto err;
-        }
-        json_object_set_string(tc_rsp, "xQ2", (const char *)tmp);
+        json_object_set_string(tc_rsp, "iqmp", (const char *)tmp);
         memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
     }
+    else {
+		rv = acvp_bin_to_hexstr(stc->d, stc->d_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+		if (rv != ACVP_SUCCESS) {
+		    ACVP_LOG_ERR("hex conversion failure (d)");
+		    goto err;
+		}
+		json_object_set_string(tc_rsp, "d", (const char *)tmp);
+		memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
+    }
 
-    if (stc->info_gen_by_server) {
-        if (stc->rand_pq == ACVP_RSA_KEYGEN_B33 ||
-            stc->rand_pq == ACVP_RSA_KEYGEN_B35 ||
-            stc->rand_pq == ACVP_RSA_KEYGEN_B36 ||
-            stc->rand_pq == ACVP_RSA_KEYGEN_PROBABLE ||
-            stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROV_AUX ||
-            stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
-            json_object_set_string(tc_rsp, "primeResult", (const char *)stc->prime_result);
-        }
-    } else {
-        if (!(stc->rand_pq == ACVP_RSA_KEYGEN_B33 || stc->rand_pq == ACVP_RSA_KEYGEN_PROBABLE)) {
+    // Aux data only if genereated by IUT
+    if (!stc->info_gen_by_server) {
+        if (stc->rand_pq == ACVP_RSA_KEYGEN_B32 ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_B34 ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_B35 || 
+            stc->rand_pq == ACVP_RSA_KEYGEN_PROVABLE ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_PROV_W_PROV_AUX ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROV_AUX) {
+            // Seed
             rv = acvp_bin_to_hexstr(stc->seed, stc->seed_len, tmp, ACVP_RSA_SEEDLEN_MAX);
-            if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (seed)");
-                goto err;
-            }
+			if (rv != ACVP_SUCCESS) {
+		        ACVP_LOG_ERR("hex conversion failure (seed)");
+			    goto err;
+			}
             json_object_set_string(tc_rsp, "seed", (const char *)tmp);
             memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
         }
-    }
 
-    if (!(stc->rand_pq == ACVP_RSA_KEYGEN_B33 || stc->rand_pq == ACVP_RSA_KEYGEN_PROBABLE)) {
-        json_object_set_value(tc_rsp, "bitlens", json_value_init_array());
-        JSON_Array *bitlens_array = json_object_get_array(tc_rsp, "bitlens");
-        json_array_append_number(bitlens_array, stc->bitlen1);
-        json_array_append_number(bitlens_array, stc->bitlen2);
-        json_array_append_number(bitlens_array, stc->bitlen3);
-        json_array_append_number(bitlens_array, stc->bitlen4);
+        if (stc->rand_pq == ACVP_RSA_KEYGEN_B34 ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_B35 ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_B36 ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_PROV_W_PROV_AUX ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROV_AUX ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
+            // Bitlens array
+            json_object_set_value(tc_rsp, "bitlens", json_value_init_array());
+            JSON_Array *bitlens_array = json_object_get_array(tc_rsp, "bitlens");
+            json_array_append_number(bitlens_array, stc->bitlen1);
+            json_array_append_number(bitlens_array, stc->bitlen2);
+            json_array_append_number(bitlens_array, stc->bitlen3);
+            json_array_append_number(bitlens_array, stc->bitlen4);
+        }
+
+        if (stc->rand_pq == ACVP_RSA_KEYGEN_B35 ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_B36 ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROV_AUX ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
+            rv = acvp_bin_to_hexstr(stc->xp, stc->xp_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("hex conversion failure (xp)");
+                goto err;
+            }
+            json_object_set_string(tc_rsp, "xP", (const char *)tmp);
+            memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
+
+            rv = acvp_bin_to_hexstr(stc->xq, stc->xq_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("hex conversion failure (xq)");
+                goto err;
+            }
+            json_object_set_string(tc_rsp, "xQ", (const char *)tmp);
+            memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
+        }
+        
+        if (stc->rand_pq == ACVP_RSA_KEYGEN_B36 ||
+            stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
+		    rv = acvp_bin_to_hexstr(stc->xp, stc->xp_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+		    if (rv != ACVP_SUCCESS) {
+		        ACVP_LOG_ERR("hex conversion failure (xp)");
+		        goto err;
+		    }
+		    json_object_set_string(tc_rsp, "xP", (const char *)tmp);
+		    memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
+
+		    rv = acvp_bin_to_hexstr(stc->xp1, stc->xp1_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+		    if (rv != ACVP_SUCCESS) {
+		        ACVP_LOG_ERR("hex conversion failure (xp1)");
+		        goto err;
+		    }
+		    json_object_set_string(tc_rsp, "xP1", (const char *)tmp);
+		    memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
+
+		    rv = acvp_bin_to_hexstr(stc->xp2, stc->xp2_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+		    if (rv != ACVP_SUCCESS) {
+		        ACVP_LOG_ERR("hex conversion failure (xp2)");
+		        goto err;
+		    }
+		    json_object_set_string(tc_rsp, "xP2", (const char *)tmp);
+		    memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
+
+		    rv = acvp_bin_to_hexstr(stc->xq, stc->xq_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+		    if (rv != ACVP_SUCCESS) {
+		        ACVP_LOG_ERR("hex conversion failure (xq)");
+		        goto err;
+		    }
+		    json_object_set_string(tc_rsp, "xQ", (const char *)tmp);
+		    memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
+
+		    rv = acvp_bin_to_hexstr(stc->xq1, stc->xq1_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+		    if (rv != ACVP_SUCCESS) {
+		        ACVP_LOG_ERR("hex conversion failure (xq1)");
+		        goto err;
+		    }
+		    json_object_set_string(tc_rsp, "xQ1", (const char *)tmp);
+		    memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
+
+		    rv = acvp_bin_to_hexstr(stc->xq2, stc->xq2_len, tmp, ACVP_RSA_EXP_LEN_MAX);
+		    if (rv != ACVP_SUCCESS) {
+		        ACVP_LOG_ERR("hex conversion failure (xq2)");
+		        goto err;
+		    }
+		    json_object_set_string(tc_rsp, "xQ2", (const char *)tmp);
+		    memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
+		}
     }
 
 err:
@@ -213,8 +267,9 @@ static ACVP_RESULT acvp_rsa_keygen_init_tc(ACVP_CTX *ctx,
                                            int bitlen2,
                                            int bitlen3,
                                            int bitlen4) {
-    memzero_s(stc, sizeof(ACVP_RSA_KEYGEN_TC));
     ACVP_RESULT rv = ACVP_SUCCESS;
+
+    memzero_s(stc, sizeof(ACVP_RSA_KEYGEN_TC));
     stc->test_type = test_type;
     stc->info_gen_by_server = info_gen_by_server;
     stc->tc_id = tc_id;
@@ -235,7 +290,9 @@ static ACVP_RESULT acvp_rsa_keygen_init_tc(ACVP_CTX *ctx,
     if (!stc->n) { return ACVP_MALLOC_FAIL; }
     stc->d = calloc(ACVP_RSA_EXP_BYTE_MAX, sizeof(unsigned char));
     if (!stc->d) { return ACVP_MALLOC_FAIL; }
-    if (rand_pq == ACVP_RSA_KEYGEN_B36 || rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX || !info_gen_by_server) {
+    if (rand_pq == ACVP_RSA_KEYGEN_B36 || 
+		rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX || 
+		!info_gen_by_server) {
         stc->xp = calloc(ACVP_RSA_EXP_BYTE_MAX, sizeof(unsigned char));
         if (!stc->xp) { return ACVP_MALLOC_FAIL; }
         stc->xp1 = calloc(ACVP_RSA_EXP_BYTE_MAX, sizeof(unsigned char));
@@ -249,7 +306,8 @@ static ACVP_RESULT acvp_rsa_keygen_init_tc(ACVP_CTX *ctx,
         stc->xq2 = calloc(ACVP_RSA_EXP_BYTE_MAX, sizeof(unsigned char));
         if (!stc->xq2) { return ACVP_MALLOC_FAIL; }
     }
-    if (rand_pq == ACVP_RSA_KEYGEN_B36 || rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
+    if (rand_pq == ACVP_RSA_KEYGEN_B36 || 
+		rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
         rv = acvp_hexstr_to_bin(xp, stc->xp, ACVP_RSA_EXP_BYTE_MAX, &(stc->xp_len));
         if (rv != ACVP_SUCCESS) {
             ACVP_LOG_ERR("Hex conversion failure (xp)");
@@ -295,13 +353,14 @@ static ACVP_RESULT acvp_rsa_keygen_init_tc(ACVP_CTX *ctx,
             return rv;
         }
     }
-
-    rv = acvp_hexstr_to_bin(e, stc->e, ACVP_RSA_EXP_BYTE_MAX, &(stc->e_len));
-    if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Hex conversion failure (e)");
-        return rv;
+    if (e) {
+		rv = acvp_hexstr_to_bin(e, stc->e, ACVP_RSA_EXP_BYTE_MAX, &(stc->e_len));
+		if (rv != ACVP_SUCCESS) {
+		    ACVP_LOG_ERR("Hex conversion failure (e)");
+		    return rv;
+		}
     }
-
+    
     stc->seed = calloc(ACVP_RSA_SEEDLEN_MAX, sizeof(unsigned char));
     if (!stc->seed) { return ACVP_MALLOC_FAIL; }
 
@@ -653,8 +712,12 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             if (info_gen_by_server) {
                 unsigned int count = 0;
 
-                if ((rand_pq >= ACVP_RSA_KEYGEN_B34 && rand_pq <= ACVP_RSA_KEYGEN_B36) ||
-                    (rand_pq >= ACVP_RSA_KEYGEN_PROV_W_PROV_AUX)) {
+                if (rand_pq == ACVP_RSA_KEYGEN_B34 ||
+                    rand_pq == ACVP_RSA_KEYGEN_B35 ||
+                    rand_pq == ACVP_RSA_KEYGEN_B36 ||
+                    rand_pq == ACVP_RSA_KEYGEN_PROV_W_PROV_AUX ||
+                    rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROV_AUX ||
+                    rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
                     bitlens = json_object_get_array(testobj, "bitlens");
                     count = json_array_get_count(bitlens);
                     if (count != 4) {
@@ -741,7 +804,8 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 }
             }
 
-            if ((rand_pq == ACVP_RSA_KEYGEN_B33 || rand_pq == ACVP_RSA_KEYGEN_PROBABLE) && test_type == ACVP_RSA_TESTTYPE_KAT) {
+            if (test_type == ACVP_RSA_TESTTYPE_KAT && 
+                (rand_pq == ACVP_RSA_KEYGEN_B33 || rand_pq == ACVP_RSA_KEYGEN_PROBABLE)) {
                 // E
                 e_str = json_object_get_string(testobj, "e");
                 if (!e_str) {


### PR DESCRIPTION
Add/Enhanced support for all RSA KeyGen modes (B.3.2-B.3.6).  I have personally verified B.3.3 and B.3.6 covering a wide array of parameter options.  If anyone knows of an implementation of the other modes, I'd be happy to validate the remainder.

This passed valgrind and a sucessfull demo vector set.