### PR TITLE
 Initial support for liboqs, ML-KEM testing

### DIFF
--- a/app/Makefile.am
+++ b/app/Makefile.am
@@ -37,6 +37,13 @@ if APP_IUT_JENT
 tmp_sources += implementations/jitter_entropy/iut.c
 endif
 
+if APP_IUT_LIBOQS
+tmp_sources += implementations/liboqs/iut.c \
+               implementations/liboqs/iut.h \
+               implementations/liboqs/iut_ml_kem.c \
+               implementations/liboqs/iut_ml_dsa.c
+endif
+
 if !BUILD_APP_AS_LIB
 bin_PROGRAMS = acvp_app
 

--- a/app/Makefile.in
+++ b/app/Makefile.in
@@ -113,10 +113,15 @@ host_triplet = @host@
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/iut_hash.c
 
 @APP_IUT_JENT_TRUE@am__append_2 = implementations/jitter_entropy/iut.c
+@APP_IUT_LIBOQS_TRUE@am__append_3 = implementations/liboqs/iut.c \
+@APP_IUT_LIBOQS_TRUE@               implementations/liboqs/iut.h \
+@APP_IUT_LIBOQS_TRUE@               implementations/liboqs/iut_ml_kem.c \
+@APP_IUT_LIBOQS_TRUE@               implementations/liboqs/iut_ml_dsa.c
+
 @BUILD_APP_AS_LIB_FALSE@bin_PROGRAMS = acvp_app$(EXEEXT)
-@BUILD_APP_AS_LIB_FALSE@@FORCE_STATIC_TRUE@am__append_3 = -all-static
-@BUILDING_OFFLINE_FALSE@@BUILD_APP_AS_LIB_FALSE@am__append_4 = $(LIBCURL_LDFLAGS)
-@BUILDING_OFFLINE_FALSE@@BUILD_APP_AS_LIB_FALSE@am__append_5 = $(LIBCURL_CFLAGS)
+@BUILD_APP_AS_LIB_FALSE@@FORCE_STATIC_TRUE@am__append_4 = -all-static
+@BUILDING_OFFLINE_FALSE@@BUILD_APP_AS_LIB_FALSE@am__append_5 = $(LIBCURL_LDFLAGS)
+@BUILDING_OFFLINE_FALSE@@BUILD_APP_AS_LIB_FALSE@am__append_6 = $(LIBCURL_CFLAGS)
 subdir = app
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
@@ -189,7 +194,10 @@ am__libacvp_app_la_SOURCES_DIST = app_main.c app_cli.c app_utils.c \
 	implementations/openssl/3/iut_kmac.c \
 	implementations/openssl/3/iut_rsa.c \
 	implementations/openssl/3/iut_hash.c \
-	implementations/jitter_entropy/iut.c
+	implementations/jitter_entropy/iut.c \
+	implementations/liboqs/iut.c implementations/liboqs/iut.h \
+	implementations/liboqs/iut_ml_kem.c \
+	implementations/liboqs/iut_ml_dsa.c
 am__dirstamp = $(am__leading_dot)dirstamp
 @APP_IUT_OPENSSL_3_TRUE@am__objects_1 =  \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut.lo \
@@ -214,10 +222,13 @@ am__dirstamp = $(am__leading_dot)dirstamp
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut_hash.lo
 @APP_IUT_JENT_TRUE@am__objects_2 =  \
 @APP_IUT_JENT_TRUE@	implementations/jitter_entropy/iut.lo
-am__objects_3 = app_main.lo app_cli.lo app_utils.lo totp/totp.lo \
+@APP_IUT_LIBOQS_TRUE@am__objects_3 = implementations/liboqs/iut.lo \
+@APP_IUT_LIBOQS_TRUE@	implementations/liboqs/iut_ml_kem.lo \
+@APP_IUT_LIBOQS_TRUE@	implementations/liboqs/iut_ml_dsa.lo
+am__objects_4 = app_main.lo app_cli.lo app_utils.lo totp/totp.lo \
 	totp/hmac_sha256.lo totp/sha256.lo $(am__objects_1) \
-	$(am__objects_2)
-@BUILD_APP_AS_LIB_TRUE@am_libacvp_app_la_OBJECTS = $(am__objects_3)
+	$(am__objects_2) $(am__objects_3)
+@BUILD_APP_AS_LIB_TRUE@am_libacvp_app_la_OBJECTS = $(am__objects_4)
 libacvp_app_la_OBJECTS = $(am_libacvp_app_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -248,8 +259,11 @@ am__acvp_app_SOURCES_DIST = app_main.c app_cli.c app_utils.c app_lcl.h \
 	implementations/openssl/3/iut_kmac.c \
 	implementations/openssl/3/iut_rsa.c \
 	implementations/openssl/3/iut_hash.c \
-	implementations/jitter_entropy/iut.c
-@APP_IUT_OPENSSL_3_TRUE@am__objects_4 = implementations/openssl/3/acvp_app-iut.$(OBJEXT) \
+	implementations/jitter_entropy/iut.c \
+	implementations/liboqs/iut.c implementations/liboqs/iut.h \
+	implementations/liboqs/iut_ml_kem.c \
+	implementations/liboqs/iut_ml_dsa.c
+@APP_IUT_OPENSSL_3_TRUE@am__objects_5 = implementations/openssl/3/acvp_app-iut.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_utils.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/registrations/acvp_app-fp_30X.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/registrations/acvp_app-fp_312.$(OBJEXT) \
@@ -269,13 +283,16 @@ am__acvp_app_SOURCES_DIST = app_main.c app_cli.c app_utils.c app_lcl.h \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_kmac.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_rsa.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_hash.$(OBJEXT)
-@APP_IUT_JENT_TRUE@am__objects_5 = implementations/jitter_entropy/acvp_app-iut.$(OBJEXT)
-am__objects_6 = acvp_app-app_main.$(OBJEXT) acvp_app-app_cli.$(OBJEXT) \
+@APP_IUT_JENT_TRUE@am__objects_6 = implementations/jitter_entropy/acvp_app-iut.$(OBJEXT)
+@APP_IUT_LIBOQS_TRUE@am__objects_7 = implementations/liboqs/acvp_app-iut.$(OBJEXT) \
+@APP_IUT_LIBOQS_TRUE@	implementations/liboqs/acvp_app-iut_ml_kem.$(OBJEXT) \
+@APP_IUT_LIBOQS_TRUE@	implementations/liboqs/acvp_app-iut_ml_dsa.$(OBJEXT)
+am__objects_8 = acvp_app-app_main.$(OBJEXT) acvp_app-app_cli.$(OBJEXT) \
 	acvp_app-app_utils.$(OBJEXT) totp/acvp_app-totp.$(OBJEXT) \
 	totp/acvp_app-hmac_sha256.$(OBJEXT) \
-	totp/acvp_app-sha256.$(OBJEXT) $(am__objects_4) \
-	$(am__objects_5)
-@BUILD_APP_AS_LIB_FALSE@am_acvp_app_OBJECTS = $(am__objects_6)
+	totp/acvp_app-sha256.$(OBJEXT) $(am__objects_5) \
+	$(am__objects_6) $(am__objects_7)
+@BUILD_APP_AS_LIB_FALSE@am_acvp_app_OBJECTS = $(am__objects_8)
 acvp_app_OBJECTS = $(am_acvp_app_OBJECTS)
 @BUILD_APP_AS_LIB_FALSE@acvp_app_DEPENDENCIES = $(am__DEPENDENCIES_1)
 acvp_app_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
@@ -302,6 +319,12 @@ am__depfiles_remade = ./$(DEPDIR)/acvp_app-app_cli.Po \
 	./$(DEPDIR)/app_main.Plo ./$(DEPDIR)/app_utils.Plo \
 	implementations/jitter_entropy/$(DEPDIR)/acvp_app-iut.Po \
 	implementations/jitter_entropy/$(DEPDIR)/iut.Plo \
+	implementations/liboqs/$(DEPDIR)/acvp_app-iut.Po \
+	implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_dsa.Po \
+	implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_kem.Po \
+	implementations/liboqs/$(DEPDIR)/iut.Plo \
+	implementations/liboqs/$(DEPDIR)/iut_ml_dsa.Plo \
+	implementations/liboqs/$(DEPDIR)/iut_ml_kem.Plo \
 	implementations/openssl/3/$(DEPDIR)/acvp_app-iut.Po \
 	implementations/openssl/3/$(DEPDIR)/acvp_app-iut_aes.Po \
 	implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cmac.Po \
@@ -530,15 +553,16 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 tmp_sources = app_main.c app_cli.c app_utils.c app_lcl.h totp/totp.c \
 	totp/hmac_sha256.c totp/sha256.c totp/hmac_sha256.h \
-	totp/sha256.h ketopt.h $(am__append_1) $(am__append_2)
+	totp/sha256.h ketopt.h $(am__append_1) $(am__append_2) \
+	$(am__append_3)
 @BUILD_APP_AS_LIB_FALSE@acvp_app_includedir = $(includedir)/acvp
 @BUILD_APP_AS_LIB_FALSE@acvp_app_SOURCES = ${tmp_sources}
 @BUILD_APP_AS_LIB_FALSE@acvp_app_CFLAGS = -g -fPIE $(LIBACVP_CFLAGS) \
 @BUILD_APP_AS_LIB_FALSE@	$(IUT_CFLAGS) $(SAFEC_CFLAGS) \
-@BUILD_APP_AS_LIB_FALSE@	$(COND_ALG_CFLAGS) $(am__append_5)
+@BUILD_APP_AS_LIB_FALSE@	$(COND_ALG_CFLAGS) $(am__append_6)
 @BUILD_APP_AS_LIB_FALSE@acvp_app_LDFLAGS = $(LIBACVP_LDFLAGS) \
-@BUILD_APP_AS_LIB_FALSE@	$(IUT_LDFLAGS) $(am__append_3) \
-@BUILD_APP_AS_LIB_FALSE@	$(am__append_4)
+@BUILD_APP_AS_LIB_FALSE@	$(IUT_LDFLAGS) $(am__append_4) \
+@BUILD_APP_AS_LIB_FALSE@	$(am__append_5)
 @BUILD_APP_AS_LIB_FALSE@acvp_app_LDADD = $(ADDL_LIB_DEPENDENCIES)
 @BUILD_APP_AS_LIB_TRUE@lib_LTLIBRARIES = libacvp_app.la
 @BUILD_APP_AS_LIB_TRUE@libacvp_app_includedir = ${includedir}/acvp
@@ -754,6 +778,20 @@ implementations/jitter_entropy/$(DEPDIR)/$(am__dirstamp):
 implementations/jitter_entropy/iut.lo:  \
 	implementations/jitter_entropy/$(am__dirstamp) \
 	implementations/jitter_entropy/$(DEPDIR)/$(am__dirstamp)
+implementations/liboqs/$(am__dirstamp):
+	@$(MKDIR_P) implementations/liboqs
+	@: > implementations/liboqs/$(am__dirstamp)
+implementations/liboqs/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) implementations/liboqs/$(DEPDIR)
+	@: > implementations/liboqs/$(DEPDIR)/$(am__dirstamp)
+implementations/liboqs/iut.lo: implementations/liboqs/$(am__dirstamp) \
+	implementations/liboqs/$(DEPDIR)/$(am__dirstamp)
+implementations/liboqs/iut_ml_kem.lo:  \
+	implementations/liboqs/$(am__dirstamp) \
+	implementations/liboqs/$(DEPDIR)/$(am__dirstamp)
+implementations/liboqs/iut_ml_dsa.lo:  \
+	implementations/liboqs/$(am__dirstamp) \
+	implementations/liboqs/$(DEPDIR)/$(am__dirstamp)
 
 libacvp_app.la: $(libacvp_app_la_OBJECTS) $(libacvp_app_la_DEPENDENCIES) $(EXTRA_libacvp_app_la_DEPENDENCIES) 
 	$(AM_V_CCLD)$(LINK) $(am_libacvp_app_la_rpath) $(libacvp_app_la_OBJECTS) $(libacvp_app_la_LIBADD) $(LIBS)
@@ -826,6 +864,15 @@ implementations/openssl/3/acvp_app-iut_hash.$(OBJEXT):  \
 implementations/jitter_entropy/acvp_app-iut.$(OBJEXT):  \
 	implementations/jitter_entropy/$(am__dirstamp) \
 	implementations/jitter_entropy/$(DEPDIR)/$(am__dirstamp)
+implementations/liboqs/acvp_app-iut.$(OBJEXT):  \
+	implementations/liboqs/$(am__dirstamp) \
+	implementations/liboqs/$(DEPDIR)/$(am__dirstamp)
+implementations/liboqs/acvp_app-iut_ml_kem.$(OBJEXT):  \
+	implementations/liboqs/$(am__dirstamp) \
+	implementations/liboqs/$(DEPDIR)/$(am__dirstamp)
+implementations/liboqs/acvp_app-iut_ml_dsa.$(OBJEXT):  \
+	implementations/liboqs/$(am__dirstamp) \
+	implementations/liboqs/$(DEPDIR)/$(am__dirstamp)
 
 acvp_app$(EXEEXT): $(acvp_app_OBJECTS) $(acvp_app_DEPENDENCIES) $(EXTRA_acvp_app_DEPENDENCIES) 
 	@rm -f acvp_app$(EXEEXT)
@@ -835,6 +882,8 @@ mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
 	-rm -f implementations/jitter_entropy/*.$(OBJEXT)
 	-rm -f implementations/jitter_entropy/*.lo
+	-rm -f implementations/liboqs/*.$(OBJEXT)
+	-rm -f implementations/liboqs/*.lo
 	-rm -f implementations/openssl/3/*.$(OBJEXT)
 	-rm -f implementations/openssl/3/*.lo
 	-rm -f implementations/openssl/3/registrations/*.$(OBJEXT)
@@ -853,6 +902,12 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/app_utils.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/jitter_entropy/$(DEPDIR)/acvp_app-iut.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/jitter_entropy/$(DEPDIR)/iut.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/liboqs/$(DEPDIR)/acvp_app-iut.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_dsa.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_kem.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/liboqs/$(DEPDIR)/iut.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/liboqs/$(DEPDIR)/iut_ml_dsa.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/liboqs/$(DEPDIR)/iut_ml_kem.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/acvp_app-iut.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/acvp_app-iut_aes.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cmac.Po@am__quote@ # am--include-marker
@@ -1308,12 +1363,55 @@ implementations/jitter_entropy/acvp_app-iut.obj: implementations/jitter_entropy/
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/jitter_entropy/acvp_app-iut.obj `if test -f 'implementations/jitter_entropy/iut.c'; then $(CYGPATH_W) 'implementations/jitter_entropy/iut.c'; else $(CYGPATH_W) '$(srcdir)/implementations/jitter_entropy/iut.c'; fi`
 
+implementations/liboqs/acvp_app-iut.o: implementations/liboqs/iut.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/liboqs/acvp_app-iut.o -MD -MP -MF implementations/liboqs/$(DEPDIR)/acvp_app-iut.Tpo -c -o implementations/liboqs/acvp_app-iut.o `test -f 'implementations/liboqs/iut.c' || echo '$(srcdir)/'`implementations/liboqs/iut.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/liboqs/$(DEPDIR)/acvp_app-iut.Tpo implementations/liboqs/$(DEPDIR)/acvp_app-iut.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/liboqs/iut.c' object='implementations/liboqs/acvp_app-iut.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/liboqs/acvp_app-iut.o `test -f 'implementations/liboqs/iut.c' || echo '$(srcdir)/'`implementations/liboqs/iut.c
+
+implementations/liboqs/acvp_app-iut.obj: implementations/liboqs/iut.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/liboqs/acvp_app-iut.obj -MD -MP -MF implementations/liboqs/$(DEPDIR)/acvp_app-iut.Tpo -c -o implementations/liboqs/acvp_app-iut.obj `if test -f 'implementations/liboqs/iut.c'; then $(CYGPATH_W) 'implementations/liboqs/iut.c'; else $(CYGPATH_W) '$(srcdir)/implementations/liboqs/iut.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/liboqs/$(DEPDIR)/acvp_app-iut.Tpo implementations/liboqs/$(DEPDIR)/acvp_app-iut.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/liboqs/iut.c' object='implementations/liboqs/acvp_app-iut.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/liboqs/acvp_app-iut.obj `if test -f 'implementations/liboqs/iut.c'; then $(CYGPATH_W) 'implementations/liboqs/iut.c'; else $(CYGPATH_W) '$(srcdir)/implementations/liboqs/iut.c'; fi`
+
+implementations/liboqs/acvp_app-iut_ml_kem.o: implementations/liboqs/iut_ml_kem.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/liboqs/acvp_app-iut_ml_kem.o -MD -MP -MF implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_kem.Tpo -c -o implementations/liboqs/acvp_app-iut_ml_kem.o `test -f 'implementations/liboqs/iut_ml_kem.c' || echo '$(srcdir)/'`implementations/liboqs/iut_ml_kem.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_kem.Tpo implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_kem.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/liboqs/iut_ml_kem.c' object='implementations/liboqs/acvp_app-iut_ml_kem.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/liboqs/acvp_app-iut_ml_kem.o `test -f 'implementations/liboqs/iut_ml_kem.c' || echo '$(srcdir)/'`implementations/liboqs/iut_ml_kem.c
+
+implementations/liboqs/acvp_app-iut_ml_kem.obj: implementations/liboqs/iut_ml_kem.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/liboqs/acvp_app-iut_ml_kem.obj -MD -MP -MF implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_kem.Tpo -c -o implementations/liboqs/acvp_app-iut_ml_kem.obj `if test -f 'implementations/liboqs/iut_ml_kem.c'; then $(CYGPATH_W) 'implementations/liboqs/iut_ml_kem.c'; else $(CYGPATH_W) '$(srcdir)/implementations/liboqs/iut_ml_kem.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_kem.Tpo implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_kem.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/liboqs/iut_ml_kem.c' object='implementations/liboqs/acvp_app-iut_ml_kem.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/liboqs/acvp_app-iut_ml_kem.obj `if test -f 'implementations/liboqs/iut_ml_kem.c'; then $(CYGPATH_W) 'implementations/liboqs/iut_ml_kem.c'; else $(CYGPATH_W) '$(srcdir)/implementations/liboqs/iut_ml_kem.c'; fi`
+
+implementations/liboqs/acvp_app-iut_ml_dsa.o: implementations/liboqs/iut_ml_dsa.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/liboqs/acvp_app-iut_ml_dsa.o -MD -MP -MF implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_dsa.Tpo -c -o implementations/liboqs/acvp_app-iut_ml_dsa.o `test -f 'implementations/liboqs/iut_ml_dsa.c' || echo '$(srcdir)/'`implementations/liboqs/iut_ml_dsa.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_dsa.Tpo implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_dsa.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/liboqs/iut_ml_dsa.c' object='implementations/liboqs/acvp_app-iut_ml_dsa.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/liboqs/acvp_app-iut_ml_dsa.o `test -f 'implementations/liboqs/iut_ml_dsa.c' || echo '$(srcdir)/'`implementations/liboqs/iut_ml_dsa.c
+
+implementations/liboqs/acvp_app-iut_ml_dsa.obj: implementations/liboqs/iut_ml_dsa.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/liboqs/acvp_app-iut_ml_dsa.obj -MD -MP -MF implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_dsa.Tpo -c -o implementations/liboqs/acvp_app-iut_ml_dsa.obj `if test -f 'implementations/liboqs/iut_ml_dsa.c'; then $(CYGPATH_W) 'implementations/liboqs/iut_ml_dsa.c'; else $(CYGPATH_W) '$(srcdir)/implementations/liboqs/iut_ml_dsa.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_dsa.Tpo implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_dsa.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/liboqs/iut_ml_dsa.c' object='implementations/liboqs/acvp_app-iut_ml_dsa.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/liboqs/acvp_app-iut_ml_dsa.obj `if test -f 'implementations/liboqs/iut_ml_dsa.c'; then $(CYGPATH_W) 'implementations/liboqs/iut_ml_dsa.c'; else $(CYGPATH_W) '$(srcdir)/implementations/liboqs/iut_ml_dsa.c'; fi`
+
 mostlyclean-libtool:
 	-rm -f *.lo
 
 clean-libtool:
 	-rm -rf .libs _libs
 	-rm -rf implementations/jitter_entropy/.libs implementations/jitter_entropy/_libs
+	-rm -rf implementations/liboqs/.libs implementations/liboqs/_libs
 	-rm -rf implementations/openssl/3/.libs implementations/openssl/3/_libs
 	-rm -rf implementations/openssl/3/registrations/.libs implementations/openssl/3/registrations/_libs
 	-rm -rf totp/.libs totp/_libs
@@ -1461,6 +1559,8 @@ distclean-generic:
 	-test . = "$(srcdir)" || test -z "$(CONFIG_CLEAN_VPATH_FILES)" || rm -f $(CONFIG_CLEAN_VPATH_FILES)
 	-rm -f implementations/jitter_entropy/$(DEPDIR)/$(am__dirstamp)
 	-rm -f implementations/jitter_entropy/$(am__dirstamp)
+	-rm -f implementations/liboqs/$(DEPDIR)/$(am__dirstamp)
+	-rm -f implementations/liboqs/$(am__dirstamp)
 	-rm -f implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
 	-rm -f implementations/openssl/3/$(am__dirstamp)
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/$(am__dirstamp)
@@ -1485,6 +1585,12 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/app_utils.Plo
 	-rm -f implementations/jitter_entropy/$(DEPDIR)/acvp_app-iut.Po
 	-rm -f implementations/jitter_entropy/$(DEPDIR)/iut.Plo
+	-rm -f implementations/liboqs/$(DEPDIR)/acvp_app-iut.Po
+	-rm -f implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_dsa.Po
+	-rm -f implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_kem.Po
+	-rm -f implementations/liboqs/$(DEPDIR)/iut.Plo
+	-rm -f implementations/liboqs/$(DEPDIR)/iut_ml_dsa.Plo
+	-rm -f implementations/liboqs/$(DEPDIR)/iut_ml_kem.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_aes.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cmac.Po
@@ -1584,6 +1690,12 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/app_utils.Plo
 	-rm -f implementations/jitter_entropy/$(DEPDIR)/acvp_app-iut.Po
 	-rm -f implementations/jitter_entropy/$(DEPDIR)/iut.Plo
+	-rm -f implementations/liboqs/$(DEPDIR)/acvp_app-iut.Po
+	-rm -f implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_dsa.Po
+	-rm -f implementations/liboqs/$(DEPDIR)/acvp_app-iut_ml_kem.Po
+	-rm -f implementations/liboqs/$(DEPDIR)/iut.Plo
+	-rm -f implementations/liboqs/$(DEPDIR)/iut_ml_dsa.Plo
+	-rm -f implementations/liboqs/$(DEPDIR)/iut_ml_kem.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_aes.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cmac.Po

--- a/app/implementations/liboqs/iut.c
+++ b/app/implementations/liboqs/iut.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024, Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/cisco/libacvp/LICENSE
+ */
+
+#include "app_lcl.h"
+#include "implementations/liboqs/iut.h"
+#include "safe_mem_lib.h"
+#include "safe_str_lib.h"
+
+#include <oqs/common.h>
+
+void iut_print_version(APP_CONFIG *cfg) {
+    printf("liboqs version: %s\n", OQS_version());
+}
+
+ACVP_RESULT iut_cleanup() {
+    iut_ml_kem_cleanup();
+    return ACVP_SUCCESS;
+}
+
+
+ACVP_RESULT iut_setup(APP_CONFIG *cfg) {
+    return ACVP_SUCCESS;
+}
+
+ACVP_RESULT iut_register_capabilities(ACVP_CTX *ctx, APP_CONFIG *cfg) {
+    ACVP_RESULT rv = ACVP_SUCCESS;
+
+    if (cfg->ml_kem|| cfg->testall) {
+        rv = acvp_cap_ml_kem_enable(ctx, ACVP_ML_KEM_KEYGEN, &app_ml_kem_handler);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_KEYGEN, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_512);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_KEYGEN, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_768);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_KEYGEN, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_1024);
+        CHECK_ENABLE_CAP_RV(rv);
+
+        rv = acvp_cap_ml_kem_enable(ctx, ACVP_ML_KEM_XCAP, &app_ml_kem_handler);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_512);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_768);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_1024);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_FUNCTION, ACVP_ML_KEM_FUNCTION_ENCAPSULATE);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_FUNCTION, ACVP_ML_KEM_FUNCTION_DECAPSULATE);
+        CHECK_ENABLE_CAP_RV(rv);
+    }
+
+#if 0
+    if (cfg->ml_dsa || cfg->testall) {
+        rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_KEYGEN, &app_ml_dsa_handler);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_KEYGEN, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_44);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_KEYGEN, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_65);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_KEYGEN, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_87);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_SIGGEN, &app_ml_dsa_handler);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_44);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_65);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_87);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, ACVP_ML_DSA_PARAM_DETERMINISTIC_MODE, ACVP_ML_DSA_DETERMINISTIC_BOTH);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_SIGVER, &app_ml_dsa_handler);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_44);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_65);
+        CHECK_ENABLE_CAP_RV(rv);
+        rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_87);
+        CHECK_ENABLE_CAP_RV(rv);
+    }
+#endif
+
+end:
+    return rv;
+}

--- a/app/implementations/liboqs/iut.h
+++ b/app/implementations/liboqs/iut.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024, Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/cisco/libacvp/LICENSE
+ */
+
+#ifndef ACVP_APP_IUT_H
+#define ACVP_APP_IUT_H
+
+#include "acvp/acvp.h"
+
+int app_ml_kem_handler(ACVP_TEST_CASE *test_case);
+int app_ml_dsa_handler(ACVP_TEST_CASE *test_case);
+
+void iut_ml_kem_cleanup(void);
+
+#endif // ACVP_APP_IUT_H
+

--- a/app/implementations/liboqs/iut_ml_dsa.c
+++ b/app/implementations/liboqs/iut_ml_dsa.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024, Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/cisco/libacvp/LICENSE
+ */
+
+#include "app_lcl.h"
+
+int app_ml_dsa_handler(ACVP_TEST_CASE *test_case) {
+    /*
+     * "tc" is test_case->tc.ml_dsa. All modes use tc->param_set to specify ML-DSA-44, 65, or 87.
+     *
+     * For keygen, take tc->seed and use it to generate tc->pub_key and tc->secret_key (and their
+     * _len values)
+     *
+     * For siggen, there are two test types (tc->type). AFT, and GDT. GDT tests provide a message,
+     * tc->msg, and expects a pub key and a signature, tc->sig, value in response. the pk value is
+     * generated once PER GROUP. The library will take the pk value from the first test case in the
+     * test group.
+     * Siggen AFT provides a message and a secret key value, and expects a signature in
+     * response. if you are not testing deterministically (tc->deterministic flag), then a random
+     * value (tc->rnd) is also provided to incorporate.
+     *
+     * For sigver, a pub key value is provided (it is constant for each test case in a test group
+     * and varies between groups), as well as a message and a signature. IuTs are expected to
+     * indicate that the provided signature is correct based on the message and other parameters.
+     * If correct, tc->ver_disposition should be set to 1. If incorrect, set it to 0 (is 0 by
+     * default).
+     */
+
+
+    if (!test_case) {
+        return -1;
+    }
+
+    return 0;
+}
+

--- a/app/implementations/liboqs/iut_ml_kem.c
+++ b/app/implementations/liboqs/iut_ml_kem.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2024, Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/cisco/libacvp/LICENSE
+ */
+
+#include "app_lcl.h"
+#include "safe_lib.h"
+
+#include <oqs/kem.h>
+
+/* Seed buffer for keygen, m buffer for encap */
+static unsigned char *rng_buffer = NULL;
+/* Total size of the seed buffer */
+static size_t rng_buf_size = 0;
+/* Iterator for the seed buffer */
+static int rng_buf_pos = 0;
+
+void iut_ml_kem_cleanup(void) {
+    if (rng_buffer) free(rng_buffer);
+    rng_buffer = NULL;
+}
+
+/**
+ * This function loops through the rng_buffer buffer and returns it as RNG; once at the end
+ * of the buffer, it goes back to the beginning
+ */
+void oqs_rng_callback_acvp(uint8_t *random_array, size_t bytes_to_read) {
+    int remaining_bytes = bytes_to_read;
+    int bytes_sent = 0;
+    int bytes_going_this_round = 0;
+
+    if (!rng_buffer || !rng_buf_size) {
+        return;
+    }
+
+    while (remaining_bytes > 0) {
+        //if we need to send more bytes than there is space left in the buffer, send only until the end of the buffer
+        bytes_going_this_round = remaining_bytes < rng_buf_size - rng_buf_pos ? remaining_bytes : rng_buf_size - rng_buf_pos;
+        memcpy_s(random_array + bytes_sent, bytes_to_read - bytes_sent, rng_buffer + rng_buf_pos, bytes_going_this_round);
+        bytes_sent += bytes_going_this_round;
+        remaining_bytes -= bytes_going_this_round;
+        rng_buf_pos += bytes_sent;
+        //if we hit end of buffer, go back to beginning
+        if (rng_buf_pos >= rng_buf_size - 1) {
+            rng_buf_pos = 0;
+        }
+    }
+}
+
+ 
+int app_ml_kem_handler(ACVP_TEST_CASE *test_case) {
+    ACVP_ML_KEM_TC *tc =NULL;
+    int rv = ACVP_CRYPTO_MODULE_FAIL;
+    OQS_KEM *kem = NULL;
+    const char *param_set = NULL;
+    if (!test_case) {
+        return -1;
+    }
+
+    tc = test_case->tc.ml_kem;
+    if (!tc) return rv;
+
+    switch (tc->param_set) {
+    case ACVP_ML_KEM_PARAM_SET_ML_KEM_512:
+        param_set = OQS_KEM_alg_ml_kem_512;
+        break;
+    case ACVP_ML_KEM_PARAM_SET_ML_KEM_768:
+        param_set = OQS_KEM_alg_ml_kem_768;
+        break;
+    case ACVP_ML_KEM_PARAM_SET_ML_KEM_1024:
+        param_set = OQS_KEM_alg_ml_kem_1024;
+        break;
+    case ACVP_ML_KEM_PARAM_SET_NONE:
+    case ACVP_ML_KEM_PARAM_SET_MAX:
+    default:
+        printf("Invalid param set for ML-KEM\n");
+        goto end;
+    }
+
+    kem = OQS_KEM_new(param_set);
+    if (!kem) {
+        printf("Error creating KEM object\n");
+        goto end;
+    }
+
+    if (tc->cipher == ACVP_ML_KEM_KEYGEN) {
+        /** 
+         * We need to specify the D and Z seed values that ML-KEM uses. We cannot do that directly.
+         * However, we can specify a custom RNG function. For testing's sake, we set a RNG function
+         * that really just returns bytes for the D and Z values the server specifies. This is not
+         * ideal and hopefully there will be a more refined way of handling this in the future.
+         */
+        if (rng_buffer) {
+            printf("Error: rng_buffer value should not already be set\n");
+            goto end;
+        }
+        rng_buf_size = tc->d_len + tc->z_len;
+        rng_buffer = calloc(rng_buf_size, sizeof(unsigned char));
+        if (!rng_buffer) {
+            printf("Error allocating seed buffer for ML-KEM\n");
+            goto end;
+        }
+        /* append D and Z in the buffer */
+        memcpy_s(rng_buffer, rng_buf_size, tc->d, tc->d_len);
+        memcpy_s(rng_buffer + tc->d_len, rng_buf_size - tc->d_len, tc->z, tc->z_len);
+
+        OQS_randombytes_custom_algorithm(&oqs_rng_callback_acvp);
+
+        if (OQS_KEM_keypair(kem, tc->ek, tc->dk) != OQS_SUCCESS) {
+            printf("Error generating keypair for ML-KEM\n");
+            goto end;
+        }
+        tc->ek_len = kem->length_public_key;
+        tc->dk_len = kem->length_secret_key;
+
+    } else if (tc->cipher == ACVP_ML_KEM_XCAP) {
+
+        if (tc->function == ACVP_ML_KEM_FUNCTION_ENCAPSULATE) {
+            /* encapsulation needs to set a random m value the same way keygen needs D and Z described above */
+            rng_buf_size = tc->m_len;
+            rng_buffer = calloc(rng_buf_size, sizeof(unsigned char));
+            if (!rng_buffer) {
+                printf("Error allocating m buffer for ML-KEM\n");
+                goto end;
+            }
+            /* Place m in the buffer */
+            memcpy_s(rng_buffer, rng_buf_size, tc->m, tc->m_len);
+
+            OQS_randombytes_custom_algorithm(&oqs_rng_callback_acvp);
+
+            OQS_KEM_encaps(kem, tc->c, tc->k, tc->ek);
+            tc->c_len = kem->length_ciphertext;
+            tc->k_len = kem->length_shared_secret;
+        } else { //decapsulate
+            OQS_KEM_decaps(kem, tc->k, tc->c, tc->dk);
+            tc->k_len = kem->length_shared_secret;
+        }
+    } else {
+        printf("Error: invalid cipher given for ML-KEM\n");
+        goto end;
+    }
+
+    rv = 0;
+end:
+    if (rng_buffer) free(rng_buffer);
+    rng_buffer = NULL;
+    if (kem) OQS_KEM_free(kem);
+    return rv;
+}

--- a/app/implementations/liboqs/iut_ml_kem.c
+++ b/app/implementations/liboqs/iut_ml_kem.c
@@ -22,6 +22,8 @@ static int rng_buf_pos = 0;
 void iut_ml_kem_cleanup(void) {
     if (rng_buffer) free(rng_buffer);
     rng_buffer = NULL;
+    rng_buf_pos = 0;
+    rng_buf_size = 0;
 }
 
 /**
@@ -148,6 +150,8 @@ int app_ml_kem_handler(ACVP_TEST_CASE *test_case) {
 end:
     if (rng_buffer) free(rng_buffer);
     rng_buffer = NULL;
+    rng_buf_pos = 0;
+    rng_buf_size = 0;
     if (kem) OQS_KEM_free(kem);
     return rv;
 }

--- a/configure
+++ b/configure
@@ -819,6 +819,8 @@ LIBACVP_CFLAGS
 LIBACVP_LDFLAGS
 LIBCURL_LDFLAGS
 LIBCURL_CFLAGS
+APP_IUT_LIBOQS_FALSE
+APP_IUT_LIBOQS_TRUE
 APP_IUT_OPENSSL_3_FALSE
 APP_IUT_OPENSSL_3_TRUE
 APP_IUT_OPENSSL_1_FALSE
@@ -978,6 +980,7 @@ enable_ssp
 enable_wrapper_library
 with_ssl_dir
 with_jent_dir
+with_liboqs_dir
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1659,6 +1662,7 @@ Optional Packages:
   --with-criterion-dir    location of Criterion install folder
   --with-ssl-dir          location of OpenSSL install folder
   --with-jent-dir         Path to JENT install directory
+  --with-liboqs-dir       Path to liboqs install directory
 
 Some influential environment variables:
   CC          C compiler command
@@ -5525,13 +5529,13 @@ then :
 else $as_nop
   lt_cv_nm_interface="BSD nm"
   echo "int some_variable = 0;" > conftest.$ac_ext
-  (eval echo "\"\$as_me:5528: $ac_compile\"" >&5)
+  (eval echo "\"\$as_me:5532: $ac_compile\"" >&5)
   (eval "$ac_compile" 2>conftest.err)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:5531: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
+  (eval echo "\"\$as_me:5535: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
   (eval "$NM \"conftest.$ac_objext\"" 2>conftest.err > conftest.out)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:5534: output\"" >&5)
+  (eval echo "\"\$as_me:5538: output\"" >&5)
   cat conftest.out >&5
   if $GREP 'External.*some_variable' conftest.out > /dev/null; then
     lt_cv_nm_interface="MS dumpbin"
@@ -6781,7 +6785,7 @@ ia64-*-hpux*)
   ;;
 *-*-irix6*)
   # Find out which ABI we are using.
-  echo '#line 6784 "configure"' > conftest.$ac_ext
+  echo '#line 6788 "configure"' > conftest.$ac_ext
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
@@ -8128,11 +8132,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8131: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8135: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:8135: \$? = $ac_status" >&5
+   echo "$as_me:8139: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8468,11 +8472,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8471: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8475: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:8475: \$? = $ac_status" >&5
+   echo "$as_me:8479: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8575,11 +8579,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8578: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8582: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8582: \$? = $ac_status" >&5
+   echo "$as_me:8586: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -8631,11 +8635,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8634: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8638: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8638: \$? = $ac_status" >&5
+   echo "$as_me:8642: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -11009,7 +11013,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 11012 "configure"
+#line 11016 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -11106,7 +11110,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 11109 "configure"
+#line 11113 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -11571,6 +11575,14 @@ fi
 if test ${with_jent_dir+y}
 then :
   withval=$with_jent_dir; iut_dir="$withval"; iut_specified=$((iut_specified+1)); acvp_app_iut="jent"; iut_lflag="-ljitterentropy"
+fi
+
+
+
+# Check whether --with-liboqs-dir was given.
+if test ${with_liboqs_dir+y}
+then :
+  withval=$with_liboqs_dir; iut_dir="$withval"; iut_specified=$((iut_specified+1)); acvp_app_iut="liboqs"; iut_lflag="-loqs"
 fi
 
 
@@ -12043,6 +12055,73 @@ See \`config.log' for more details" "$LINENO" 5; }
 fi
 
 
+        elif test "x$acvp_app_iut" = "xliboqs"; then
+            lib_dependencies+="-lcrypto "
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing OQS_version" >&5
+printf %s "checking for library containing OQS_version... " >&6; }
+if test ${ac_cv_search_OQS_version+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char OQS_version ();
+int
+main (void)
+{
+return OQS_version ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' oqs
+do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib "$lib_dependencies" $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_search_OQS_version=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext
+  if test ${ac_cv_search_OQS_version+y}
+then :
+  break
+fi
+done
+if test ${ac_cv_search_OQS_version+y}
+then :
+
+else $as_nop
+  ac_cv_search_OQS_version=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_OQS_version" >&5
+printf "%s\n" "$ac_cv_search_OQS_version" >&6; }
+ac_res=$ac_cv_search_OQS_version
+if test "$ac_res" != no
+then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+else $as_nop
+  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "Cannot locate liboqs
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+
+
         fi
         ######################
         # End checks for IUT #
@@ -12224,6 +12303,14 @@ fi
 else
   APP_IUT_OPENSSL_3_TRUE='#'
   APP_IUT_OPENSSL_3_FALSE=
+fi
+
+ if test "x$acvp_app_iut" = "xliboqs"; then
+  APP_IUT_LIBOQS_TRUE=
+  APP_IUT_LIBOQS_FALSE='#'
+else
+  APP_IUT_LIBOQS_TRUE='#'
+  APP_IUT_LIBOQS_FALSE=
 fi
 
 
@@ -12518,6 +12605,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${APP_IUT_OPENSSL_3_TRUE}" && test -z "${APP_IUT_OPENSSL_3_FALSE}"; then
   as_fn_error $? "conditional \"APP_IUT_OPENSSL_3\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${APP_IUT_LIBOQS_TRUE}" && test -z "${APP_IUT_LIBOQS_FALSE}"; then
+  as_fn_error $? "conditional \"APP_IUT_LIBOQS\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${UNIT_TEST_SUPPORTED_TRUE}" && test -z "${UNIT_TEST_SUPPORTED_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,12 @@ if test "x$disable_app" = "xno" ; then
         [iut_dir="$withval"; iut_specified=$((iut_specified+1)); acvp_app_iut="jent"; iut_lflag="-ljitterentropy"],
         [])
 
+    AC_ARG_WITH([liboqs-dir],
+        [AS_HELP_STRING([--with-liboqs-dir],
+        [Path to liboqs install directory])],
+        [iut_dir="$withval"; iut_specified=$((iut_specified+1)); acvp_app_iut="liboqs"; iut_lflag="-loqs"],
+        [])
+
     if test $iut_specified -gt 1 ; then
         AC_MSG_FAILURE([Multiple testable implementations provided. Please only provide a path to one testable implementations])
     fi
@@ -269,6 +275,11 @@ if test "x$disable_lib_detection" = "xno"; then
             AC_SEARCH_LIBS([jent_entropy_init], [jitterentropy], [],
                         [AC_MSG_FAILURE([Cannot locate libjitterentropy])], ["$lib_dependencies"])
 
+        elif test "x$acvp_app_iut" = "xliboqs"; then
+            lib_dependencies+="-lcrypto "
+            AC_SEARCH_LIBS([OQS_version], [oqs], [],
+                        [AC_MSG_FAILURE([Cannot locate liboqs])], ["$lib_dependencies"])
+
         fi
         ######################
         # End checks for IUT #
@@ -337,6 +348,7 @@ fi
 AM_CONDITIONAL([APP_IUT_JENT], [test "x$acvp_app_iut" = "xjent"])
 AM_CONDITIONAL([APP_IUT_OPENSSL_1], [test "x$acvp_app_iut" = "xopenssl_1"])
 AM_CONDITIONAL([APP_IUT_OPENSSL_3], [test "x$acvp_app_iut" = "xopenssl_3"])
+AM_CONDITIONAL([APP_IUT_LIBOQS], [test "x$acvp_app_iut" = "xliboqs"])
 
 # Set the flags needed for curl/murl library
 if test "x$libcurldir" != "x" ; then


### PR DESCRIPTION
- Add support for building against liboqs with configure option (Tested with default static library for now, will double check shared as continue development)
- Add support for testing ML-KEM keygen and encap/decap using liboqs
    - Unable to set needed random values that are server provided. However, we can set a custom RNG callback (similar to what liboqs does in its tests/examples) and fill that buffer with the needed values.
    
Thoughts for liboqs:
- Store d and z values (keygen) as well as m values (encap) in the OQS_KEM object, or at least some reference to them. Allow user to set them. Have keypair/encap/decap calls check if user has set values, and only perform random generation if not. 
- Add small convenience function to reset RNG callback to default after a custom one has been set. (We could set the pointer back to the same function, but there are different options depending on if OpenSSL was used or not, etc). 