### PR TITLE
Updates windows builds for new app structure; fix freeBSD builds

### DIFF
--- a/app/app_main.c
+++ b/app/app_main.c
@@ -96,6 +96,25 @@ static ACVP_RESULT progress(char *msg, ACVP_LOG_LVL level) {
 
     printf("[ACVP]");
 
+#ifdef _WIN32
+    switch (level) {
+    case ACVP_LOG_LVL_ERR:
+        printf("[ERROR]");
+        break;
+    case ACVP_LOG_LVL_WARN:
+        printf("[WARNING]");
+        break;
+    case ACVP_LOG_LVL_STATUS:
+    case ACVP_LOG_LVL_INFO:
+    case ACVP_LOG_LVL_VERBOSE:
+    case ACVP_LOG_LVL_DEBUG:
+    case ACVP_LOG_LVL_NONE:
+    case ACVP_LOG_LVL_MAX:
+    default:
+        break;
+    }
+
+#else
     switch (level) {
     case ACVP_LOG_LVL_ERR:
         printf(ANSI_COLOR_RED "[ERROR]" ANSI_COLOR_RESET);
@@ -112,6 +131,7 @@ static ACVP_RESULT progress(char *msg, ACVP_LOG_LVL level) {
     default:
         break;
     }
+#endif
 
     printf(": %s\n", msg);
 

--- a/configure
+++ b/configure
@@ -13076,7 +13076,7 @@ ac_res=$ac_cv_search_gzdopen
 if test "$ac_res" != no
 then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
-  lib_dependencies+="-lz "
+  lib_dependencies="${lib_dependencies} -lz "
 fi
 
     fi
@@ -13105,17 +13105,17 @@ fi
 printf %s "checking for presence of lib${lib} in lib/lib64 dirs... " >&6; }
                 # Check for shared libraries in lib64, then lib. If no match, check for static libraries in either dir.
                 if test -f "$iut_dir/lib64/lib${lib}.so"; then
-                    iut_lib_flags+="$iut_dir/lib64/lib${lib}.so "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib64/lib${lib}.so "
                 elif test -f "$iut_dir/lib64/lib${lib}.dylib"; then
-                    iut_lib_flags+="$iut_dir/lib64/lib${lib}.dylib "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib64/lib${lib}.dylib "
                 elif test -f "$iut_dir/lib/lib${lib}.so"; then
-                    iut_lib_flags+="$iut_dir/lib/lib${lib}.so "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib/lib${lib}.so "
                 elif test -f "$iut_dir/lib/lib${lib}.dylib"; then
-                    iut_lib_flags+="$iut_dir/lib/lib${lib}.dylib "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib/lib${lib}.dylib "
                 elif test -f "$iut_dir/lib64/lib${lib}.a"; then
-                    iut_lib_flags+="$iut_dir/lib64/lib${lib}.a "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib64/lib${lib}.a "
                 elif test -f "$iut_dir/lib/lib${lib}.a"; then
-                    iut_lib_flags+="$iut_dir/lib/lib${lib}.a "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib/lib${lib}.a "
                 else
                     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
@@ -13128,7 +13128,7 @@ printf "%s\n" "yes" >&6; }
             IFS="$tmp_ifs"
             tmp_cflags="$CFLAGS"
             CFLAGS="$CFLAGS -I$iut_dir/include"
-            LIBS="$iut_lib_flags $LIBS"
+            LIBS="${iut_lib_flags} $LIBS"
         fi
 
         if test "x$acvp_app_iut" = "xopenssl"; then
@@ -13188,7 +13188,7 @@ ac_res=$ac_cv_search_dlopen
 if test "$ac_res" != no
 then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
-  lib_dependencies+="-ldl "
+  lib_dependencies="${lib_dependencies} -ldl "
 fi
 
 
@@ -13230,7 +13230,7 @@ printf %s "checking for link to libcrypto... " >&6; }
 int
 main (void)
 {
-EVP_CIPHER_CTX_get_num(NULL);
+OpenSSL_version(0);
   ;
   return 0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -235,7 +235,7 @@ if test "x$disable_lib_detection" = "xno"; then
     fi
 
     if test "x$enable_offline" != "xfalse"; then
-        AC_SEARCH_LIBS([gzdopen], [z], [lib_dependencies+="-lz "], [], [])
+        AC_SEARCH_LIBS([gzdopen], [z], [lib_dependencies="${lib_dependencies} -lz "], [], [])
     fi
 
     if test "x$disable_app" = "xno" ; then
@@ -261,17 +261,17 @@ if test "x$disable_lib_detection" = "xno"; then
                 AC_MSG_CHECKING(for presence of lib${lib} in lib/lib64 dirs)
                 # Check for shared libraries in lib64, then lib. If no match, check for static libraries in either dir.
                 if test -f "$iut_dir/lib64/lib${lib}.so"; then
-                    iut_lib_flags+="$iut_dir/lib64/lib${lib}.so "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib64/lib${lib}.so "
                 elif test -f "$iut_dir/lib64/lib${lib}.dylib"; then
-                    iut_lib_flags+="$iut_dir/lib64/lib${lib}.dylib "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib64/lib${lib}.dylib "
                 elif test -f "$iut_dir/lib/lib${lib}.so"; then
-                    iut_lib_flags+="$iut_dir/lib/lib${lib}.so "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib/lib${lib}.so "
                 elif test -f "$iut_dir/lib/lib${lib}.dylib"; then
-                    iut_lib_flags+="$iut_dir/lib/lib${lib}.dylib "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib/lib${lib}.dylib "
                 elif test -f "$iut_dir/lib64/lib${lib}.a"; then
-                    iut_lib_flags+="$iut_dir/lib64/lib${lib}.a "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib64/lib${lib}.a "
                 elif test -f "$iut_dir/lib/lib${lib}.a"; then
-                    iut_lib_flags+="$iut_dir/lib/lib${lib}.a "
+                    iut_lib_flags="${iut_lib_flags} $iut_dir/lib/lib${lib}.a "
                 else
                     AC_MSG_FAILURE([Cannot locate lib${lib} in $iut_dir/lib64 or $iut_dir/lib])
                 fi
@@ -280,11 +280,11 @@ if test "x$disable_lib_detection" = "xno"; then
             IFS="$tmp_ifs"
             tmp_cflags="$CFLAGS"
             CFLAGS="$CFLAGS -I$iut_dir/include"
-            LIBS="$iut_lib_flags $LIBS"
+            LIBS="${iut_lib_flags} $LIBS"
         fi
 
         if test "x$acvp_app_iut" = "xopenssl"; then
-            AC_SEARCH_LIBS([dlopen], [dl], [lib_dependencies+="-ldl "], [], [])
+            AC_SEARCH_LIBS([dlopen], [dl], [lib_dependencies="${lib_dependencies} -ldl "], [], [])
 
             AC_COMPILE_IFELSE(
                 [AC_LANG_PROGRAM([[
@@ -301,7 +301,7 @@ if test "x$disable_lib_detection" = "xno"; then
             AC_LINK_IFELSE(
                 [AC_LANG_PROGRAM([
                     #include <openssl/evp.h>
-                ], [EVP_CIPHER_CTX_get_num(NULL);])],
+                ], [OpenSSL_version(0);])],
                 [AC_MSG_RESULT(yes)],[AC_MSG_FAILURE([Cannot link to given libcrypto])]
             )
             AC_MSG_CHECKING(for link to libssl)

--- a/ms/acvp_app.sln
+++ b/ms/acvp_app.sln
@@ -7,20 +7,14 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "acvp_app", "resources\acvp_
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		fom|x64 = fom|x64
-		fom|x86 = fom|x86
-		nofom|x64 = nofom|x64
-		nofom|x86 = nofom|x86
+		openssl3|x64 = openssl3|x64
+		openssl3|x86 = openssl3|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom|x64.ActiveCfg = fom|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom|x64.Build.0 = fom|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom|x86.ActiveCfg = fom|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.fom|x86.Build.0 = fom|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom|x64.ActiveCfg = nofom|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom|x64.Build.0 = nofom|x64
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom|x86.ActiveCfg = nofom|Win32
-		{6A63359B-E912-421D-B6B9-02A9B45B3067}.nofom|x86.Build.0 = nofom|Win32
+		{6A63359B-E912-421D-B6B9-02A9B45B3067}.openssl3|x64.ActiveCfg = openssl3|x64
+		{6A63359B-E912-421D-B6B9-02A9B45B3067}.openssl3|x64.Build.0 = openssl3|x64
+		{6A63359B-E912-421D-B6B9-02A9B45B3067}.openssl3|x86.ActiveCfg = openssl3|Win32
+		{6A63359B-E912-421D-B6B9-02A9B45B3067}.openssl3|x86.Build.0 = openssl3|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ms/make_app.bat
+++ b/ms/make_app.bat
@@ -7,13 +7,7 @@ rem Visual Studio wants absolute paths in some cases
 set ACV_ROOT_PATH_REL=%~dp0..\
 for %%i in ("%ACV_ROOT_PATH_REL%") do SET "ACV_ROOT_PATH=%%~fi
 
-set PROJ_CONFIG="nofom"
-
-if NOT [%FOM_DIR%] == [] (
-  set ACV_LIB_PATHS=%FOM_DIR%\lib
-  set ACV_INC_PATHS=%FOM_DIR%\include
-  set PROJ_CONFIG=fom
-)
+set PROJ_CONFIG="openssl3"
 
 if [%SSL_DIR%] == [] (
   echo "Missing SSL dir, stopping"

--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -26,6 +26,7 @@ EXPORTS
   acvp_cap_ecdsa_enable
   acvp_cap_eddsa_enable
   acvp_cap_eddsa_set_parm
+  acvp_cap_eddsa_set_domain
   acvp_cap_rsa_keygen_set_parm
   acvp_cap_rsa_sigver_set_parm
   acvp_cap_rsa_keygen_set_mode
@@ -87,8 +88,12 @@ EXPORTS
   acvp_cap_lms_set_mode_compatability_pair
   acvp_cap_ml_dsa_enable
   acvp_cap_ml_dsa_set_parm
+  acvp_cap_ml_dsa_set_domain
   acvp_cap_ml_kem_enable
   acvp_cap_ml_kem_set_parm
+  acvp_cap_slh_dsa_enable
+  acvp_cap_slh_dsa_set_parm
+  acvp_cap_slh_dsa_set_domain
   acvp_cap_set_prereq
   acvp_create_test_session
   acvp_free_test_session
@@ -157,4 +162,5 @@ EXPORTS
   acvp_get_lms_alg
   acvp_get_ml_dsa_alg
   acvp_get_ml_kem_alg
+  acvp_get_slh_dsa_alg
   acvp_sleep

--- a/ms/resources/acvp_app.vcxproj
+++ b/ms/resources/acvp_app.vcxproj
@@ -1,20 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="fom|Win32">
-      <Configuration>fom</Configuration>
+    <ProjectConfiguration Include="openssl3|Win32">
+      <Configuration>openssl3</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="fom|x64">
-      <Configuration>fom</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="nofom|Win32">
-      <Configuration>nofom</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="nofom|x64">
-      <Configuration>nofom</Configuration>
+    <ProjectConfiguration Include="openssl3|x64">
+      <Configuration>openssl3</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
@@ -25,19 +17,11 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='fom|x64'">
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='openssl3|x64'">
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='openssl3|Win32'">
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -47,95 +31,69 @@
   <ImportGroup Label="Shared">
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='openssl3|Win32'">
     <OutDir>$(SolutionDir)\build\</OutDir>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
     <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='fom|x64'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='openssl3|x64'">
     <OutDir>$(SolutionDir)\build\</OutDir>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
     <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">
-    <OutDir>$(SolutionDir)\build\</OutDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='fom|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='openssl3|Win32'">
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;fipscanister.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
-      <PreprocessorDefinitions>ACVP_NO_RUNTIME;__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include;$(ProjectDir)..\..\totp;$(ProjectDir)..\..\app\</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='fom|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='openssl3|x64'">
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;fipscanister.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
-      <PreprocessorDefinitions>ACVP_NO_RUNTIME;__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='nofom|Win32'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include</AdditionalIncludeDirectories>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='nofom|x64'">
-    <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;Normaliz.lib;Ws2_32.lib;Wldap32.lib;crypt32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libacvp.lib;libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ACV_LIB_PATHS)</AdditionalLibraryDirectories>
-    </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;$(ACV_KDF_SUPPORT);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>__STDC_WANT_SECURE_LIB__=0;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ACV_INC_PATHS);$(ProjectDir)..\..\safe_c_stub\include;$(ProjectDir)..\..\app\totp;$(ProjectDir)..\..\app\</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\app\app_aes.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_aes.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_cmac.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_des.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_drbg.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_dsa.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_ecdsa.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_eddsa.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_hmac.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_kas.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_kdf.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_kda.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_kmac.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_ml_dsa.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_ml_kem.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_slh_dsa.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_rsa.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_hash.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_utils.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\registrations\fp_30X.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\registrations\fp_312.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\registrations\fp_340.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\registrations\fp_350.c" />
+    <ClCompile Include="..\..\app\implementations\openssl\3\registrations\non_fips.c" />
     <ClCompile Include="..\..\app\app_cli.c" />
-    <ClCompile Include="..\..\app\app_cmac.c" />
-    <ClCompile Include="..\..\app\app_des.c" />
-    <ClCompile Include="..\..\app\app_drbg.c" />
-    <ClCompile Include="..\..\app\app_dsa.c" />
-    <ClCompile Include="..\..\app\app_ecdsa.c" />
-    <ClCompile Include="..\..\app\app_eddsa.c" />
-    <ClCompile Include="..\..\app\app_hmac.c" />
-    <ClCompile Include="..\..\app\app_kas.c" />
-    <ClCompile Include="..\..\app\app_kdf.c" />
-    <ClCompile Include="..\..\app\app_kda.c" />
-    <ClCompile Include="..\..\app\app_kmac.c" />
-    <ClCompile Include="..\..\app\app_lms.c" />
-    <ClCompile Include="..\..\app\app_ml_dsa.c" />
-    <ClCompile Include="..\..\app\app_ml_kem.c" />
-    <ClCompile Include="..\..\app\app_main.c" />
-    <ClCompile Include="..\..\app\app_rsa.c" />
-    <ClCompile Include="..\..\app\app_sha.c" />
     <ClCompile Include="..\..\app\app_utils.c" />
+    <ClCompile Include="..\..\app\app_main.c" />
+    <ClCompile Include="..\..\app\totp\hmac_sha256.c" />
+    <ClCompile Include="..\..\app\totp\sha256.c" />
+    <ClCompile Include="..\..\app\totp\totp.c" />
     <ClCompile Include="..\..\safe_c_stub\src\safe_str_stub.c" />
     <ClCompile Include="..\..\safe_c_stub\src\safe_mem_stub.c" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\..\app\app_fips_init_lcl.h" />
-    <ClInclude Include="..\..\app\app_fips_lcl.h" />
-    <ClInclude Include="..\..\app\app_lcl.h" />
-    <ClInclude Include="..\..\app\ketopt.h" />
-    <ClCompile Include="..\..\safe_c_stub\include\mem_primitives_lib.h" />
-    <ClCompile Include="..\..\safe_c_stub\include\safe_lib.h" />
-    <ClCompile Include="..\..\safe_c_stub\include\safe_lib_errno.h" />
-    <ClCompile Include="..\..\safe_c_stub\include\safe_mem_lib.h" />
-    <ClCompile Include="..\..\safe_c_stub\include\safe_str_lib.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ms/resources/acvp_app.vcxproj.filters
+++ b/ms/resources/acvp_app.vcxproj.filters
@@ -15,64 +15,94 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\app\app_aes.c">
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_aes.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_cmac.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_des.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_drbg.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_dsa.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_ecdsa.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_eddsa.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_hmac.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_kas.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_kdf.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_kda.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_kmac.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_ml_dsa.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_ml_kem.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_slh_dsa.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_rsa.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_hash.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut_utils.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\iut.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\registrations\fp_30X.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\registrations\fp_312.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\registrations\fp_340.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\registrations\fp_350.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\implementations\openssl\3\registrations\non_fips.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\app\app_cli.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\app\app_cmac.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_des.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_drbg.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_dsa.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_ecdsa.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_eddsa.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_hmac.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_kas.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_kdf.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_kda.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_kmac.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_lms.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_ml_dsa.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\app\app_ml_kem.c">
+    <ClCompile Include="..\..\app\app_utils.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\app\app_main.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\app\app_rsa.c">
+    <ClCompile Include="..\..\app\totp\sha256.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\app\app_sha.c">
+    <ClCompile Include="..\..\app\totp\hmac_sha256.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\app\app_utils.c">
+    <ClCompile Include="..\..\app\totp\totp.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\safe_c_stub\src\safe_str_stub.c">
@@ -81,6 +111,8 @@
     <ClCompile Include="..\..\safe_c_stub\src\safe_mem_stub.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
     <ClCompile Include="..\..\safe_c_stub\include\mem_primitives_lib.h">
       <Filter>Header Files</Filter>
     </ClCompile>
@@ -96,12 +128,13 @@
     <ClCompile Include="..\..\safe_c_stub\include\safe_str_lib.h">
       <Filter>Header Files</Filter>
     </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\..\app\app_fips_init_lcl.h">
+    <ClCompile Include="..\..\app\totp\hmac_sha256.h">
       <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\app\app_fips_lcl.h">
+    </ClCompile>
+    <ClCompile Include="..\..\app\totp\sha256.h">
+      <Filter>Header Files</Filter>
+    </ClCompile>
+    <ClInclude Include="..\..\app\implementations\openssl\3\iut.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\app\app_lcl.h">

--- a/ms/resources/libacvp.vcxproj
+++ b/ms/resources/libacvp.vcxproj
@@ -159,6 +159,7 @@
     <ClCompile Include="..\..\src\acvp_lms.c" />
     <ClCompile Include="..\..\src\acvp_ml_dsa.c" />
     <ClCompile Include="..\..\src\acvp_ml_kem.c" />
+    <ClCompile Include="..\..\src\acvp_slh_dsa.c" />
     <ClCompile Include="..\..\src\acvp_operating_env.c" />
     <ClCompile Include="..\..\src\acvp_rsa_keygen.c" />
     <ClCompile Include="..\..\src\acvp_rsa_sig.c" />

--- a/ms/resources/libacvp.vcxproj.filters
+++ b/ms/resources/libacvp.vcxproj.filters
@@ -114,6 +114,9 @@
     <ClCompile Include="..\..\src\acvp_ml_kem.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\acvp_slh_dsa.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\acvp_operating_env.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
- Windows build system for app restructured to match app code changes and newer OpenSSL versions; currently supports openssl 3+, may support more IuTs later if demand appears
- Remove color logging from windows (Incompatible. Could add windows-specific color code, but they are transitioning between several shells right now so does not seem worth it)
- In the autoconf system: freeBSD shell does not support the "+=" operator; replacing with a more portable syntax
- Todo: Investigate why libcurl seems to hang on network activity when FIPS provider is enabled in Windows (Not likely a libacvp issue, but possible, should ID cause either way)