### PR TITLE
Logging consistency improvements

### DIFF
--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -195,7 +195,7 @@ static ACVP_RESULT acvp_aes_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
 
     rv = acvp_bin_to_hexstr(stc->key, stc->key_len / 8, tmp, ACVP_SYM_CT_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (key)");
+        ACVP_LOG_ERR("Hex conversion failure (key)");
         goto end;
     }
     json_object_set_string(r_tobj, "key", tmp);
@@ -204,7 +204,7 @@ static ACVP_RESULT acvp_aes_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
         memzero_s(tmp, ACVP_SYM_CT_MAX);
         rv = acvp_bin_to_hexstr(stc->iv, stc->iv_len, tmp, ACVP_SYM_CT_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (iv)");
+            ACVP_LOG_ERR("Hex conversion failure (iv)");
             goto end;
         }
         json_object_set_string(r_tobj, "iv", tmp);
@@ -216,13 +216,13 @@ static ACVP_RESULT acvp_aes_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
         if (stc->cipher == ACVP_AES_CFB1) {
             rv = acvp_bin_to_hexstr(stc->pt, 1, tmp, ACVP_SYM_PT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (pt)");
+                ACVP_LOG_ERR("Hex conversion failure (pt)");
                 goto end;
             }
         } else {
             rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp, ACVP_SYM_PT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (pt)");
+                ACVP_LOG_ERR("Hex conversion failure (pt)");
                 goto end;
             }
         }
@@ -232,13 +232,13 @@ static ACVP_RESULT acvp_aes_output_mct_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *stc
         if (stc->cipher == ACVP_AES_CFB1) {
             rv = acvp_bin_to_hexstr(stc->ct, 1, tmp, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (ct)");
+                ACVP_LOG_ERR("Hex conversion failure (ct)");
                 goto end;
             }
         } else {
             rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, tmp, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (ct)");
+                ACVP_LOG_ERR("Hex conversion failure (ct)");
                 goto end;
             }
         }
@@ -322,14 +322,14 @@ static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx,
             if (stc->cipher == ACVP_AES_CFB1) {
                 rv = acvp_bin_to_hexstr(stc->ct, 1, tmp, ACVP_SYM_CT_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (ct)");
+                    ACVP_LOG_ERR("Hex conversion failure (ct)");
                     free(tmp);
                     return rv;
                 }
             } else {
                 rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, tmp, ACVP_SYM_CT_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (ct)");
+                    ACVP_LOG_ERR("Hex conversion failure (ct)");
                     free(tmp);
                     return rv;
                 }
@@ -382,7 +382,7 @@ static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx,
             if (stc->cipher == ACVP_AES_CFB1) {
                 rv = acvp_bin_to_hexstr(stc->pt, 1, tmp, ACVP_SYM_PT_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (pt)");
+                    ACVP_LOG_ERR("Hex conversion failure (pt)");
                     json_value_free(r_tval);
                     free(tmp);
                     return rv;
@@ -390,7 +390,7 @@ static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx,
             } else {
                 rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp, ACVP_SYM_CT_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (pt)");
+                    ACVP_LOG_ERR("Hex conversion failure (pt)");
                     free(tmp);
                     json_value_free(r_tval);
                     return rv;
@@ -691,7 +691,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     /* Create ACVP array for response */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -1273,7 +1273,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                             alg_id != ACVP_AES_CCM &&
                             alg_id != ACVP_AES_KWP && 
                             alg_id != ACVP_AES_GMAC) {
-                        ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                        ACVP_LOG_ERR("crypto module failed the operation");
                         acvp_aes_release_tc(&stc);
                         json_value_free(r_tval);
                         rv = ACVP_CRYPTO_MODULE_FAIL;
@@ -1344,7 +1344,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx,
           (stc->cipher == ACVP_AES_CTR && stc->conformance == ACVP_CONFORMANCE_RFC3686))) {
         rv = acvp_bin_to_hexstr(stc->iv, stc->iv_len, tmp, ACVP_SYM_CT_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (iv)");
+            ACVP_LOG_ERR("Hex conversion failure (iv)");
             goto err;
         }
         json_object_set_string(tc_rsp, "iv", tmp);
@@ -1353,7 +1353,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx,
     if (stc->cipher == ACVP_AES_XPN && stc->salt_source == ACVP_SYM_CIPH_SALT_SRC_INT) {
         rv = acvp_bin_to_hexstr(stc->salt, stc->salt_len, tmp, ACVP_AES_XPN_SALTLEN);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (salt)");
+            ACVP_LOG_ERR("Hex conversion failure (salt)");
             goto err;
         }
         json_object_set_string(tc_rsp, "salt", tmp);
@@ -1372,7 +1372,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx,
             rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, tmp, ACVP_SYM_CT_MAX);
         }
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (ct)");
+            ACVP_LOG_ERR("Hex conversion failure (ct)");
             goto err;
         }
         if (stc->cipher != ACVP_AES_GMAC) {
@@ -1386,7 +1386,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx,
             memzero_s(tmp, ACVP_SYM_CT_MAX);
             rv = acvp_bin_to_hexstr(stc->tag, stc->tag_len, tmp, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (tag)");
+                ACVP_LOG_ERR("Hex conversion failure (tag)");
                 goto err;
             }
             json_object_set_string(tc_rsp, "tag", tmp);
@@ -1416,7 +1416,7 @@ static ACVP_RESULT acvp_aes_output_tc(ACVP_CTX *ctx,
             rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp, ACVP_SYM_PT_MAX);
         }
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (pt)");
+            ACVP_LOG_ERR("Hex conversion failure (pt)");
             goto err;
         }
         if (stc->cipher != ACVP_AES_GMAC) {

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -3602,7 +3602,7 @@ ACVP_RESULT acvp_cap_hash_set_parm(ACVP_CTX *ctx,
         case ACVP_SUB_HASH_SHA2_512_224:
         case ACVP_SUB_HASH_SHA2_512_256:
         default:
-            ACVP_LOG_ERR("parm 'ACVP_HASH_OUT_BIT' only allowed for ACVP_HASH_SHAKE_* ");
+            ACVP_LOG_ERR("parm 'ACVP_HASH_OUT_BIT' only allowed for ACVP_HASH_SHAKE_*");
             return ACVP_INVALID_ARG;
         }
 

--- a/src/acvp_cmac.c
+++ b/src/acvp_cmac.c
@@ -65,7 +65,7 @@ static ACVP_RESULT acvp_cmac_init_tc(ACVP_CTX *ctx,
     if (direction_verify) {
         rv = acvp_hexstr_to_bin(mac, stc->mac, ACVP_CMAC_MACLEN_MAX, (int *)&(stc->mac_len));
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Hex converstion failure (mac)");
+            ACVP_LOG_ERR("Hex conversion failure (mac)");
             return rv;
         }
     }
@@ -77,30 +77,30 @@ static ACVP_RESULT acvp_cmac_init_tc(ACVP_CTX *ctx,
 
     rv = acvp_hexstr_to_bin(msg, stc->msg, ACVP_CMAC_MSGLEN_MAX_STR, NULL);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Hex converstion failure (msg)");
+        ACVP_LOG_ERR("Hex conversion failure (msg)");
         return rv;
     }
 
     if (alg_id == ACVP_CMAC_AES) {
         rv = acvp_hexstr_to_bin(key, stc->key, ACVP_CMAC_KEY_MAX, (int *)&(stc->key_len));
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Hex converstion failure (key)");
+            ACVP_LOG_ERR("Hex conversion failure (key)");
             return rv;
         }
     } else if (alg_id == ACVP_CMAC_TDES) {
         rv = acvp_hexstr_to_bin(key, stc->key, ACVP_CMAC_KEY_MAX, NULL);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Hex converstion failure (key1)");
+            ACVP_LOG_ERR("Hex conversion failure (key1)");
             return rv;
         }
         rv = acvp_hexstr_to_bin(key2, stc->key2, ACVP_CMAC_KEY_MAX, NULL);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Hex converstion failure (key2)");
+            ACVP_LOG_ERR("Hex conversion failure (key2)");
             return rv;
         }
         rv = acvp_hexstr_to_bin(key3, stc->key3, ACVP_CMAC_KEY_MAX, NULL);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Hex converstion failure (key3)");
+            ACVP_LOG_ERR("Hex conversion failure (key3)");
             return rv;
         }
     }
@@ -137,7 +137,7 @@ static ACVP_RESULT acvp_cmac_output_tc(ACVP_CTX *ctx, ACVP_CMAC_TC *stc, JSON_Ob
     } else {
         rv = acvp_bin_to_hexstr(stc->mac, stc->mac_len, tmp, ACVP_CMAC_MACLEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (mac)");
+            ACVP_LOG_ERR("Hex conversion failure (mac)");
             goto end;
         }
         json_object_set_string(tc_rsp, "mac", tmp);
@@ -208,7 +208,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     }
 
     if (!alg_str) {
-        ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return ACVP_MALFORMED_JSON;
     }
 
@@ -222,12 +222,12 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id == 0) {
-        ACVP_LOG_ERR("ERROR: unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
         return ACVP_UNSUPPORTED_OP;
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
 
@@ -236,7 +236,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -456,7 +456,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                ACVP_LOG_ERR("crypto module failed the operation");
                 acvp_cmac_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
@@ -468,7 +468,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_cmac_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure in hash module");
                 acvp_cmac_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -249,21 +249,21 @@ static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx,
     rv = acvp_bin_to_hexstr(stc->key, single_key_byte_len,
                             tmp_k1, single_key_str_len);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (key)");
+        ACVP_LOG_ERR("Hex conversion failure (key)");
         goto err;
     }
 
     rv = acvp_bin_to_hexstr(stc->key + 8, single_key_byte_len,
                             tmp_k2, single_key_str_len);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (key)");
+        ACVP_LOG_ERR("Hex conversion failure (key)");
         goto err;
     }
 
     rv = acvp_bin_to_hexstr(stc->key + 16, single_key_byte_len,
                             tmp_k3, single_key_str_len);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (key)");
+        ACVP_LOG_ERR("Hex conversion failure (key)");
         goto err;
     }
 
@@ -281,7 +281,7 @@ static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx,
 
         rv = acvp_bin_to_hexstr(stc->iv, stc->iv_len, tmp_iv, ACVP_SYM_IV_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (iv)");
+            ACVP_LOG_ERR("Hex conversion failure (iv)");
             goto err;
         }
         json_object_set_string(r_tobj, "iv", tmp_iv);
@@ -299,14 +299,14 @@ static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx,
             stc->pt[0] &= ACVP_CFB1_BIT_MASK;
             rv = acvp_bin_to_hexstr(stc->pt, 1, tmp_pt, ACVP_SYM_PT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (pt)");
+                ACVP_LOG_ERR("Hex conversion failure (pt)");
                 goto err;
             }
             json_object_set_string(r_tobj, "pt", tmp_pt);
         } else {
             rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp_pt, ACVP_SYM_PT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (pt)");
+                ACVP_LOG_ERR("Hex conversion failure (pt)");
                 goto err;
             }
             json_object_set_string(r_tobj, "pt", tmp_pt);
@@ -325,14 +325,14 @@ static ACVP_RESULT acvp_des_output_mct_tc(ACVP_CTX *ctx,
         if (stc->cipher == ACVP_TDES_CFB1) {
             rv = acvp_bin_to_hexstr(stc->ct, 1, tmp_ct, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (ct)");
+                ACVP_LOG_ERR("Hex conversion failure (ct)");
                 goto err;
             }
             json_object_set_string(r_tobj, "ct", tmp_ct);
         } else {
             rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, tmp_ct, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (ct)");
+                ACVP_LOG_ERR("Hex conversion failure (ct)");
                 goto err;
             }
             json_object_set_string(r_tobj, "ct", tmp_ct);
@@ -521,7 +521,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
                 stc->ct[0] &= ACVP_CFB1_BIT_MASK;
                 rv = acvp_bin_to_hexstr(stc->ct, 1, tmp, ACVP_SYM_CT_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (ct)");
+                    ACVP_LOG_ERR("Hex conversion failure (ct)");
                     free(tmp);
                     json_value_free(r_tval);
                     return rv;
@@ -529,7 +529,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
             } else {
                 rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, tmp, ACVP_SYM_CT_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (ct)");
+                    ACVP_LOG_ERR("Hex conversion failure (ct)");
                     free(tmp);
                     json_value_free(r_tval);
                     return rv;
@@ -541,7 +541,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
             if (stc->cipher == ACVP_TDES_CFB1) {
                 rv = acvp_bin_to_hexstr(stc->pt, 1, tmp, ACVP_SYM_CT_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (pt)");
+                    ACVP_LOG_ERR("Hex conversion failure (pt)");
                     free(tmp);
                     json_value_free(r_tval);
                     return rv;
@@ -549,7 +549,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
             } else {
                 rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp, ACVP_SYM_CT_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (pt)");
+                    ACVP_LOG_ERR("Hex conversion failure (pt)");
                     free(tmp);
                     json_value_free(r_tval);
                     return rv;
@@ -694,7 +694,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -1058,7 +1058,7 @@ static ACVP_RESULT acvp_des_output_tc(ACVP_CTX *ctx,
         if (stc->cipher == ACVP_TDES_CFB1) {
             rv = acvp_bin_to_hexstr(stc->ct, (stc->ct_len + 7) / 8, tmp, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (ct)");
+                ACVP_LOG_ERR("Hex conversion failure (ct)");
                 free(tmp);
                 return rv;
             }
@@ -1066,7 +1066,7 @@ static ACVP_RESULT acvp_des_output_tc(ACVP_CTX *ctx,
         } else {
             rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, tmp, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (ct)");
+                ACVP_LOG_ERR("Hex conversion failure (ct)");
                 free(tmp);
                 return rv;
             }
@@ -1083,7 +1083,7 @@ static ACVP_RESULT acvp_des_output_tc(ACVP_CTX *ctx,
         if (stc->cipher == ACVP_TDES_CFB1) {
             rv = acvp_bin_to_hexstr(stc->pt, (stc->pt_len + 7) / 8, tmp, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (pt)");
+                ACVP_LOG_ERR("Hex conversion failure (pt)");
                 free(tmp);
                 return rv;
             }
@@ -1091,7 +1091,7 @@ static ACVP_RESULT acvp_des_output_tc(ACVP_CTX *ctx,
         } else {
             rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp, ACVP_SYM_CT_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (pt)");
+                ACVP_LOG_ERR("Hex conversion failure (pt)");
                 free(tmp);
                 return rv;
             }

--- a/src/acvp_drbg.c
+++ b/src/acvp_drbg.c
@@ -118,7 +118,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -594,7 +594,7 @@ static ACVP_RESULT acvp_drbg_output_tc(ACVP_CTX *ctx, ACVP_DRBG_TC *stc, JSON_Ob
 
     rv = acvp_bin_to_hexstr(stc->drb, stc->drb_len, tmp, ACVP_DRB_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (returnedBits)");
+        ACVP_LOG_ERR("Hex conversion failure (returnedBits)");
         goto end;
     }
     json_object_set_string(tc_rsp, "returnedBits", tmp);

--- a/src/acvp_dsa.c
+++ b/src/acvp_dsa.c
@@ -371,7 +371,7 @@ static ACVP_RESULT acvp_dsa_output_tc(ACVP_CTX *ctx, ACVP_DSA_TC *stc, JSON_Obje
             }
             rv = acvp_bin_to_hexstr(stc->g, stc->g_len, tmp, ACVP_DSA_PQG_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (g)");
+                ACVP_LOG_ERR("Hex conversion failure (g)");
                 goto err;
             }
             json_object_set_string(r_tobj, "g", (const char *)tmp);
@@ -386,7 +386,7 @@ static ACVP_RESULT acvp_dsa_output_tc(ACVP_CTX *ctx, ACVP_DSA_TC *stc, JSON_Obje
             }
             rv = acvp_bin_to_hexstr(stc->p, stc->p_len, tmp, ACVP_DSA_PQG_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (p)");
+                ACVP_LOG_ERR("Hex conversion failure (p)");
                 goto err;
             }
             json_object_set_string(r_tobj, "p", (const char *)tmp);
@@ -394,7 +394,7 @@ static ACVP_RESULT acvp_dsa_output_tc(ACVP_CTX *ctx, ACVP_DSA_TC *stc, JSON_Obje
 
             rv = acvp_bin_to_hexstr(stc->q, stc->q_len, tmp, ACVP_DSA_PQG_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (q)");
+                ACVP_LOG_ERR("Hex conversion failure (q)");
                 goto err;
             }
             json_object_set_string(r_tobj, "q", (const char *)tmp);
@@ -402,7 +402,7 @@ static ACVP_RESULT acvp_dsa_output_tc(ACVP_CTX *ctx, ACVP_DSA_TC *stc, JSON_Obje
             memzero_s(tmp, ACVP_DSA_SEED_MAX);
             rv = acvp_bin_to_hexstr(stc->seed, stc->seedlen, tmp, ACVP_DSA_SEED_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (p)");
+                ACVP_LOG_ERR("Hex conversion failure (p)");
                 goto err;
             }
             json_object_set_string(r_tobj, "domainSeed", tmp);
@@ -423,7 +423,7 @@ static ACVP_RESULT acvp_dsa_output_tc(ACVP_CTX *ctx, ACVP_DSA_TC *stc, JSON_Obje
         }
         rv = acvp_bin_to_hexstr(stc->r, stc->r_len, tmp, ACVP_DSA_PQG_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (r)");
+            ACVP_LOG_ERR("Hex conversion failure (r)");
             goto err;
         }
         json_object_set_string(r_tobj, "r", (const char *)tmp);
@@ -431,7 +431,7 @@ static ACVP_RESULT acvp_dsa_output_tc(ACVP_CTX *ctx, ACVP_DSA_TC *stc, JSON_Obje
 
         rv = acvp_bin_to_hexstr(stc->s, stc->s_len, tmp, ACVP_DSA_PQG_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (s)");
+            ACVP_LOG_ERR("Hex conversion failure (s)");
             goto err;
         }
         json_object_set_string(r_tobj, "s", (const char *)tmp);
@@ -450,7 +450,7 @@ static ACVP_RESULT acvp_dsa_output_tc(ACVP_CTX *ctx, ACVP_DSA_TC *stc, JSON_Obje
 
         rv = acvp_bin_to_hexstr(stc->y, stc->y_len, tmp, ACVP_DSA_PQG_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (y)");
+            ACVP_LOG_ERR("Hex conversion failure (y)");
             goto err;
         }
         json_object_set_string(r_tobj, "y", (const char *)tmp);
@@ -458,7 +458,7 @@ static ACVP_RESULT acvp_dsa_output_tc(ACVP_CTX *ctx, ACVP_DSA_TC *stc, JSON_Obje
 
         rv = acvp_bin_to_hexstr(stc->x, stc->x_len, tmp, ACVP_DSA_PQG_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (x)");
+            ACVP_LOG_ERR("Hex conversion failure (x)");
             goto err;
         }
         json_object_set_string(r_tobj, "x", (const char *)tmp);
@@ -517,13 +517,13 @@ static ACVP_RESULT acvp_dsa_keygen_handler(ACVP_CTX *ctx,
 
     l = json_object_get_number(groupobj, "l");
     if (!l) {
-        ACVP_LOG_ERR("Failed to include l. ");
+        ACVP_LOG_ERR("Failed to include l.");
         return ACVP_MISSING_ARG;
     }
 
     n = json_object_get_number(groupobj, "n");
     if (!n) {
-        ACVP_LOG_ERR("Failed to include n. ");
+        ACVP_LOG_ERR("Failed to include n.");
         return ACVP_MISSING_ARG;
     }
 
@@ -532,13 +532,13 @@ static ACVP_RESULT acvp_dsa_keygen_handler(ACVP_CTX *ctx,
 
     tests = json_object_get_array(groupobj, "tests");
     if (!tests) {
-        ACVP_LOG_ERR("Failed to include tests. ");
+        ACVP_LOG_ERR("Failed to include tests.");
         return ACVP_MISSING_ARG;
     }
 
     t_cnt = json_array_get_count(tests);
     if (!t_cnt) {
-        ACVP_LOG_ERR("Failed to include tests in array. ");
+        ACVP_LOG_ERR("Failed to include tests in array.");
         return ACVP_MISSING_ARG;
     }
 
@@ -553,7 +553,7 @@ static ACVP_RESULT acvp_dsa_keygen_handler(ACVP_CTX *ctx,
 
         tc_id = json_object_get_number(testobj, "tcId");
         if (!tc_id) {
-            ACVP_LOG_ERR("Failed to include tc_id. ");
+            ACVP_LOG_ERR("Failed to include tc_id.");
             return ACVP_MISSING_ARG;
         }
 
@@ -590,7 +590,7 @@ static ACVP_RESULT acvp_dsa_keygen_handler(ACVP_CTX *ctx,
         }
         rv = acvp_bin_to_hexstr(stc->p, stc->p_len, tmp, ACVP_DSA_PQG_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (p)");
+            ACVP_LOG_ERR("Hex conversion failure (p)");
             free(tmp);
             goto err;
         }
@@ -599,7 +599,7 @@ static ACVP_RESULT acvp_dsa_keygen_handler(ACVP_CTX *ctx,
 
         rv = acvp_bin_to_hexstr(stc->q, stc->q_len, tmp, ACVP_DSA_PQG_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (q)");
+            ACVP_LOG_ERR("Hex conversion failure (q)");
             free(tmp);
             goto err;
         }
@@ -608,7 +608,7 @@ static ACVP_RESULT acvp_dsa_keygen_handler(ACVP_CTX *ctx,
 
         rv = acvp_bin_to_hexstr(stc->g, stc->g_len, tmp, ACVP_DSA_PQG_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (g)");
+            ACVP_LOG_ERR("Hex conversion failure (g)");
             free(tmp);
             goto err;
         }
@@ -694,29 +694,29 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
     gen_pq = json_object_get_string(groupobj, "pqMode");
     gen_g = json_object_get_string(groupobj, "gMode");
     if (!gen_pq && !gen_g) {
-        ACVP_LOG_ERR("Failed to include either gen_pq or gen_g. ");
+        ACVP_LOG_ERR("Failed to include either gen_pq or gen_g.");
         return ACVP_MISSING_ARG;
     }
     if (gen_pq && gen_g) {
-        ACVP_LOG_ERR("Server included both gen_pq and gen_g. ");
+        ACVP_LOG_ERR("Server included both gen_pq and gen_g.");
         return ACVP_INVALID_ARG;
     }
 
     l = json_object_get_number(groupobj, "l");
     if (!l) {
-        ACVP_LOG_ERR("Failed to include l. ");
+        ACVP_LOG_ERR("Failed to include l.");
         return ACVP_MISSING_ARG;
     }
 
     n = json_object_get_number(groupobj, "n");
     if (!n) {
-        ACVP_LOG_ERR("Failed to include n. ");
+        ACVP_LOG_ERR("Failed to include n.");
         return ACVP_MISSING_ARG;
     }
 
     sha_str = json_object_get_string(groupobj, "hashAlg");
     if (!sha_str) {
-        ACVP_LOG_ERR("Failed to include hashAlg. ");
+        ACVP_LOG_ERR("Failed to include hashAlg.");
         return ACVP_MISSING_ARG;
     }
     sha = acvp_lookup_hash_alg(sha_str);
@@ -737,13 +737,13 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
 
     tests = json_object_get_array(groupobj, "tests");
     if (!tests) {
-        ACVP_LOG_ERR("Failed to include tests. ");
+        ACVP_LOG_ERR("Failed to include tests.");
         return ACVP_MISSING_ARG;
     }
 
     t_cnt = json_array_get_count(tests);
     if (!t_cnt) {
-        ACVP_LOG_ERR("Failed to include tests in array. ");
+        ACVP_LOG_ERR("Failed to include tests in array.");
         return ACVP_MISSING_ARG;
     }
 
@@ -758,7 +758,7 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
 
         tc_id = json_object_get_number(testobj, "tcId");
         if (!tc_id) {
-            ACVP_LOG_ERR("Failed to include tc_id. ");
+            ACVP_LOG_ERR("Failed to include tc_id.");
             return ACVP_MISSING_ARG;
         }
 
@@ -775,13 +775,13 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
             if (gpq == ACVP_DSA_CANONICAL) {
                 seed = json_object_get_string(testobj, "domainSeed");
                 if (!seed) {
-                    ACVP_LOG_ERR("Failed to include domainSeed. ");
+                    ACVP_LOG_ERR("Failed to include domainSeed.");
                     return ACVP_MISSING_ARG;
                 }
 
                 idx = json_object_get_string(testobj, "index");
                 if (!idx) {
-                    ACVP_LOG_ERR("Failed to include idx. ");
+                    ACVP_LOG_ERR("Failed to include idx.");
                     return ACVP_MISSING_ARG;
                 }
 
@@ -793,13 +793,13 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
 
             p = json_object_get_string(testobj, "p");
             if (!p) {
-                ACVP_LOG_ERR("Failed to include p. ");
+                ACVP_LOG_ERR("Failed to include p.");
                 return ACVP_MISSING_ARG;
             }
 
             q = json_object_get_string(testobj, "q");
             if (!q) {
-                ACVP_LOG_ERR("Failed to include q. ");
+                ACVP_LOG_ERR("Failed to include q.");
                 return ACVP_MISSING_ARG;
             }
 
@@ -930,19 +930,19 @@ static ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
 
     l = json_object_get_number(groupobj, "l");
     if (!l) {
-        ACVP_LOG_ERR("Failed to include l. ");
+        ACVP_LOG_ERR("Failed to include l.");
         return ACVP_MISSING_ARG;
     }
 
     n = json_object_get_number(groupobj, "n");
     if (!n) {
-        ACVP_LOG_ERR("Failed to include n. ");
+        ACVP_LOG_ERR("Failed to include n.");
         return ACVP_MISSING_ARG;
     }
 
     sha_str = json_object_get_string(groupobj, "hashAlg");
     if (!sha_str) {
-        ACVP_LOG_ERR("Failed to include hashAlg. ");
+        ACVP_LOG_ERR("Failed to include hashAlg.");
         return ACVP_MISSING_ARG;
     }
     sha = acvp_lookup_hash_alg(sha_str);
@@ -957,13 +957,13 @@ static ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
 
     tests = json_object_get_array(groupobj, "tests");
     if (!tests) {
-        ACVP_LOG_ERR("Failed to include tests. ");
+        ACVP_LOG_ERR("Failed to include tests.");
         return ACVP_MISSING_ARG;
     }
 
     t_cnt = json_array_get_count(tests);
     if (!t_cnt) {
-        ACVP_LOG_ERR("Failed to include tests in array. ");
+        ACVP_LOG_ERR("Failed to include tests in array.");
         return ACVP_MISSING_ARG;
     }
 
@@ -978,13 +978,13 @@ static ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
 
         tc_id = json_object_get_number(testobj, "tcId");
         if (!tc_id) {
-            ACVP_LOG_ERR("Failed to include tc_id. ");
+            ACVP_LOG_ERR("Failed to include tc_id.");
             return ACVP_MISSING_ARG;
         }
 
         msg = json_object_get_string(testobj, "message");
         if (!msg) {
-            ACVP_LOG_ERR("Failed to include message. ");
+            ACVP_LOG_ERR("Failed to include message.");
             return ACVP_MISSING_ARG;
         }
 
@@ -1023,7 +1023,7 @@ static ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
 
         rv = acvp_bin_to_hexstr(stc->p, stc->p_len, tmp, ACVP_DSA_PQG_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (p)");
+            ACVP_LOG_ERR("Hex conversion failure (p)");
             free(tmp);
             goto err;
         }
@@ -1032,7 +1032,7 @@ static ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
 
         rv = acvp_bin_to_hexstr(stc->q, stc->q_len, tmp, ACVP_DSA_PQG_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (q)");
+            ACVP_LOG_ERR("Hex conversion failure (q)");
             free(tmp);
             goto err;
         }
@@ -1041,7 +1041,7 @@ static ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
 
         rv = acvp_bin_to_hexstr(stc->g, stc->g_len, tmp, ACVP_DSA_PQG_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (g)");
+            ACVP_LOG_ERR("Hex conversion failure (g)");
             free(tmp);
             goto err;
         }
@@ -1050,7 +1050,7 @@ static ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
 
         rv = acvp_bin_to_hexstr(stc->y, stc->y_len, tmp, ACVP_DSA_PQG_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (y)");
+            ACVP_LOG_ERR("Hex conversion failure (y)");
             free(tmp);
             goto err;
         }
@@ -1102,19 +1102,19 @@ static ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
 
     l = json_object_get_number(groupobj, "l");
     if (!l) {
-        ACVP_LOG_ERR("Failed to include l. ");
+        ACVP_LOG_ERR("Failed to include l.");
         return ACVP_MISSING_ARG;
     }
 
     n = json_object_get_number(groupobj, "n");
     if (!n) {
-        ACVP_LOG_ERR("Failed to include n. ");
+        ACVP_LOG_ERR("Failed to include n.");
         return ACVP_MISSING_ARG;
     }
 
     sha_str = json_object_get_string(groupobj, "hashAlg");
     if (!sha_str) {
-        ACVP_LOG_ERR("Failed to include hashAlg. ");
+        ACVP_LOG_ERR("Failed to include hashAlg.");
         return ACVP_MISSING_ARG;
     }
     sha = acvp_lookup_hash_alg(sha_str);
@@ -1142,13 +1142,13 @@ static ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
 
     tests = json_object_get_array(groupobj, "tests");
     if (!tests) {
-        ACVP_LOG_ERR("Failed to include tests. ");
+        ACVP_LOG_ERR("Failed to include tests.");
         return ACVP_MISSING_ARG;
     }
 
     t_cnt = json_array_get_count(tests);
     if (!t_cnt) {
-        ACVP_LOG_ERR("Failed to include tests in array. ");
+        ACVP_LOG_ERR("Failed to include tests in array.");
         return ACVP_MISSING_ARG;
     }
 
@@ -1163,7 +1163,7 @@ static ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
 
         tc_id = json_object_get_number(testobj, "tcId");
         if (!tc_id) {
-            ACVP_LOG_ERR("Failed to include tc_id. ");
+            ACVP_LOG_ERR("Failed to include tc_id.");
             return ACVP_MISSING_ARG;
         }
 
@@ -1173,13 +1173,13 @@ static ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
 
         p = json_object_get_string(testobj, "p");
         if (!p) {
-            ACVP_LOG_ERR("Failed to include p. ");
+            ACVP_LOG_ERR("Failed to include p.");
             return ACVP_MISSING_ARG;
         }
 
         q = json_object_get_string(testobj, "q");
         if (!q) {
-            ACVP_LOG_ERR("Failed to include q. ");
+            ACVP_LOG_ERR("Failed to include q.");
             return ACVP_MISSING_ARG;
         }
 
@@ -1210,32 +1210,32 @@ static ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
             return ACVP_UNSUPPORTED_OP;
         case ACVP_DSA_PROBABLE:
             if (!seed) {
-                ACVP_LOG_ERR("Failed to include seed. ");
+                ACVP_LOG_ERR("Failed to include seed.");
                 return ACVP_MISSING_ARG;
             }
             break;
         case ACVP_DSA_CANONICAL:
             if (!idx) {
-                ACVP_LOG_ERR("Failed to include idx. ");
+                ACVP_LOG_ERR("Failed to include idx.");
                 return ACVP_MISSING_ARG;
             }
             if (!g) {
-                ACVP_LOG_ERR("Failed to include q. ");
+                ACVP_LOG_ERR("Failed to include q.");
                 return ACVP_MISSING_ARG;
             }
             break;
         case ACVP_DSA_UNVERIFIABLE:
             if (!seed) {
-                ACVP_LOG_ERR("Failed to include seed. ");
+                ACVP_LOG_ERR("Failed to include seed.");
                 return ACVP_MISSING_ARG;
             }
             if (!h) {
-                ACVP_LOG_ERR("Failed to include h. ");
+                ACVP_LOG_ERR("Failed to include h.");
                 return ACVP_MISSING_ARG;
             }
             break;
         default:
-            ACVP_LOG_ERR("Failed to include valid gen_pq. ");
+            ACVP_LOG_ERR("Failed to include valid gen_pq.");
             return ACVP_UNSUPPORTED_OP;
         }
 
@@ -1300,19 +1300,19 @@ static ACVP_RESULT acvp_dsa_sigver_handler(ACVP_CTX *ctx,
 
     l = json_object_get_number(groupobj, "l");
     if (!l) {
-        ACVP_LOG_ERR("Failed to include l. ");
+        ACVP_LOG_ERR("Failed to include l.");
         return ACVP_MISSING_ARG;
     }
 
     n = json_object_get_number(groupobj, "n");
     if (!n) {
-        ACVP_LOG_ERR("Failed to include n. ");
+        ACVP_LOG_ERR("Failed to include n.");
         return ACVP_MISSING_ARG;
     }
 
     sha_str = json_object_get_string(groupobj, "hashAlg");
     if (!sha_str) {
-        ACVP_LOG_ERR("Failed to include hashAlg. ");
+        ACVP_LOG_ERR("Failed to include hashAlg.");
         return ACVP_MISSING_ARG;
     }
     sha = acvp_lookup_hash_alg(sha_str);
@@ -1327,13 +1327,13 @@ static ACVP_RESULT acvp_dsa_sigver_handler(ACVP_CTX *ctx,
 
     tests = json_object_get_array(groupobj, "tests");
     if (!tests) {
-        ACVP_LOG_ERR("Failed to include tests. ");
+        ACVP_LOG_ERR("Failed to include tests.");
         return ACVP_MISSING_ARG;
     }
 
     t_cnt = json_array_get_count(tests);
     if (!t_cnt) {
-        ACVP_LOG_ERR("Failed to include tests in array. ");
+        ACVP_LOG_ERR("Failed to include tests in array.");
         return ACVP_MISSING_ARG;
     }
 
@@ -1341,19 +1341,19 @@ static ACVP_RESULT acvp_dsa_sigver_handler(ACVP_CTX *ctx,
 
     p = json_object_get_string(groupobj, "p");
     if (!p) {
-        ACVP_LOG_ERR("Failed to include p. ");
+        ACVP_LOG_ERR("Failed to include p.");
         return ACVP_MISSING_ARG;
     }
 
     q = json_object_get_string(groupobj, "q");
     if (!q) {
-        ACVP_LOG_ERR("Failed to include q. ");
+        ACVP_LOG_ERR("Failed to include q.");
         return ACVP_MISSING_ARG;
     }
 
     g = json_object_get_string(groupobj, "g");
     if (!g) {
-        ACVP_LOG_ERR("Failed to include g. ");
+        ACVP_LOG_ERR("Failed to include g.");
         return ACVP_MISSING_ARG;
     }
 
@@ -1366,28 +1366,28 @@ static ACVP_RESULT acvp_dsa_sigver_handler(ACVP_CTX *ctx,
 
         tc_id = json_object_get_number(testobj, "tcId");
         if (!tc_id) {
-            ACVP_LOG_ERR("Failed to include tc_id. ");
+            ACVP_LOG_ERR("Failed to include tc_id.");
             return ACVP_MISSING_ARG;
         }
 
         msg = json_object_get_string(testobj, "message");
         if (!msg) {
-            ACVP_LOG_ERR("Failed to include message. ");
+            ACVP_LOG_ERR("Failed to include message.");
             return ACVP_MISSING_ARG;
         }
         r = json_object_get_string(testobj, "r");
         if (!r) {
-            ACVP_LOG_ERR("Failed to include r. ");
+            ACVP_LOG_ERR("Failed to include r.");
             return ACVP_MISSING_ARG;
         }
         s = json_object_get_string(testobj, "s");
         if (!s) {
-            ACVP_LOG_ERR("Failed to include s. ");
+            ACVP_LOG_ERR("Failed to include s.");
             return ACVP_MISSING_ARG;
         }
         y = json_object_get_string(testobj, "y");
         if (!y) {
-            ACVP_LOG_ERR("Failed to include y. ");
+            ACVP_LOG_ERR("Failed to include y.");
             return ACVP_MISSING_ARG;
         }
 
@@ -1485,7 +1485,7 @@ static ACVP_RESULT acvp_dsa_pqgver_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -1500,7 +1500,7 @@ static ACVP_RESULT acvp_dsa_pqgver_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
 
     groups = json_object_get_array(obj, "testGroups");
     if (!groups) {
-        ACVP_LOG_ERR("Failed to include testGroups. ");
+        ACVP_LOG_ERR("Failed to include testGroups.");
         rv = ACVP_MISSING_ARG;
         goto err;
     }
@@ -1607,7 +1607,7 @@ static ACVP_RESULT acvp_dsa_pqggen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -1622,7 +1622,7 @@ static ACVP_RESULT acvp_dsa_pqggen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
 
     groups = json_object_get_array(obj, "testGroups");
     if (!groups) {
-        ACVP_LOG_ERR("Failed to include testGroups. ");
+        ACVP_LOG_ERR("Failed to include testGroups.");
         rv = ACVP_MISSING_ARG;
         goto err;
     }
@@ -1722,7 +1722,7 @@ static ACVP_RESULT acvp_dsa_siggen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -1737,7 +1737,7 @@ static ACVP_RESULT acvp_dsa_siggen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
 
     groups = json_object_get_array(obj, "testGroups");
     if (!groups) {
-        ACVP_LOG_ERR("Failed to include testGroups. ");
+        ACVP_LOG_ERR("Failed to include testGroups.");
         rv = ACVP_MISSING_ARG;
         goto err;
     }
@@ -1839,7 +1839,7 @@ static ACVP_RESULT acvp_dsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -1854,7 +1854,7 @@ static ACVP_RESULT acvp_dsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
 
     groups = json_object_get_array(obj, "testGroups");
     if (!groups) {
-        ACVP_LOG_ERR("Failed to include testGroups. ");
+        ACVP_LOG_ERR("Failed to include testGroups.");
         rv = ACVP_MISSING_ARG;
         goto err;
     }
@@ -1955,7 +1955,7 @@ static ACVP_RESULT acvp_dsa_sigver_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -1970,7 +1970,7 @@ static ACVP_RESULT acvp_dsa_sigver_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) 
 
     groups = json_object_get_array(obj, "testGroups");
     if (!groups) {
-        ACVP_LOG_ERR("Failed to include testGroups. ");
+        ACVP_LOG_ERR("Failed to include testGroups.");
         rv = ACVP_MISSING_ARG;
         goto err;
     }
@@ -2038,17 +2038,17 @@ ACVP_RESULT acvp_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     int diff = 0;
 
     if (!ctx) {
-        ACVP_LOG_ERR("CTX is NULL. ");
+        ACVP_LOG_ERR("CTX is NULL.");
         return ACVP_NO_CTX;
     }
 
     if (!obj) {
-        ACVP_LOG_ERR("OBJ is NULL. ");
+        ACVP_LOG_ERR("OBJ is NULL.");
         return ACVP_MALFORMED_JSON;
     }
 
     if (!mode) {
-        ACVP_LOG_ERR("Failed to include mode. ");
+        ACVP_LOG_ERR("Failed to include mode.");
         return ACVP_MISSING_ARG;
     }
 

--- a/src/acvp_ecdsa.c
+++ b/src/acvp_ecdsa.c
@@ -35,7 +35,7 @@ static ACVP_RESULT acvp_ecdsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
     if (cipher == ACVP_ECDSA_KEYGEN) {
         rv = acvp_bin_to_hexstr(stc->qy, stc->qy_len, tmp, ACVP_ECDSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (qy)");
+            ACVP_LOG_ERR("Hex conversion failure (qy)");
             goto err;
         }
         json_object_set_string(tc_rsp, "qy", (const char *)tmp);
@@ -43,7 +43,7 @@ static ACVP_RESULT acvp_ecdsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
 
         rv = acvp_bin_to_hexstr(stc->qx, stc->qx_len, tmp, ACVP_ECDSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (qx)");
+            ACVP_LOG_ERR("Hex conversion failure (qx)");
             goto err;
         }
         json_object_set_string(tc_rsp, "qx", (const char *)tmp);
@@ -51,7 +51,7 @@ static ACVP_RESULT acvp_ecdsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
 
         rv = acvp_bin_to_hexstr(stc->d, stc->d_len, tmp, ACVP_ECDSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (d)");
+            ACVP_LOG_ERR("Hex conversion failure (d)");
             goto err;
         }
         json_object_set_string(tc_rsp, "d", (const char *)tmp);
@@ -63,7 +63,7 @@ static ACVP_RESULT acvp_ecdsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
     if (cipher == ACVP_ECDSA_SIGGEN || cipher == ACVP_DET_ECDSA_SIGGEN) {
         rv = acvp_bin_to_hexstr(stc->r, stc->r_len, tmp, ACVP_ECDSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (r)");
+            ACVP_LOG_ERR("Hex conversion failure (r)");
             goto err;
         }
         json_object_set_string(tc_rsp, "r", (const char *)tmp);
@@ -71,7 +71,7 @@ static ACVP_RESULT acvp_ecdsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
 
         rv = acvp_bin_to_hexstr(stc->s, stc->s_len, tmp, ACVP_ECDSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (s)");
+            ACVP_LOG_ERR("Hex conversion failure (s)");
             goto err;
         }
         json_object_set_string(tc_rsp, "s", (const char *)tmp);
@@ -265,7 +265,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
 
     alg_str = json_object_get_string(obj, "algorithm");
     if (!alg_str) {
-        ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return ACVP_MALFORMED_JSON;
     }
 
@@ -285,7 +285,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
 
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
     ACVP_LOG_VERBOSE("    ECDSA mode: %s", mode_str);
@@ -295,7 +295,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
         return rv;
     }
 
@@ -472,7 +472,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                    ACVP_LOG_ERR("crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -490,7 +490,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
                 char *tmp = calloc(ACVP_ECDSA_EXP_LEN_MAX + 1, sizeof(char));
                 rv = acvp_bin_to_hexstr(stc.qy, stc.qy_len, tmp, ACVP_ECDSA_EXP_LEN_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (qy)");
+                    ACVP_LOG_ERR("Hex conversion failure (qy)");
                     free(tmp);
                     json_value_free(r_tval);
                     goto err;
@@ -500,7 +500,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
 
                 rv = acvp_bin_to_hexstr(stc.qx, stc.qx_len, tmp, ACVP_ECDSA_EXP_LEN_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (qx)");
+                    ACVP_LOG_ERR("Hex conversion failure (qx)");
                     free(tmp);
                     json_value_free(r_tval);
                     goto err;
@@ -511,7 +511,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
             }
             rv = acvp_ecdsa_output_tc(ctx, alg_id, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure in hash module");
                 json_value_free(r_tval);
                 goto err;
             }

--- a/src/acvp_eddsa.c
+++ b/src/acvp_eddsa.c
@@ -41,7 +41,7 @@ static ACVP_RESULT acvp_eddsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
     if (cipher == ACVP_EDDSA_KEYGEN) {
         rv = acvp_bin_to_hexstr(stc->d, stc->d_len, tmp, ACVP_EDDSA_MSG_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (d)");
+            ACVP_LOG_ERR("Hex conversion failure (d)");
             goto err;
         }
         json_object_set_string(tc_rsp, "d", (const char *)tmp);
@@ -49,7 +49,7 @@ static ACVP_RESULT acvp_eddsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
 
         rv = acvp_bin_to_hexstr(stc->q, stc->q_len, tmp, ACVP_EDDSA_MSG_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (q)");
+            ACVP_LOG_ERR("Hex conversion failure (q)");
             goto err;
         }
         json_object_set_string(tc_rsp, "q", (const char *)tmp);
@@ -59,7 +59,7 @@ static ACVP_RESULT acvp_eddsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_
     if (cipher == ACVP_EDDSA_SIGGEN) {
         rv = acvp_bin_to_hexstr(stc->signature, stc->signature_len, tmp, ACVP_EDDSA_MSG_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (signature)");
+            ACVP_LOG_ERR("Hex conversion failure (signature)");
             goto err;
         }
         json_object_set_string(tc_rsp, "signature", (const char *)tmp);
@@ -232,7 +232,7 @@ static ACVP_RESULT acvp_eddsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
 
     alg_str = json_object_get_string(obj, "algorithm");
     if (!alg_str) {
-        ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return ACVP_MALFORMED_JSON;
     }
 
@@ -252,7 +252,7 @@ static ACVP_RESULT acvp_eddsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
 
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
     ACVP_LOG_VERBOSE("    EDDSA mode: %s", mode_str);
@@ -262,7 +262,7 @@ static ACVP_RESULT acvp_eddsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -442,7 +442,7 @@ static ACVP_RESULT acvp_eddsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                    ACVP_LOG_ERR("crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -463,7 +463,7 @@ static ACVP_RESULT acvp_eddsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
                 }
                 rv = acvp_bin_to_hexstr(stc.q, stc.q_len, tmp, ACVP_EDDSA_POINT_LEN_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (q)");
+                    ACVP_LOG_ERR("Hex conversion failure (q)");
                     free(tmp);
                     json_value_free(r_tval);
                     goto err;
@@ -474,7 +474,7 @@ static ACVP_RESULT acvp_eddsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
             }
             rv = acvp_eddsa_output_tc(ctx, alg_id, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure in hash module");
                 json_value_free(r_tval);
                 goto err;
             }

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -81,7 +81,7 @@ static ACVP_RESULT acvp_hash_output_mct_tc(ACVP_CTX *ctx, ACVP_HASH_TC *stc, JSO
         rv = acvp_bin_to_hexstr(stc->md, stc->md_len, tmp, ACVP_HASH_MD_STR_MAX);
     }
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (md)");
+        ACVP_LOG_ERR("Hex conversion failure (md)");
         goto end;
     }
 
@@ -478,7 +478,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -774,7 +774,7 @@ static ACVP_RESULT acvp_hash_output_tc(ACVP_CTX *ctx, ACVP_HASH_TC *stc, JSON_Ob
         rv = acvp_bin_to_hexstr(stc->md, stc->md_len, tmp, ACVP_HASH_MD_STR_MAX);
     }
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (msg)");
+        ACVP_LOG_ERR("Hex conversion failure (msg)");
         goto end;
     }
     json_object_set_string(tc_rsp, "md", tmp);
@@ -850,7 +850,7 @@ static ACVP_RESULT acvp_hash_init_tc(ACVP_CTX *ctx,
         rv = acvp_hexstr_to_bin(msg, stc->msg, ACVP_SHAKE_MSG_BYTE_MAX, NULL);
     }
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Hex converstion failure (msg)");
+        ACVP_LOG_ERR("Hex conversion failure (msg)");
         return rv;
     }
 

--- a/src/acvp_hmac.c
+++ b/src/acvp_hmac.c
@@ -76,7 +76,7 @@ static ACVP_RESULT acvp_hmac_output_tc(ACVP_CTX *ctx, ACVP_HMAC_TC *stc, JSON_Ob
 
     rv = acvp_bin_to_hexstr(stc->mac, stc->mac_len, tmp, ACVP_HMAC_MAC_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (mac)");
+        ACVP_LOG_ERR("Hex conversion failure (mac)");
         goto end;
     }
     json_object_set_string(tc_rsp, "mac", tmp);
@@ -141,7 +141,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     }
 
     if (!alg_str) {
-        ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return ACVP_MALFORMED_JSON;
     }
 
@@ -155,12 +155,12 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id == 0) {
-        ACVP_LOG_ERR("ERROR: unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
         return ACVP_UNSUPPORTED_OP;
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
 
@@ -169,7 +169,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -184,7 +184,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     groups = json_object_get_array(obj, "testGroups");
     if (!groups) {
-        ACVP_LOG_ERR("Failed to include testGroups. ");
+        ACVP_LOG_ERR("Failed to include testGroups.");
         rv = ACVP_MISSING_ARG;
         goto err;
     }
@@ -212,21 +212,21 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         msglen = json_object_get_number(groupobj, "msgLen");
         if (!msglen) {
-            ACVP_LOG_ERR("Failed to include msgLen. ");
+            ACVP_LOG_ERR("Failed to include msgLen.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
 
         keylen = json_object_get_number(groupobj, "keyLen");
         if (!keylen) {
-            ACVP_LOG_ERR("Failed to include keyLen. ");
+            ACVP_LOG_ERR("Failed to include keyLen.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
 
         maclen = json_object_get_number(groupobj, "macLen");
         if (!maclen) {
-            ACVP_LOG_ERR("Failed to include macLen. ");
+            ACVP_LOG_ERR("Failed to include macLen.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
@@ -236,14 +236,14 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         tests = json_object_get_array(groupobj, "tests");
         if (!tests) {
-            ACVP_LOG_ERR("Failed to include tests. ");
+            ACVP_LOG_ERR("Failed to include tests.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
 
         t_cnt = json_array_get_count(tests);
         if (!t_cnt) {
-            ACVP_LOG_ERR("Failed to include tests in array. ");
+            ACVP_LOG_ERR("Failed to include tests in array.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
@@ -255,13 +255,13 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             tc_id = json_object_get_number(testobj, "tcId");
             if (!tc_id) {
-                ACVP_LOG_ERR("Failed to include tc_id. ");
+                ACVP_LOG_ERR("Failed to include tc_id.");
                 rv = ACVP_MISSING_ARG;
                 goto err;
             }
             msg = json_object_get_string(testobj, "msg");
             if (!msg) {
-                ACVP_LOG_ERR("Failed to include msg. ");
+                ACVP_LOG_ERR("Failed to include msg.");
                 rv = ACVP_MISSING_ARG;
                 goto err;
             }
@@ -275,7 +275,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             key = json_object_get_string(testobj, "key");
             if (!key) {
-                ACVP_LOG_ERR("Failed to include key. ");
+                ACVP_LOG_ERR("Failed to include key.");
                 rv = ACVP_MISSING_ARG;
                 goto err;
             }
@@ -316,7 +316,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                ACVP_LOG_ERR("crypto module failed the operation");
                 acvp_hmac_release_tc(&stc);
                 json_value_free(r_tval);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
@@ -328,7 +328,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_hmac_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure in hash module");
                 json_value_free(r_tval);
                 acvp_hmac_release_tc(&stc);
                 goto err;

--- a/src/acvp_kas_ecc.c
+++ b/src/acvp_kas_ecc.c
@@ -37,7 +37,7 @@ static ACVP_RESULT acvp_kas_ecc_output_cdh_tc(ACVP_CTX *ctx,
 
     rv = acvp_bin_to_hexstr(stc->pix, stc->pixlen, tmp, ACVP_KAS_ECC_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (pix)");
+        ACVP_LOG_ERR("Hex conversion failure (pix)");
         goto end;
     }
     json_object_set_string(tc_rsp, "publicIutX", tmp);
@@ -45,7 +45,7 @@ static ACVP_RESULT acvp_kas_ecc_output_cdh_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->piy, stc->piylen, tmp, ACVP_KAS_ECC_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (piy)");
+        ACVP_LOG_ERR("Hex conversion failure (piy)");
         goto end;
     }
     json_object_set_string(tc_rsp, "publicIutY", tmp);
@@ -53,7 +53,7 @@ static ACVP_RESULT acvp_kas_ecc_output_cdh_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->z, stc->zlen, tmp, ACVP_KAS_ECC_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (Z)");
+        ACVP_LOG_ERR("Hex conversion failure (Z)");
         goto end;
     }
     json_object_set_string(tc_rsp, "z", tmp);
@@ -88,7 +88,7 @@ static ACVP_RESULT acvp_kas_ecc_output_comp_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->chash, stc->chashlen, tmp, ACVP_KAS_ECC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (Z)");
+            ACVP_LOG_ERR("Hex conversion failure (Z)");
             goto end;
         }
         memcmp_s(stc->chash, ACVP_KAS_ECC_BYTE_MAX, stc->z, stc->zlen, &diff);
@@ -103,7 +103,7 @@ static ACVP_RESULT acvp_kas_ecc_output_comp_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->pix, stc->pixlen, tmp, ACVP_KAS_ECC_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (pix)");
+        ACVP_LOG_ERR("Hex conversion failure (pix)");
         goto end;
     }
     json_object_set_string(tc_rsp, "ephemeralPublicIutX", tmp);
@@ -111,7 +111,7 @@ static ACVP_RESULT acvp_kas_ecc_output_comp_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->piy, stc->piylen, tmp, ACVP_KAS_ECC_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (piy)");
+        ACVP_LOG_ERR("Hex conversion failure (piy)");
         goto end;
     }
     json_object_set_string(tc_rsp, "ephemeralPublicIutY", tmp);
@@ -119,7 +119,7 @@ static ACVP_RESULT acvp_kas_ecc_output_comp_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->d, stc->dlen, tmp, ACVP_KAS_ECC_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (d)");
+        ACVP_LOG_ERR("Hex conversion failure (d)");
         goto end;
     }
     json_object_set_string(tc_rsp, "ephemeralPrivateIut", tmp);
@@ -127,7 +127,7 @@ static ACVP_RESULT acvp_kas_ecc_output_comp_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->chash, stc->chashlen, tmp, ACVP_KAS_ECC_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (Z)");
+        ACVP_LOG_ERR("Hex conversion failure (Z)");
         goto end;
     }
     json_object_set_string(tc_rsp, "hashZIut", tmp);
@@ -770,7 +770,7 @@ ACVP_RESULT acvp_kas_ecc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -890,7 +890,7 @@ static ACVP_RESULT acvp_kas_ecc_output_ssc_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->chash, stc->chashlen, tmp, ACVP_KAS_ECC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (Z)");
+            ACVP_LOG_ERR("Hex conversion failure (Z)");
             goto end;
         }
         memcmp_s(stc->chash, ACVP_KAS_ECC_BYTE_MAX, stc->z, stc->zlen, &diff);
@@ -904,7 +904,7 @@ static ACVP_RESULT acvp_kas_ecc_output_ssc_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->pix, stc->pixlen, tmp, ACVP_KAS_ECC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (pix)");
+            ACVP_LOG_ERR("Hex conversion failure (pix)");
             goto end;
         }
         json_object_set_string(tc_rsp, "ephemeralPublicIutX", tmp);
@@ -912,7 +912,7 @@ static ACVP_RESULT acvp_kas_ecc_output_ssc_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->piy, stc->piylen, tmp, ACVP_KAS_ECC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (piy)");
+            ACVP_LOG_ERR("Hex conversion failure (piy)");
             goto end;
         }
         json_object_set_string(tc_rsp, "ephemeralPublicIutY", tmp);
@@ -920,7 +920,7 @@ static ACVP_RESULT acvp_kas_ecc_output_ssc_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->d, stc->dlen, tmp, ACVP_KAS_ECC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (d)");
+            ACVP_LOG_ERR("Hex conversion failure (d)");
             goto end;
         }
         json_object_set_string(tc_rsp, "ephemeralPrivateIut", tmp);
@@ -928,7 +928,7 @@ static ACVP_RESULT acvp_kas_ecc_output_ssc_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_KAS_ECC_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->chash, stc->chashlen, tmp, ACVP_KAS_ECC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (Z)");
+            ACVP_LOG_ERR("Hex conversion failure (Z)");
             goto end;
         }
         if (stc->md == ACVP_NO_SHA) {
@@ -1283,7 +1283,7 @@ ACVP_RESULT acvp_kas_ecc_ssc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_kas_ffc.c
+++ b/src/acvp_kas_ffc.c
@@ -86,7 +86,7 @@ static ACVP_RESULT acvp_kas_ffc_output_ssc_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_KAS_FFC_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->piut, stc->piutlen, tmp, ACVP_KAS_FFC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (IUT Pub)");
+            ACVP_LOG_ERR("Hex conversion failure (IUT Pub)");
             goto end;
         }
         json_object_set_string(tc_rsp, "ephemeralPublicIut", tmp);
@@ -94,7 +94,7 @@ static ACVP_RESULT acvp_kas_ffc_output_ssc_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_KAS_FFC_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->chash, stc->chashlen, tmp, ACVP_KAS_FFC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (Z)");
+            ACVP_LOG_ERR("Hex conversion failure (Z)");
             goto end;
         }
         if(stc->md == ACVP_NO_SHA) {
@@ -137,7 +137,7 @@ static ACVP_RESULT acvp_kas_ffc_output_comp_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KAS_FFC_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->piut, stc->piutlen, tmp, ACVP_KAS_FFC_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (Z)");
+        ACVP_LOG_ERR("Hex conversion failure (Z)");
         goto end;
     }
     json_object_set_string(tc_rsp, "ephemeralPublicIut", tmp);
@@ -145,7 +145,7 @@ static ACVP_RESULT acvp_kas_ffc_output_comp_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KAS_FFC_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->chash, stc->chashlen, tmp, ACVP_KAS_FFC_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (Z)");
+        ACVP_LOG_ERR("Hex conversion failure (Z)");
         goto end;
     }
     json_object_set_string(tc_rsp, "hashZIut", tmp);
@@ -580,7 +580,7 @@ ACVP_RESULT acvp_kas_ffc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -1001,7 +1001,7 @@ ACVP_RESULT acvp_kas_ffc_ssc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_kas_ifc.c
+++ b/src/acvp_kas_ifc.c
@@ -40,14 +40,14 @@ static ACVP_RESULT acvp_kas_ifc_ssc_output_tc(ACVP_CTX *ctx,
     if (stc->kas_role == ACVP_KAS_IFC_INITIATOR) {
         rv = acvp_bin_to_hexstr(stc->iut_ct_z, stc->iut_ct_z_len, tmp, ACVP_KAS_IFC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (iut_ct_z)");
+            ACVP_LOG_ERR("Hex conversion failure (iut_ct_z)");
             goto end;
         }
         json_object_set_string(tc_rsp, "iutC", tmp);
 
         rv = acvp_bin_to_hexstr(stc->iut_pt_z, stc->iut_pt_z_len, tmp, ACVP_KAS_IFC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (iut_pt_z)");
+            ACVP_LOG_ERR("Hex conversion failure (iut_pt_z)");
             goto end;
         }
         if (stc->md == ACVP_NO_SHA) {
@@ -65,14 +65,14 @@ static ACVP_RESULT acvp_kas_ifc_ssc_output_tc(ACVP_CTX *ctx,
         if (stc->scheme == ACVP_KAS_IFC_KAS2) {
             rv = acvp_bin_to_hexstr(stc->iut_ct_z, stc->iut_ct_z_len, tmp, ACVP_KAS_IFC_STR_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (iut_ct_z)");
+                ACVP_LOG_ERR("Hex conversion failure (iut_ct_z)");
                 goto end;
             }
             json_object_set_string(tc_rsp, "iutC", tmp);
 
             rv = acvp_bin_to_hexstr(stc->iut_pt_z, stc->iut_pt_z_len, tmp, ACVP_KAS_IFC_STR_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (iut_pt_z)");
+                ACVP_LOG_ERR("Hex conversion failure (iut_pt_z)");
                 goto end;
             }
             if (stc->md == ACVP_NO_SHA) {
@@ -83,7 +83,7 @@ static ACVP_RESULT acvp_kas_ifc_ssc_output_tc(ACVP_CTX *ctx,
         } else {
             rv = acvp_bin_to_hexstr(stc->server_pt_z, stc->server_pt_z_len, tmp, ACVP_KAS_IFC_STR_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (server_pt_z)");
+                ACVP_LOG_ERR("Hex conversion failure (server_pt_z)");
                 goto end;
             }
             if (stc->md == ACVP_NO_SHA) {
@@ -114,7 +114,7 @@ static ACVP_RESULT acvp_kas_ifc_ssc_output_tc(ACVP_CTX *ctx,
         }
         rv = acvp_bin_to_hexstr((const unsigned char *)merge, z_len, tmp, ACVP_KAS_IFC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (KAS2 combined Z)");
+            ACVP_LOG_ERR("Hex conversion failure (KAS2 combined Z)");
             goto end;
         }
         json_object_set_string(tc_rsp, "z", tmp);
@@ -962,7 +962,7 @@ ACVP_RESULT acvp_kas_ifc_ssc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_kda.c
+++ b/src/acvp_kda.c
@@ -51,7 +51,7 @@ static ACVP_RESULT acvp_kda_hkdf_output_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KDA_DKM_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->outputDkm, stc->l, tmp, ACVP_KDA_DKM_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (dkm)");
+        ACVP_LOG_ERR("Hex conversion failure (dkm)");
         goto end;
     }
     json_object_set_string(tc_rsp, "dkm", tmp);
@@ -91,7 +91,7 @@ static ACVP_RESULT acvp_kda_onestep_output_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KDA_DKM_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->outputDkm, stc->l, tmp, ACVP_KDA_DKM_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (dkm)");
+        ACVP_LOG_ERR("Hex conversion failure (dkm)");
         goto end;
     }
     json_object_set_string(tc_rsp, "dkm", tmp);
@@ -279,7 +279,7 @@ static ACVP_RESULT acvp_kda_twostep_output_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KDA_DKM_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->outputDkm, stc->l, tmp, ACVP_KDA_DKM_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (dkm)");
+        ACVP_LOG_ERR("Hex conversion failure (dkm)");
         goto end;
     }
     json_object_set_string(tc_rsp, "dkm", tmp);
@@ -1508,7 +1508,7 @@ ACVP_RESULT acvp_kda_hkdf_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -1604,7 +1604,7 @@ ACVP_RESULT acvp_kda_onestep_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -1700,7 +1700,7 @@ ACVP_RESULT acvp_kda_twostep_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_kdf108.c
+++ b/src/acvp_kdf108.c
@@ -48,7 +48,7 @@ static ACVP_RESULT acvp_kdf108_output_tc(ACVP_CTX *ctx,
     rv = acvp_bin_to_hexstr(stc->key_out, stc->key_out_len,
                             tmp, ACVP_KDF108_KEYOUT_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (key_out)");
+        ACVP_LOG_ERR("Hex conversion failure (key_out)");
         goto end;
     }
     if (stc->mode == ACVP_KDF108_MODE_KMAC) {
@@ -76,7 +76,7 @@ static ACVP_RESULT acvp_kdf108_output_tc(ACVP_CTX *ctx,
         rv = acvp_bin_to_hexstr(stc->fixed_data, stc->fixed_data_len,
                                 tmp, ACVP_KDF108_FIXED_DATA_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (fixed_data)");
+            ACVP_LOG_ERR("Hex conversion failure (fixed_data)");
             goto end;
         }
         json_object_set_string(tc_rsp, "fixedData", tmp);
@@ -385,7 +385,7 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_kdf135_ikev1.c
+++ b/src/acvp_kdf135_ikev1.c
@@ -32,7 +32,7 @@ static ACVP_RESULT acvp_kdf135_ikev1_output_tc(ACVP_CTX *ctx, ACVP_KDF135_IKEV1_
 
     rv = acvp_bin_to_hexstr(stc->s_key_id, stc->s_key_id_len, tmp, ACVP_KDF135_IKEV1_SKEY_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (s_key_id)");
+        ACVP_LOG_ERR("Hex conversion failure (s_key_id)");
         goto err;
     }
     json_object_set_string(tc_rsp, "sKeyId", (const char *)tmp);
@@ -40,7 +40,7 @@ static ACVP_RESULT acvp_kdf135_ikev1_output_tc(ACVP_CTX *ctx, ACVP_KDF135_IKEV1_
 
     rv = acvp_bin_to_hexstr(stc->s_key_id_d, stc->s_key_id_d_len, tmp, ACVP_KDF135_IKEV1_SKEY_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (s_key_id_d)");
+        ACVP_LOG_ERR("Hex conversion failure (s_key_id_d)");
         goto err;
     }
     json_object_set_string(tc_rsp, "sKeyIdD", (const char *)tmp);
@@ -48,7 +48,7 @@ static ACVP_RESULT acvp_kdf135_ikev1_output_tc(ACVP_CTX *ctx, ACVP_KDF135_IKEV1_
 
     rv = acvp_bin_to_hexstr(stc->s_key_id_a, stc->s_key_id_a_len, tmp, ACVP_KDF135_IKEV1_SKEY_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (s_key_id_a)");
+        ACVP_LOG_ERR("Hex conversion failure (s_key_id_a)");
         goto err;
     }
     json_object_set_string(tc_rsp, "sKeyIdA", (const char *)tmp);
@@ -56,7 +56,7 @@ static ACVP_RESULT acvp_kdf135_ikev1_output_tc(ACVP_CTX *ctx, ACVP_KDF135_IKEV1_
 
     rv = acvp_bin_to_hexstr(stc->s_key_id_e, stc->s_key_id_e_len, tmp, ACVP_KDF135_IKEV1_SKEY_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (s_key_id_e)");
+        ACVP_LOG_ERR("Hex conversion failure (s_key_id_e)");
         goto err;
     }
     json_object_set_string(tc_rsp, "sKeyIdE", (const char *)tmp);
@@ -275,7 +275,7 @@ ACVP_RESULT acvp_kdf135_ikev1_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_kdf135_ikev2.c
+++ b/src/acvp_kdf135_ikev2.c
@@ -29,7 +29,7 @@ static ACVP_RESULT acvp_kdf135_ikev2_output_tc(ACVP_CTX *ctx, ACVP_KDF135_IKEV2_
 
     rv = acvp_bin_to_hexstr(stc->s_key_seed, stc->key_out_len, tmp, ACVP_KDF135_IKEV2_SKEY_SEED_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (s_key_seed)");
+        ACVP_LOG_ERR("Hex conversion failure (s_key_seed)");
         goto err;
     }
     json_object_set_string(tc_rsp, "sKeySeed", (const char *)tmp);
@@ -37,7 +37,7 @@ static ACVP_RESULT acvp_kdf135_ikev2_output_tc(ACVP_CTX *ctx, ACVP_KDF135_IKEV2_
 
     rv = acvp_bin_to_hexstr(stc->s_key_seed_rekey, stc->key_out_len, tmp, ACVP_KDF135_IKEV2_SKEY_SEED_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (s_key_seed_rekey)");
+        ACVP_LOG_ERR("Hex conversion failure (s_key_seed_rekey)");
         goto err;
     }
     json_object_set_string(tc_rsp, "sKeySeedReKey", (const char *)tmp);
@@ -48,7 +48,7 @@ static ACVP_RESULT acvp_kdf135_ikev2_output_tc(ACVP_CTX *ctx, ACVP_KDF135_IKEV2_
     tmp = calloc(ACVP_KDF135_IKEV2_DKEY_MATERIAL_STR_MAX, sizeof(char));
     rv = acvp_bin_to_hexstr(stc->derived_keying_material, stc->keying_material_len, tmp, ACVP_KDF135_IKEV2_DKEY_MATERIAL_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (derived_keying_material)");
+        ACVP_LOG_ERR("Hex conversion failure (derived_keying_material)");
         goto err;
     }
     json_object_set_string(tc_rsp, "derivedKeyingMaterial", (const char *)tmp);
@@ -56,7 +56,7 @@ static ACVP_RESULT acvp_kdf135_ikev2_output_tc(ACVP_CTX *ctx, ACVP_KDF135_IKEV2_
 
     rv = acvp_bin_to_hexstr(stc->derived_keying_material_child, stc->keying_material_len, tmp, ACVP_KDF135_IKEV2_DKEY_MATERIAL_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (derived_keying_material)");
+        ACVP_LOG_ERR("Hex conversion failure (derived_keying_material)");
         goto err;
     }
     json_object_set_string(tc_rsp, "derivedKeyingMaterialChild", (const char *)tmp);
@@ -64,7 +64,7 @@ static ACVP_RESULT acvp_kdf135_ikev2_output_tc(ACVP_CTX *ctx, ACVP_KDF135_IKEV2_
 
     rv = acvp_bin_to_hexstr(stc->derived_keying_material_child_dh, stc->keying_material_len, tmp, ACVP_KDF135_IKEV2_DKEY_MATERIAL_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (derived_keying_material)");
+        ACVP_LOG_ERR("Hex conversion failure (derived_keying_material)");
         goto err;
     }
     json_object_set_string(tc_rsp, "derivedKeyingMaterialDh", (const char *)tmp);
@@ -272,7 +272,7 @@ ACVP_RESULT acvp_kdf135_ikev2_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_kdf135_snmp.c
+++ b/src/acvp_kdf135_snmp.c
@@ -106,7 +106,7 @@ ACVP_RESULT acvp_kdf135_snmp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -121,7 +121,7 @@ ACVP_RESULT acvp_kdf135_snmp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     groups = json_object_get_array(obj, "testGroups");
     if (!groups) {
-        ACVP_LOG_ERR("Failed to include testGroups. ");
+        ACVP_LOG_ERR("Failed to include testGroups.");
         rv = ACVP_MISSING_ARG;
         goto err;
     }
@@ -157,7 +157,7 @@ ACVP_RESULT acvp_kdf135_snmp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         engine_id = json_object_get_string(groupobj, "engineId");
         if (!engine_id) {
-            ACVP_LOG_ERR("Failed to include engineId. ");
+            ACVP_LOG_ERR("Failed to include engineId.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
@@ -168,14 +168,14 @@ ACVP_RESULT acvp_kdf135_snmp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         tests = json_object_get_array(groupobj, "tests");
         if (!tests) {
-            ACVP_LOG_ERR("Failed to include tests. ");
+            ACVP_LOG_ERR("Failed to include tests.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
 
         t_cnt = json_array_get_count(tests);
         if (!t_cnt) {
-            ACVP_LOG_ERR("Failed to include tests in array. ");
+            ACVP_LOG_ERR("Failed to include tests in array.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
@@ -187,7 +187,7 @@ ACVP_RESULT acvp_kdf135_snmp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             tc_id = json_object_get_number(testobj, "tcId");
             if (!tc_id) {
-                ACVP_LOG_ERR("Failed to include tc_id. ");
+                ACVP_LOG_ERR("Failed to include tc_id.");
                 rv = ACVP_MISSING_ARG;
                 goto err;
             }
@@ -286,7 +286,7 @@ static ACVP_RESULT acvp_kdf135_snmp_output_tc(ACVP_CTX *ctx, ACVP_KDF135_SNMP_TC
 
     rv = acvp_bin_to_hexstr(stc->s_key, stc->skey_len, tmp, ACVP_KDF135_SNMP_SKEY_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (s_key)");
+        ACVP_LOG_ERR("Hex conversion failure (s_key)");
         goto err;
     }
     json_object_set_string(tc_rsp, "sharedKey", (const char *)tmp);

--- a/src/acvp_kdf135_srtp.c
+++ b/src/acvp_kdf135_srtp.c
@@ -32,7 +32,7 @@ static ACVP_RESULT acvp_kdf135_srtp_output_tc(ACVP_CTX *ctx, ACVP_KDF135_SRTP_TC
 
     rv = acvp_bin_to_hexstr(stc->srtp_ke, stc->aes_keylen / 8, tmp, ACVP_KDF135_SRTP_OUTPUT_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (srtp_ke)");
+        ACVP_LOG_ERR("Hex conversion failure (srtp_ke)");
         goto err;
     }
     json_object_set_string(tc_rsp, "srtpKe", (const char *)tmp);
@@ -40,7 +40,7 @@ static ACVP_RESULT acvp_kdf135_srtp_output_tc(ACVP_CTX *ctx, ACVP_KDF135_SRTP_TC
 
     rv = acvp_bin_to_hexstr(stc->srtp_ka, 160 / 8, tmp, ACVP_KDF135_SRTP_OUTPUT_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (srtp_ka)");
+        ACVP_LOG_ERR("Hex conversion failure (srtp_ka)");
         goto err;
     }
     json_object_set_string(tc_rsp, "srtpKa", (const char *)tmp);
@@ -48,7 +48,7 @@ static ACVP_RESULT acvp_kdf135_srtp_output_tc(ACVP_CTX *ctx, ACVP_KDF135_SRTP_TC
 
     rv = acvp_bin_to_hexstr(stc->srtp_ks, 112 / 8, tmp, ACVP_KDF135_SRTP_OUTPUT_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (srtp_ks)");
+        ACVP_LOG_ERR("Hex conversion failure (srtp_ks)");
         goto err;
     }
     json_object_set_string(tc_rsp, "srtpKs", (const char *)tmp);
@@ -56,7 +56,7 @@ static ACVP_RESULT acvp_kdf135_srtp_output_tc(ACVP_CTX *ctx, ACVP_KDF135_SRTP_TC
 
     rv = acvp_bin_to_hexstr(stc->srtcp_ke, stc->aes_keylen / 8, tmp, ACVP_KDF135_SRTP_OUTPUT_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (srtcp_ke)");
+        ACVP_LOG_ERR("Hex conversion failure (srtcp_ke)");
         goto err;
     }
     json_object_set_string(tc_rsp, "srtcpKe", (const char *)tmp);
@@ -64,7 +64,7 @@ static ACVP_RESULT acvp_kdf135_srtp_output_tc(ACVP_CTX *ctx, ACVP_KDF135_SRTP_TC
 
     rv = acvp_bin_to_hexstr(stc->srtcp_ka, 160 / 8, tmp, ACVP_KDF135_SRTP_OUTPUT_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (srtcp_ka)");
+        ACVP_LOG_ERR("Hex conversion failure (srtcp_ka)");
         goto err;
     }
     json_object_set_string(tc_rsp, "srtcpKa", (const char *)tmp);
@@ -72,7 +72,7 @@ static ACVP_RESULT acvp_kdf135_srtp_output_tc(ACVP_CTX *ctx, ACVP_KDF135_SRTP_TC
 
     rv = acvp_bin_to_hexstr(stc->srtcp_ks, 112 / 8, tmp, ACVP_KDF135_SRTP_OUTPUT_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (srtcp_ks)");
+        ACVP_LOG_ERR("Hex conversion failure (srtcp_ks)");
         goto err;
     }
     json_object_set_string(tc_rsp, "srtcpKs", (const char *)tmp);
@@ -256,7 +256,7 @@ ACVP_RESULT acvp_kdf135_srtp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_kdf135_ssh.c
+++ b/src/acvp_kdf135_ssh.c
@@ -118,7 +118,7 @@ ACVP_RESULT acvp_kdf135_ssh_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -133,7 +133,7 @@ ACVP_RESULT acvp_kdf135_ssh_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     groups = json_object_get_array(obj, "testGroups");
     if (!groups) {
-        ACVP_LOG_ERR("Failed to include testGroups. ");
+        ACVP_LOG_ERR("Failed to include testGroups.");
         rv = ACVP_MISSING_ARG;
         goto err;
     }
@@ -168,14 +168,14 @@ ACVP_RESULT acvp_kdf135_ssh_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         // Get the expected (user will generate) key and iv lengths
         cipher_str = json_object_get_string(groupobj, "cipher");
         if (!cipher_str) {
-            ACVP_LOG_ERR("Failed to include cipher. ");
+            ACVP_LOG_ERR("Failed to include cipher.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
 
         sha_str = json_object_get_string(groupobj, "hashAlg");
         if (!sha_str) {
-            ACVP_LOG_ERR("Failed to include hashAlg. ");
+            ACVP_LOG_ERR("Failed to include hashAlg.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
@@ -240,14 +240,14 @@ ACVP_RESULT acvp_kdf135_ssh_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         tests = json_object_get_array(groupobj, "tests");
         if (!tests) {
-            ACVP_LOG_ERR("Failed to include tests. ");
+            ACVP_LOG_ERR("Failed to include tests.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
 
         t_cnt = json_array_get_count(tests);
         if (!t_cnt) {
-            ACVP_LOG_ERR("Failed to include tests in array. ");
+            ACVP_LOG_ERR("Failed to include tests in array.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
@@ -259,28 +259,28 @@ ACVP_RESULT acvp_kdf135_ssh_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             tc_id = json_object_get_number(testobj, "tcId");
             if (!tc_id) {
-                ACVP_LOG_ERR("Failed to include tc_id. ");
+                ACVP_LOG_ERR("Failed to include tc_id.");
                 rv = ACVP_MISSING_ARG;
                 goto err;
             }
 
             shared_secret_str = json_object_get_string(testobj, "k");
             if (!shared_secret_str) {
-                ACVP_LOG_ERR("Failed to include k. ");
+                ACVP_LOG_ERR("Failed to include k.");
                 rv = ACVP_MISSING_ARG;
                 goto err;
             }
 
             hash_str = json_object_get_string(testobj, "h");
             if (!hash_str) {
-                ACVP_LOG_ERR("Failed to include h. ");
+                ACVP_LOG_ERR("Failed to include h.");
                 rv = ACVP_MISSING_ARG;
                 goto err;
             }
 
             session_id_str = json_object_get_string(testobj, "sessionId");
             if (!session_id_str) {
-                ACVP_LOG_ERR("Failed to include sessionId. ");
+                ACVP_LOG_ERR("Failed to include sessionId.");
                 rv = ACVP_MISSING_ARG;
                 goto err;
             }

--- a/src/acvp_kdf135_x942.c
+++ b/src/acvp_kdf135_x942.c
@@ -215,7 +215,7 @@ ACVP_RESULT acvp_kdf135_x942_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -231,7 +231,7 @@ ACVP_RESULT acvp_kdf135_x942_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     groups = json_object_get_array(obj, "testGroups");
     if (!groups) {
-        ACVP_LOG_ERR("Failed to include testGroups. ");
+        ACVP_LOG_ERR("Failed to include testGroups.");
         rv = ACVP_MISSING_ARG;
         goto err;
     }
@@ -308,14 +308,14 @@ ACVP_RESULT acvp_kdf135_x942_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         tests = json_object_get_array(groupobj, "tests");
         if (!tests) {
-            ACVP_LOG_ERR("Failed to include tests. ");
+            ACVP_LOG_ERR("Failed to include tests.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
 
         t_cnt = json_array_get_count(tests);
         if (!t_cnt) {
-            ACVP_LOG_ERR("Failed to include tests in array. ");
+            ACVP_LOG_ERR("Failed to include tests in array.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }

--- a/src/acvp_kdf135_x963.c
+++ b/src/acvp_kdf135_x963.c
@@ -34,7 +34,7 @@ static ACVP_RESULT acvp_kdf135_x963_output_tc(ACVP_CTX *ctx, ACVP_KDF135_X963_TC
     }
     rv = acvp_bin_to_hexstr(stc->key_data, stc->key_data_len, tmp, ACVP_KDF135_X963_KEYDATA_MAX_CHARS);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (key_data)");
+        ACVP_LOG_ERR("Hex conversion failure (key_data)");
         goto err;
     }
     json_object_set_string(tc_rsp, "keyData", (const char *)tmp);
@@ -180,7 +180,7 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -196,7 +196,7 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     groups = json_object_get_array(obj, "testGroups");
     if (!groups) {
-        ACVP_LOG_ERR("Failed to include testGroups. ");
+        ACVP_LOG_ERR("Failed to include testGroups.");
         rv = ACVP_MISSING_ARG;
         goto err;
     }
@@ -228,14 +228,14 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         field_size = json_object_get_number(groupobj, "fieldSize");
         if (!field_size) {
-            ACVP_LOG_ERR("Failed to include field size. ");
+            ACVP_LOG_ERR("Failed to include field size.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
 
         key_data_length = json_object_get_number(groupobj, "keyDataLength");
         if (!key_data_length) {
-            ACVP_LOG_ERR("Failed to include key data length. ");
+            ACVP_LOG_ERR("Failed to include key data length.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
@@ -244,7 +244,7 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         hash_alg_str = json_object_get_string(groupobj, "hashAlg");
         if (!hash_alg_str) {
-            ACVP_LOG_ERR("Failed to include hashAlg. ");
+            ACVP_LOG_ERR("Failed to include hashAlg.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
@@ -264,14 +264,14 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         tests = json_object_get_array(groupobj, "tests");
         if (!tests) {
-            ACVP_LOG_ERR("Failed to include tests. ");
+            ACVP_LOG_ERR("Failed to include tests.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
 
         t_cnt = json_array_get_count(tests);
         if (!t_cnt) {
-            ACVP_LOG_ERR("Failed to include tests in array. ");
+            ACVP_LOG_ERR("Failed to include tests in array.");
             rv = ACVP_MISSING_ARG;
             goto err;
         }
@@ -283,7 +283,7 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             tc_id = json_object_get_number(testobj, "tcId");
             if (!tc_id) {
-                ACVP_LOG_ERR("Failed to include tc_id. ");
+                ACVP_LOG_ERR("Failed to include tc_id.");
                 rv = ACVP_MISSING_ARG;
                 goto err;
             }
@@ -291,13 +291,13 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             z = json_object_get_string(testobj, "z");
             shared_info = json_object_get_string(testobj, "sharedInfo");
             if (!z) {
-                ACVP_LOG_ERR("Failed to include z. ");
+                ACVP_LOG_ERR("Failed to include z.");
                 rv = ACVP_INVALID_ARG;
                 goto err;
             }
 
             if (!shared_info) {
-                ACVP_LOG_ERR("Failed to include shared_info. ");
+                ACVP_LOG_ERR("Failed to include shared_info.");
                 rv = ACVP_INVALID_ARG;
                 goto err;
             }

--- a/src/acvp_kdf_tls12.c
+++ b/src/acvp_kdf_tls12.c
@@ -111,7 +111,7 @@ ACVP_RESULT acvp_kdf_tls12_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -313,7 +313,7 @@ static ACVP_RESULT acvp_kdf_tls12_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS12_TC *st
 
     rv = acvp_bin_to_hexstr(stc->msecret, stc->pm_len, tmp, ACVP_KDF_TLS12_MSG_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (mac)");
+        ACVP_LOG_ERR("Hex conversion failure (mac)");
         goto err;
     }
     json_object_set_string(tc_rsp, "masterSecret", tmp);
@@ -321,7 +321,7 @@ static ACVP_RESULT acvp_kdf_tls12_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS12_TC *st
 
     rv = acvp_bin_to_hexstr(stc->kblock, stc->kb_len, tmp, ACVP_KDF_TLS12_MSG_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (mac)");
+        ACVP_LOG_ERR("Hex conversion failure (mac)");
         goto err;
     }
     json_object_set_string(tc_rsp, "keyBlock", tmp);

--- a/src/acvp_kdf_tls13.c
+++ b/src/acvp_kdf_tls13.c
@@ -136,7 +136,7 @@ ACVP_RESULT acvp_kdf_tls13_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -385,7 +385,7 @@ static ACVP_RESULT acvp_kdf_tls13_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS13_TC *st
     }
     rv = acvp_bin_to_hexstr(stc->c_early_traffic_secret, stc->cets_len, tmp, ACVP_KDF_TLS13_DATA_LEN_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (client early traffic secret)");
+        ACVP_LOG_ERR("Hex conversion failure (client early traffic secret)");
         goto err;
     }
     json_object_set_string(tc_rsp, "clientEarlyTrafficSecret", tmp);
@@ -399,7 +399,7 @@ static ACVP_RESULT acvp_kdf_tls13_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS13_TC *st
     }
     rv = acvp_bin_to_hexstr(stc->early_expt_master_secret, stc->eems_len, tmp, ACVP_KDF_TLS13_DATA_LEN_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (early export master secret)");
+        ACVP_LOG_ERR("Hex conversion failure (early export master secret)");
         goto err;
     }
     json_object_set_string(tc_rsp, "earlyExporterMasterSecret", tmp);
@@ -413,7 +413,7 @@ static ACVP_RESULT acvp_kdf_tls13_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS13_TC *st
     }
     rv = acvp_bin_to_hexstr(stc->c_hs_traffic_secret, stc->chts_len, tmp, ACVP_KDF_TLS13_DATA_LEN_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (client handshake traffic secret)");
+        ACVP_LOG_ERR("Hex conversion failure (client handshake traffic secret)");
         goto err;
     }
     json_object_set_string(tc_rsp, "clientHandshakeTrafficSecret", tmp);
@@ -427,7 +427,7 @@ static ACVP_RESULT acvp_kdf_tls13_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS13_TC *st
     }
     rv = acvp_bin_to_hexstr(stc->s_hs_traffic_secret, stc->shts_len, tmp, ACVP_KDF_TLS13_DATA_LEN_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (server handshake traffic secret)");
+        ACVP_LOG_ERR("Hex conversion failure (server handshake traffic secret)");
         goto err;
     }
     json_object_set_string(tc_rsp, "serverHandshakeTrafficSecret", tmp);
@@ -441,7 +441,7 @@ static ACVP_RESULT acvp_kdf_tls13_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS13_TC *st
     }
     rv = acvp_bin_to_hexstr(stc->c_app_traffic_secret, stc->cats_len, tmp, ACVP_KDF_TLS13_DATA_LEN_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (client app traffic secret)");
+        ACVP_LOG_ERR("Hex conversion failure (client app traffic secret)");
         goto err;
     }
     json_object_set_string(tc_rsp, "clientApplicationTrafficSecret", tmp);
@@ -456,7 +456,7 @@ static ACVP_RESULT acvp_kdf_tls13_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS13_TC *st
     }
     rv = acvp_bin_to_hexstr(stc->s_app_traffic_secret, stc->sats_len, tmp, ACVP_KDF_TLS13_DATA_LEN_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (server app traffic secret)");
+        ACVP_LOG_ERR("Hex conversion failure (server app traffic secret)");
         goto err;
     }
     json_object_set_string(tc_rsp, "serverApplicationTrafficSecret", tmp);
@@ -471,7 +471,7 @@ static ACVP_RESULT acvp_kdf_tls13_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS13_TC *st
     }
     rv = acvp_bin_to_hexstr(stc->expt_master_secret, stc->ems_len, tmp, ACVP_KDF_TLS13_DATA_LEN_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (exporter master secret)");
+        ACVP_LOG_ERR("Hex conversion failure (exporter master secret)");
         goto err;
     }
     json_object_set_string(tc_rsp, "exporterMasterSecret", tmp);
@@ -485,7 +485,7 @@ static ACVP_RESULT acvp_kdf_tls13_output_tc(ACVP_CTX *ctx, ACVP_KDF_TLS13_TC *st
     }
     rv = acvp_bin_to_hexstr(stc->resume_master_secret, stc->rms_len, tmp, ACVP_KDF_TLS13_DATA_LEN_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (resumption master secret)");
+        ACVP_LOG_ERR("Hex conversion failure (resumption master secret)");
         goto err;
     }
     json_object_set_string(tc_rsp, "resumptionMasterSecret", tmp);

--- a/src/acvp_kmac.c
+++ b/src/acvp_kmac.c
@@ -52,20 +52,20 @@ static ACVP_RESULT acvp_kmac_init_tc(ACVP_CTX *ctx,
 
     rv = acvp_hexstr_to_bin(msg, stc->msg, ACVP_KMAC_MSG_BYTE_MAX, NULL);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Hex converstion failure (msg)");
+        ACVP_LOG_ERR("Hex conversion failure (msg)");
         return rv;
     }
 
     rv = acvp_hexstr_to_bin(key, stc->key, ACVP_KMAC_KEY_BYTE_MAX, NULL);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Hex converstion failure (key)");
+        ACVP_LOG_ERR("Hex conversion failure (key)");
         return rv;
     }
 
     if (type == ACVP_KMAC_TEST_TYPE_MVT) {
         rv = acvp_hexstr_to_bin(mac, stc->mac, ACVP_KMAC_MAC_BYTE_MAX, NULL);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Hex converstion failure (mac)");
+            ACVP_LOG_ERR("Hex conversion failure (mac)");
             return rv;
         }
     }
@@ -73,7 +73,7 @@ static ACVP_RESULT acvp_kmac_init_tc(ACVP_CTX *ctx,
     if (hex_customization) {
         rv = acvp_hexstr_to_bin(custom, stc->custom_hex, ACVP_KMAC_CUSTOM_HEX_BYTE_MAX, &stc->custom_len);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Hex converstion failure (customizationHex)");
+            ACVP_LOG_ERR("Hex conversion failure (customizationHex)");
             return rv;
         }
     } else {
@@ -120,7 +120,7 @@ static ACVP_RESULT acvp_kmac_output_tc(ACVP_CTX *ctx, ACVP_KMAC_TC *stc, JSON_Ob
 
         rv = acvp_bin_to_hexstr(stc->mac, stc->mac_len, tmp, ACVP_KMAC_MAC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (mac)");
+            ACVP_LOG_ERR("Hex conversion failure (mac)");
             goto end;
         }
         json_object_set_string(tc_rsp, "mac", tmp);
@@ -203,7 +203,7 @@ ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     }
 
     if (!alg_str) {
-        ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return ACVP_MALFORMED_JSON;
     }
 
@@ -213,12 +213,12 @@ ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     /* Get the crypto module handler for this kmac algorithm */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id == 0) {
-        ACVP_LOG_ERR("ERROR: unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
         return ACVP_UNSUPPORTED_OP;
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
 
@@ -227,7 +227,7 @@ ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -242,7 +242,7 @@ ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     groups = json_object_get_array(obj, "testGroups");
     if (!groups) {
-        ACVP_LOG_ERR("Failed to include testGroups. ");
+        ACVP_LOG_ERR("Failed to include testGroups.");
         rv = ACVP_TC_MISSING_DATA;
         goto err;
     }
@@ -301,14 +301,14 @@ ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
         tests = json_object_get_array(groupobj, "tests");
         if (!tests) {
-            ACVP_LOG_ERR("Failed to include tests. ");
+            ACVP_LOG_ERR("Failed to include tests.");
             rv = ACVP_TC_MISSING_DATA;
             goto err;
         }
 
         t_cnt = json_array_get_count(tests);
         if (!t_cnt) {
-            ACVP_LOG_ERR("Failed to include tests in array. ");
+            ACVP_LOG_ERR("Failed to include tests in array.");
             rv = ACVP_TC_MISSING_DATA;
             goto err;
         }
@@ -320,7 +320,7 @@ ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             tc_id = json_object_get_number(testobj, "tcId");
             if (!tc_id) {
-                ACVP_LOG_ERR("Failed to include tc_id. ");
+                ACVP_LOG_ERR("Failed to include tc_id.");
                 rv = ACVP_TC_MISSING_DATA;
                 goto err;
             }
@@ -440,7 +440,7 @@ ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                ACVP_LOG_ERR("crypto module failed the operation");
                 acvp_kmac_release_tc(&stc);
                 json_value_free(r_tval);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
@@ -452,7 +452,7 @@ ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kmac_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in kmac module");
+                ACVP_LOG_ERR("JSON output failure in kmac module");
                 json_value_free(r_tval);
                 acvp_kmac_release_tc(&stc);
                 goto err;

--- a/src/acvp_kts_ifc.c
+++ b/src/acvp_kts_ifc.c
@@ -39,7 +39,7 @@ static ACVP_RESULT acvp_kts_ifc_output_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_KTS_IFC_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->ct, stc->ct_len, tmp, ACVP_KTS_IFC_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (iutC)");
+            ACVP_LOG_ERR("Hex conversion failure (iutC)");
             goto end;
         }
 
@@ -49,7 +49,7 @@ static ACVP_RESULT acvp_kts_ifc_output_tc(ACVP_CTX *ctx,
     memzero_s(tmp, ACVP_KTS_IFC_STR_MAX);
     rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp, ACVP_KTS_IFC_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (dkm)");
+        ACVP_LOG_ERR("Hex conversion failure (dkm)");
         goto end;
     }
 
@@ -668,7 +668,7 @@ ACVP_RESULT acvp_kts_ifc_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_lms.c
+++ b/src/acvp_lms.c
@@ -40,7 +40,7 @@ static ACVP_RESULT acvp_lms_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_LM
         memzero_s(tmp, ACVP_LMS_TMP_MAX);
         rv = acvp_bin_to_hexstr(stc->pub_key, stc->pub_key_len, tmp, ACVP_LMS_TMP_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (publicKey)");
+            ACVP_LOG_ERR("Hex conversion failure (publicKey)");
             goto end;
         }
         json_object_set_string(tc_rsp, "publicKey", tmp);
@@ -49,7 +49,7 @@ static ACVP_RESULT acvp_lms_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_LM
         /* This also needs publicKey in the test group response, handled elsewhere */
         rv = acvp_bin_to_hexstr(stc->sig, stc->sig_len, tmp, ACVP_LMS_TMP_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (signature)");
+            ACVP_LOG_ERR("Hex conversion failure (signature)");
             goto end;
         }
         json_object_set_string(tc_rsp, "signature", tmp);
@@ -257,7 +257,7 @@ ACVP_RESULT acvp_lms_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
         return rv;
     }
 
@@ -440,7 +440,7 @@ ACVP_RESULT acvp_lms_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 char *tmp = calloc(ACVP_LMS_TMP_MAX + 1, sizeof(char));
                 rv = acvp_bin_to_hexstr(stc.pub_key, stc.pub_key_len, tmp, ACVP_LMS_TMP_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (pub_key)");
+                    ACVP_LOG_ERR("Hex conversion failure (pub_key)");
                     free(tmp);
                     json_value_free(r_tval);
                     goto err;

--- a/src/acvp_ml_dsa.c
+++ b/src/acvp_ml_dsa.c
@@ -45,7 +45,7 @@ static ACVP_RESULT acvp_ml_dsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP
         memzero_s(tmp, ACVP_ML_DSA_MSG_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->pub_key, stc->pub_key_len, tmp, ACVP_ML_DSA_MSG_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (pk)");
+            ACVP_LOG_ERR("Hex conversion failure (pk)");
             goto end;
         }
         json_object_set_string(tc_rsp, "pk", tmp);
@@ -53,7 +53,7 @@ static ACVP_RESULT acvp_ml_dsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP
         memzero_s(tmp, ACVP_ML_DSA_MSG_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->secret_key, stc->secret_key_len, tmp, ACVP_ML_DSA_MSG_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (sk)");
+            ACVP_LOG_ERR("Hex conversion failure (sk)");
             goto end;
         }
         json_object_set_string(tc_rsp, "sk", tmp);
@@ -62,7 +62,7 @@ static ACVP_RESULT acvp_ml_dsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP
         /* This also needs pk in the test group response for GDT, handled elsewhere */
         rv = acvp_bin_to_hexstr(stc->sig, stc->sig_len, tmp, ACVP_ML_DSA_MSG_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (signature)");
+            ACVP_LOG_ERR("Hex conversion failure (signature)");
             goto end;
         }
         json_object_set_string(tc_rsp, "signature", tmp);
@@ -357,7 +357,7 @@ ACVP_RESULT acvp_ml_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     /* Create ACVP array for response */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_ml_kem.c
+++ b/src/acvp_ml_kem.c
@@ -45,7 +45,7 @@ static ACVP_RESULT acvp_ml_kem_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP
         memzero_s(tmp, ACVP_ML_KEM_TMP_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->ek, stc->ek_len, tmp, ACVP_ML_KEM_TMP_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (ek)");
+            ACVP_LOG_ERR("Hex conversion failure (ek)");
             goto end;
         }
         json_object_set_string(tc_rsp, "ek", tmp);
@@ -53,7 +53,7 @@ static ACVP_RESULT acvp_ml_kem_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP
         memzero_s(tmp, ACVP_ML_KEM_TMP_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->dk, stc->dk_len, tmp, ACVP_ML_KEM_TMP_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (dk)");
+            ACVP_LOG_ERR("Hex conversion failure (dk)");
             goto end;
         }
         json_object_set_string(tc_rsp, "dk", tmp);
@@ -63,7 +63,7 @@ static ACVP_RESULT acvp_ml_kem_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP
             memzero_s(tmp, ACVP_ML_KEM_TMP_STR_MAX);
             rv = acvp_bin_to_hexstr(stc->c, stc->c_len, tmp, ACVP_ML_KEM_TMP_STR_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (c)");
+                ACVP_LOG_ERR("Hex conversion failure (c)");
                 goto end;
             }
             json_object_set_string(tc_rsp, "c", tmp);
@@ -71,7 +71,7 @@ static ACVP_RESULT acvp_ml_kem_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP
         memzero_s(tmp, ACVP_ML_KEM_TMP_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->k, stc->k_len, tmp, ACVP_ML_KEM_TMP_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (k)");
+            ACVP_LOG_ERR("Hex conversion failure (k)");
             goto end;
         }
         json_object_set_string(tc_rsp, "k", tmp);
@@ -307,7 +307,7 @@ ACVP_RESULT acvp_ml_kem_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     /* Create ACVP array for response */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_pbkdf.c
+++ b/src/acvp_pbkdf.c
@@ -46,7 +46,7 @@ static ACVP_RESULT acvp_pbkdf_output_tc(ACVP_CTX *ctx,
     rv = acvp_bin_to_hexstr(stc->key, stc->key_len,
                             tmp, ACVP_PBKDF_KEY_STR_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (key)");
+        ACVP_LOG_ERR("Hex conversion failure (key)");
         goto end;
     }
     json_object_set_string(tc_rsp, "derivedKey", tmp);
@@ -258,7 +258,7 @@ ACVP_RESULT acvp_pbkdf_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_rsa_keygen.c
+++ b/src/acvp_rsa_keygen.c
@@ -42,7 +42,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
     if (stc->pub_exp_mode == ACVP_RSA_PUB_EXP_MODE_RANDOM && !stc->info_gen_by_server) {
         rv = acvp_bin_to_hexstr(stc->e, stc->e_len, tmp, ACVP_RSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (e)");
+            ACVP_LOG_ERR("Hex conversion failure (e)");
             goto err;
         }
         json_object_set_string(tc_rsp, "e", (const char *)tmp);
@@ -50,7 +50,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
 
     rv = acvp_bin_to_hexstr(stc->p, stc->p_len, tmp, ACVP_RSA_EXP_LEN_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (p)");
+        ACVP_LOG_ERR("Hex conversion failure (p)");
         goto err;
     }
     json_object_set_string(tc_rsp, "p", (const char *)tmp);
@@ -58,7 +58,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
 
     rv = acvp_bin_to_hexstr(stc->q, stc->q_len, tmp, ACVP_RSA_EXP_LEN_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (q)");
+        ACVP_LOG_ERR("Hex conversion failure (q)");
         goto err;
     }
     json_object_set_string(tc_rsp, "q", (const char *)tmp);
@@ -66,7 +66,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
 
     rv = acvp_bin_to_hexstr(stc->n, stc->n_len, tmp, ACVP_RSA_EXP_LEN_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (n)");
+        ACVP_LOG_ERR("Hex conversion failure (n)");
         goto err;
     }
     json_object_set_string(tc_rsp, "n", (const char *)tmp);
@@ -75,21 +75,21 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
     if (stc->key_format == ACVP_RSA_KEY_FORMAT_CRT) {
         rv = acvp_bin_to_hexstr(stc->dmp1, stc->d_len, tmp, ACVP_RSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (dmp1)");
+            ACVP_LOG_ERR("Hex conversion failure (dmp1)");
             goto err;
         }
         json_object_set_string(tc_rsp, "dmp1", (const char *)tmp);
         memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
         rv = acvp_bin_to_hexstr(stc->dmq1, stc->d_len, tmp, ACVP_RSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (dmq1)");
+            ACVP_LOG_ERR("Hex conversion failure (dmq1)");
             goto err;
         }
         json_object_set_string(tc_rsp, "dmq1", (const char *)tmp);
         memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
         rv = acvp_bin_to_hexstr(stc->iqmp, stc->d_len, tmp, ACVP_RSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (iqmp)");
+            ACVP_LOG_ERR("Hex conversion failure (iqmp)");
             goto err;
         }
         json_object_set_string(tc_rsp, "iqmp", (const char *)tmp);
@@ -98,7 +98,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
     else {
 		rv = acvp_bin_to_hexstr(stc->d, stc->d_len, tmp, ACVP_RSA_EXP_LEN_MAX);
 		if (rv != ACVP_SUCCESS) {
-		    ACVP_LOG_ERR("hex conversion failure (d)");
+		    ACVP_LOG_ERR("Hex conversion failure (d)");
 		    goto err;
 		}
 		json_object_set_string(tc_rsp, "d", (const char *)tmp);
@@ -116,7 +116,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
             // Seed
             rv = acvp_bin_to_hexstr(stc->seed, stc->seed_len, tmp, ACVP_RSA_SEEDLEN_MAX);
 			if (rv != ACVP_SUCCESS) {
-		        ACVP_LOG_ERR("hex conversion failure (seed)");
+		        ACVP_LOG_ERR("Hex conversion failure (seed)");
 			    goto err;
 			}
             json_object_set_string(tc_rsp, "seed", (const char *)tmp);
@@ -144,7 +144,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
             stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
             rv = acvp_bin_to_hexstr(stc->xp, stc->xp_len, tmp, ACVP_RSA_EXP_LEN_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (xp)");
+                ACVP_LOG_ERR("Hex conversion failure (xp)");
                 goto err;
             }
             json_object_set_string(tc_rsp, "xP", (const char *)tmp);
@@ -152,7 +152,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
 
             rv = acvp_bin_to_hexstr(stc->xq, stc->xq_len, tmp, ACVP_RSA_EXP_LEN_MAX);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("hex conversion failure (xq)");
+                ACVP_LOG_ERR("Hex conversion failure (xq)");
                 goto err;
             }
             json_object_set_string(tc_rsp, "xQ", (const char *)tmp);
@@ -163,7 +163,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
             stc->rand_pq == ACVP_RSA_KEYGEN_PROB_W_PROB_AUX) {
 		    rv = acvp_bin_to_hexstr(stc->xp1, stc->xp1_len, tmp, ACVP_RSA_EXP_LEN_MAX);
 		    if (rv != ACVP_SUCCESS) {
-		        ACVP_LOG_ERR("hex conversion failure (xp1)");
+		        ACVP_LOG_ERR("Hex conversion failure (xp1)");
 		        goto err;
 		    }
 		    json_object_set_string(tc_rsp, "xP1", (const char *)tmp);
@@ -171,7 +171,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
 
 		    rv = acvp_bin_to_hexstr(stc->xp2, stc->xp2_len, tmp, ACVP_RSA_EXP_LEN_MAX);
 		    if (rv != ACVP_SUCCESS) {
-		        ACVP_LOG_ERR("hex conversion failure (xp2)");
+		        ACVP_LOG_ERR("Hex conversion failure (xp2)");
 		        goto err;
 		    }
 		    json_object_set_string(tc_rsp, "xP2", (const char *)tmp);
@@ -179,7 +179,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
 
 		    rv = acvp_bin_to_hexstr(stc->xq1, stc->xq1_len, tmp, ACVP_RSA_EXP_LEN_MAX);
 		    if (rv != ACVP_SUCCESS) {
-		        ACVP_LOG_ERR("hex conversion failure (xq1)");
+		        ACVP_LOG_ERR("Hex conversion failure (xq1)");
 		        goto err;
 		    }
 		    json_object_set_string(tc_rsp, "xQ1", (const char *)tmp);
@@ -187,7 +187,7 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
 
 		    rv = acvp_bin_to_hexstr(stc->xq2, stc->xq2_len, tmp, ACVP_RSA_EXP_LEN_MAX);
 		    if (rv != ACVP_SUCCESS) {
-		        ACVP_LOG_ERR("hex conversion failure (xq2)");
+		        ACVP_LOG_ERR("Hex conversion failure (xq2)");
 		        goto err;
 		    }
 		    json_object_set_string(tc_rsp, "xQ2", (const char *)tmp);
@@ -493,7 +493,7 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_rsa_prim.c
+++ b/src/acvp_rsa_prim.c
@@ -35,7 +35,7 @@ static ACVP_RESULT acvp_rsa_decprim_output_tc_rev_1(ACVP_CTX *ctx, ACVP_RSA_PRIM
 
     rv = acvp_bin_to_hexstr(stc->e, stc->e_len, tmp, ACVP_RSA_EXP_LEN_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (p)");
+        ACVP_LOG_ERR("Hex conversion failure (p)");
         goto err;
     }
     json_object_set_string(tc_rsp, "e", (const char *)tmp);
@@ -43,7 +43,7 @@ static ACVP_RESULT acvp_rsa_decprim_output_tc_rev_1(ACVP_CTX *ctx, ACVP_RSA_PRIM
 
     rv = acvp_bin_to_hexstr(stc->n, stc->n_len, tmp, ACVP_RSA_EXP_LEN_MAX);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("hex conversion failure (q)");
+        ACVP_LOG_ERR("Hex conversion failure (q)");
         goto err;
     }
     json_object_set_string(tc_rsp, "n", (const char *)tmp);
@@ -54,7 +54,7 @@ static ACVP_RESULT acvp_rsa_decprim_output_tc_rev_1(ACVP_CTX *ctx, ACVP_RSA_PRIM
     if (stc->disposition) {
         rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp, ACVP_RSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (q)");
+            ACVP_LOG_ERR("Hex conversion failure (q)");
             goto err;
         }
         json_object_set_string(tc_rsp, "plainText", (const char *)tmp);
@@ -78,7 +78,7 @@ static ACVP_RESULT acvp_rsa_decprim_output_tc_rev_56br2(ACVP_CTX *ctx, ACVP_RSA_
     if (stc->disposition) {
         rv = acvp_bin_to_hexstr(stc->pt, stc->pt_len, tmp, ACVP_RSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (pt)");
+            ACVP_LOG_ERR("Hex conversion failure (pt)");
             goto err;
         }
         json_object_set_string(tc_rsp, "pt", (const char *)tmp);
@@ -101,7 +101,7 @@ static ACVP_RESULT acvp_rsa_sigprim_output_tc(ACVP_CTX *ctx, ACVP_RSA_PRIM_TC *s
     if (stc->disposition) {
         rv = acvp_bin_to_hexstr(stc->signature, stc->sig_len, tmp, ACVP_RSA_EXP_LEN_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (q)");
+            ACVP_LOG_ERR("Hex conversion failure (q)");
             goto err;
         }
         json_object_set_string(tc_rsp, "signature", (const char *)tmp);
@@ -505,7 +505,7 @@ ACVP_RESULT acvp_rsa_decprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
         return rv;
     }
 
@@ -883,7 +883,7 @@ ACVP_RESULT acvp_rsa_sigprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_rsa_sig.c
+++ b/src/acvp_rsa_sig.c
@@ -39,7 +39,7 @@ static ACVP_RESULT acvp_rsa_sig_output_tc(ACVP_CTX *ctx, ACVP_RSA_SIG_TC *stc, J
         }
         rv = acvp_bin_to_hexstr(stc->signature, stc->sig_len, tmp, ACVP_RSA_SIGNATURE_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (signature)");
+            ACVP_LOG_ERR("Hex conversion failure (signature)");
             goto err;
         }
         json_object_set_string(tc_rsp, "signature", (const char *)tmp);
@@ -273,7 +273,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
         return rv;
     }
 
@@ -504,7 +504,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
                 }
                 rv = acvp_bin_to_hexstr(stc.e, stc.e_len, tmp, ACVP_RSA_EXP_LEN_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (e)");
+                    ACVP_LOG_ERR("Hex conversion failure (e)");
                     free(tmp);
                     json_value_free(r_tval);
                     goto err;
@@ -514,7 +514,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
 
                 rv = acvp_bin_to_hexstr(stc.n, stc.n_len, tmp, ACVP_RSA_EXP_LEN_MAX);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("hex conversion failure (n)");
+                    ACVP_LOG_ERR("Hex conversion failure (n)");
                     free(tmp);
                     json_value_free(r_tval);
                     goto err;

--- a/src/acvp_safe_primes.c
+++ b/src/acvp_safe_primes.c
@@ -93,7 +93,7 @@ static ACVP_RESULT acvp_safe_primes_output_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_SAFE_PRIMES_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->x, stc->xlen, tmp, ACVP_SAFE_PRIMES_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (x)");
+            ACVP_LOG_ERR("Hex conversion failure (x)");
             goto end;
         }
         json_object_set_string(tc_rsp, "x", tmp);
@@ -101,7 +101,7 @@ static ACVP_RESULT acvp_safe_primes_output_tc(ACVP_CTX *ctx,
         memzero_s(tmp, ACVP_SAFE_PRIMES_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->y, stc->ylen, tmp, ACVP_SAFE_PRIMES_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (y)");
+            ACVP_LOG_ERR("Hex conversion failure (y)");
             goto end;
         }
         json_object_set_string(tc_rsp, "y", tmp);
@@ -226,7 +226,7 @@ ACVP_RESULT acvp_safe_primes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 

--- a/src/acvp_slh_dsa.c
+++ b/src/acvp_slh_dsa.c
@@ -45,7 +45,7 @@ static ACVP_RESULT acvp_slh_dsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACV
         memzero_s(tmp, ACVP_SLH_DSA_SIG_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->pub_key, stc->pub_key_len, tmp, ACVP_SLH_DSA_SIG_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (pk)");
+            ACVP_LOG_ERR("Hex conversion failure (pk)");
             goto end;
         }
         json_object_set_string(tc_rsp, "pk", tmp);
@@ -53,7 +53,7 @@ static ACVP_RESULT acvp_slh_dsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACV
         memzero_s(tmp, ACVP_SLH_DSA_SIG_STR_MAX);
         rv = acvp_bin_to_hexstr(stc->secret_key, stc->secret_key_len, tmp, ACVP_SLH_DSA_SIG_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (sk)");
+            ACVP_LOG_ERR("Hex conversion failure (sk)");
             goto end;
         }
         json_object_set_string(tc_rsp, "sk", tmp);
@@ -61,7 +61,7 @@ static ACVP_RESULT acvp_slh_dsa_output_tc(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACV
     case ACVP_SUB_SLH_DSA_SIGGEN:
         rv = acvp_bin_to_hexstr(stc->sig, stc->sig_len, tmp, ACVP_SLH_DSA_SIG_STR_MAX);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("hex conversion failure (signature)");
+            ACVP_LOG_ERR("Hex conversion failure (signature)");
             goto end;
         }
         json_object_set_string(tc_rsp, "signature", tmp);
@@ -340,7 +340,7 @@ ACVP_RESULT acvp_slh_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     /* Create ACVP array for response */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct. ");
+        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
         return rv;
     }
 


### PR DESCRIPTION
This PR only contains log string changes.
- Fix several spelling issues with "conversion"
- Fix some capitalization inconsistencies with "Hex"
- Remove redundant "ERROR" prefix on some error messages
- Remove extra whitespace on some log messages

More fixes likely to follow.
Eventually will likely try to consolidate many of these strings into macros or functions.