### PR TITLE
Remove ecdsa sigver componentTest registration support

### DIFF
--- a/app/implementations/openssl/3/iut_ecdsa.c
+++ b/app/implementations/openssl/3/iut_ecdsa.c
@@ -202,7 +202,6 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
             }
 
             if (alg == ACVP_SUB_DET_ECDSA_SIGGEN) {
-#ifdef ACVP_FIPS186_5
                 if (pkey_pbld) OSSL_PARAM_BLD_free(pkey_pbld);
                 if (params) OSSL_PARAM_free(params);
                 pkey_pbld = NULL;
@@ -220,7 +219,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
                     printf("Error generating parameters for pkey generation in DetECDSA siggen\n");
                     goto err;
                 }
-#endif
+
                 if (pkey_ctx) EVP_PKEY_CTX_free(pkey_ctx);
                 pkey_ctx = NULL;
                 if (EVP_DigestSignInit_ex(sig_ctx, &pkey_ctx, md, NULL, NULL, group_pkey, NULL) != 1) {
@@ -346,39 +345,25 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
 
         sig_len = (size_t)i2d_ECDSA_SIG(sig_obj, &sig);
 
-        if (!tc->is_component) {
-            sig_ctx = EVP_MD_CTX_new();
-            if (!sig_ctx) {
-                printf("Error initializing sign CTX for ECDSA sigver\n");
-                goto err;
-            }
+        sig_ctx = EVP_MD_CTX_new();
+        if (!sig_ctx) {
+            printf("Error initializing sign CTX for ECDSA sigver\n");
+            goto err;
+        }
 
-            if (EVP_DigestVerifyInit_ex(sig_ctx, NULL, md, NULL, NULL, pkey, NULL) != 1) {
-                printf("Error initializing signing for ECDSA sigver\n");
-                goto err;
-            }
-            if (EVP_DigestVerify(sig_ctx, sig, sig_len, tc->message, tc->msg_len) == 1) {
-                tc->ver_disposition = 1;
-            }
-        } else {
-            comp_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);
-            if (!comp_ctx) {
-                printf("Error initializing sign CTX for ECDSA component sigver\n");
-                goto err;
-            }
-            if (EVP_PKEY_verify_init(comp_ctx) != 1) {
-                printf("Error initializing signing for ECDSA component sigver\n");
-                goto err;
-            }
-            if (EVP_PKEY_verify(comp_ctx, sig, sig_len, tc->message, tc->msg_len) == 1) {
-                tc->ver_disposition = 1;
-            }
+        if (EVP_DigestVerifyInit_ex(sig_ctx, NULL, md, NULL, NULL, pkey, NULL) != 1) {
+            printf("Error initializing signing for ECDSA sigver\n");
+            goto err;
+        }
+        if (EVP_DigestVerify(sig_ctx, sig, sig_len, tc->message, tc->msg_len) == 1) {
+            tc->ver_disposition = 1;
         }
         break;
     default:
         printf("Invalid ECDSA alg in test case\n");
         goto err;
     }
+
     rv = 0;
 err:
     if (qx) BN_free(qx);

--- a/app/implementations/openssl/3/registrations/fp_30X.c
+++ b/app/implementations/openssl/3/registrations/fp_30X.c
@@ -1788,8 +1788,6 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_COMPONENT_TEST, ACVP_ECDSA_COMPONENT_MODE_BOTH);
-    CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P224);
     CHECK_ENABLE_CAP_RV(rv);

--- a/app/implementations/openssl/3/registrations/fp_312.c
+++ b/app/implementations/openssl/3/registrations/fp_312.c
@@ -2176,8 +2176,6 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_COMPONENT_TEST, ACVP_ECDSA_COMPONENT_MODE_BOTH);
-    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_REVISION, ACVP_REVISION_1_0);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K233);

--- a/app/implementations/openssl/3/registrations/fp_340.c
+++ b/app/implementations/openssl/3/registrations/fp_340.c
@@ -2004,8 +2004,6 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_COMPONENT_TEST, ACVP_ECDSA_COMPONENT_MODE_BOTH);
-    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K233);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K283);

--- a/app/implementations/openssl/3/registrations/fp_350.c
+++ b/app/implementations/openssl/3/registrations/fp_350.c
@@ -2009,8 +2009,6 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_COMPONENT_TEST, ACVP_ECDSA_COMPONENT_MODE_BOTH);
-    CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K233);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K283);

--- a/app/implementations/openssl/3/registrations/non_fips.c
+++ b/app/implementations/openssl/3/registrations/non_fips.c
@@ -1796,8 +1796,6 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_COMPONENT_TEST, ACVP_ECDSA_COMPONENT_MODE_BOTH);
-    CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P224);
     CHECK_ENABLE_CAP_RV(rv);

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -1599,11 +1599,7 @@ static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CTX *ctx, ACVP_CIPHER ciph
         if (!cap_entry->cap.ecdsa_sigver_cap) {
             return ACVP_NO_CAP;
         }
-        if (ecdsa_cap->component == ACVP_ECDSA_COMPONENT_MODE_YES) {
-            json_object_set_boolean(cap_obj, "componentTest", 1);
-        } else {
-            json_object_set_boolean(cap_obj, "componentTest", 0);
-        }
+
         current_curve = ecdsa_cap->curves;
         //add "universally" set hash algs here instead of later to be resliant to different combos of API calls
         while (current_curve) {
@@ -5785,23 +5781,7 @@ ACVP_RESULT acvp_build_registration_json(ACVP_CTX *ctx, JSON_Value **reg) {
                 }
                 break;
             case ACVP_ECDSA_SIGVER:
-                /* If component_test = BOTH, we need two registrations */
-                if (cap_entry->cap.ecdsa_sigver_cap->component == ACVP_ECDSA_COMPONENT_MODE_BOTH) {
-                    cap_entry->cap.ecdsa_sigver_cap->component = ACVP_ECDSA_COMPONENT_MODE_NO;
-                    rv = acvp_build_ecdsa_register_cap(ctx, cap_entry->cipher, cap_obj, cap_entry);
-                    if (rv != ACVP_SUCCESS) {
-                        cap_entry->cap.ecdsa_sigver_cap->component = ACVP_ECDSA_COMPONENT_MODE_BOTH;
-                        break;
-                    }
-                    json_array_append_value(caps_arr, cap_val);
-                    cap_val = json_value_init_object();
-                    cap_obj = json_value_get_object(cap_val);
-                    cap_entry->cap.ecdsa_sigver_cap->component = ACVP_ECDSA_COMPONENT_MODE_YES;
-                    rv = acvp_build_ecdsa_register_cap(ctx, cap_entry->cipher, cap_obj, cap_entry);
-                    cap_entry->cap.ecdsa_sigver_cap->component = ACVP_ECDSA_COMPONENT_MODE_BOTH;
-                } else {
-                    rv = acvp_build_ecdsa_register_cap(ctx, cap_entry->cipher, cap_obj, cap_entry);
-                }
+                rv = acvp_build_ecdsa_register_cap(ctx, cap_entry->cipher, cap_obj, cap_entry);
                 break;
             case ACVP_EDDSA_KEYGEN:
             case ACVP_EDDSA_KEYVER:

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -5903,7 +5903,7 @@ ACVP_RESULT acvp_cap_ecdsa_set_parm(ACVP_CTX *ctx,
         cap->hash_algs[value] = 1;
         break;
     case ACVP_ECDSA_COMPONENT_TEST:
-        if (cipher == ACVP_ECDSA_SIGGEN || cipher == ACVP_ECDSA_SIGVER || cipher == ACVP_DET_ECDSA_SIGGEN) {
+        if (cipher == ACVP_ECDSA_SIGGEN || cipher == ACVP_DET_ECDSA_SIGGEN) {
             if (value >= ACVP_ECDSA_COMPONENT_MODE_NO && value <= ACVP_ECDSA_COMPONENT_MODE_BOTH) {
                 if (value == ACVP_ECDSA_COMPONENT_MODE_BOTH) {
                     /* This will generate two vector sets, one for and one not for component mode */
@@ -5915,7 +5915,7 @@ ACVP_RESULT acvp_cap_ecdsa_set_parm(ACVP_CTX *ctx,
                 return ACVP_INVALID_ARG;
             }
         } else {
-            ACVP_LOG_ERR("ECDSA Component Tests only apply to siggen and sigver");
+            ACVP_LOG_ERR("ECDSA Component Tests only apply to siggen");
             return ACVP_INVALID_ARG;
         }
         break;

--- a/src/acvp_ecdsa.c
+++ b/src/acvp_ecdsa.c
@@ -390,7 +390,9 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
                 goto err;
             }
 
-            is_component = json_object_get_boolean(groupobj, "componentTest");
+            if (alg_id != ACVP_ECDSA_SIGVER) {
+               is_component = json_object_get_boolean(groupobj, "componentTest");
+            }
         }
 
         ACVP_LOG_VERBOSE("           Test group: %d", i);


### PR DESCRIPTION
This had been resolved for 2.1.2; the updates had not made their way into 2.2.0 yet. Support for this feature was removed by the ACVP server.