### PR TITLE
Fix for ML-KEM, version output fix, etc

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -275,7 +275,7 @@ static int check_option_length(const char *opt, int c, int maxAllowed) {
 
 int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
     ketopt_t opt = KETOPT_INIT;
-    int c = 0, diff = 0, len = 0, print_ver = 0, ldt_manually_set = 0;
+    int c = 0, diff = 0, len = 0, ldt_manually_set = 0;
 
     cfg->empty_alg = 1;
 
@@ -289,7 +289,7 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
         case 'v':
         case 301:
             /* Print version info AFTER other args are read, so we can see module runtime info better */
-            print_ver = 1;
+            cfg->output_version = 1;
             break;
         case 'h':
         case 302:
@@ -603,11 +603,6 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
         return 1;
     }
 
-    if (print_ver) {
-        print_version_info(cfg);
-        return 0;
-    }
-
     if (ldt_manually_set && (!cfg->hash && !cfg->testall)) {
         printf("Warning: max hash LDT size specified, but hash not enabled. Ignoring provided value...\n");
         acvp_sleep(2);
@@ -617,7 +612,7 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
     if (cfg->empty_alg && !cfg->post && !cfg->get && !cfg->put && !cfg->get_results
             && !cfg->get_expected && !cfg->manual_reg && !cfg->vector_upload
             && !cfg->delete && !cfg->cancel_session && !(cfg->resume_session && 
-            cfg->vector_req)) {
+            cfg->vector_req) && !cfg->output_version) {
         /* The user needs to select at least 1 algorithm */
         printf(ANSI_COLOR_RED "Requires at least 1 Algorithm Test Suite\n"ANSI_COLOR_RESET);
         printf("%s\n", ACVP_APP_HELP_MSG);

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -35,6 +35,7 @@ extern char value[JSON_STRING_LENGTH]; /* Non const for API */
 #define ANSI_COLOR_RESET "\x1b[0m"
 
 typedef struct app_config {
+    int output_version;
     ACVP_LOG_LVL level;
     int sample;
     int manual_reg;

--- a/app/app_main.c
+++ b/app/app_main.c
@@ -153,6 +153,11 @@ int main(int argc, char **argv) {
         return 1;
     }
 
+    if (cfg.output_version) {
+        print_version_info(&cfg);
+        goto end;
+    }
+
     rv = iut_setup(&cfg);
     if (rv != ACVP_SUCCESS) {
         printf("Error setting up implementation for testing at startup\n");

--- a/app/implementations/openssl/3/iut_kdf.c
+++ b/app/implementations/openssl/3/iut_kdf.c
@@ -250,7 +250,8 @@ int app_kdf108_handler(ACVP_TEST_CASE *test_case) {
         return -1;
     }
 
-    if (stc->counter_location < ACVP_KDF108_FIXED_DATA_ORDER_MIN || stc->counter_location > ACVP_KDF108_FIXED_DATA_ORDER_MAX) {
+    if (!(stc->mac_mode == ACVP_KDF108_MAC_MODE_KMAC_128 || stc->mac_mode == ACVP_KDF108_MAC_MODE_KMAC_256) &&
+            (stc->counter_location <= ACVP_KDF108_FIXED_DATA_ORDER_MIN || stc->counter_location >= ACVP_KDF108_FIXED_DATA_ORDER_MAX)) {
         printf("unsupported counter location in test case\n");
         return -1;
     }

--- a/app/implementations/openssl/3/registrations/fp_350.c
+++ b/app/implementations/openssl/3/registrations/fp_350.c
@@ -796,7 +796,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kdf135_x942_set_domain(ctx, ACVP_KDF_X942_OTHER_INFO_LEN, 0, 4096, 8);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_kdf135_x942_set_domain(ctx, ACVP_KDF_X942_ZZ_LEN, 8, 4096, 8);
+    rv = acvp_cap_kdf135_x942_set_domain(ctx, ACVP_KDF_X942_ZZ_LEN, 112, 4096, 8);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kdf135_x942_set_domain(ctx, ACVP_KDF_X942_SUPP_INFO_LEN, 0, 120, 8);
     CHECK_ENABLE_CAP_RV(rv);

--- a/src/acvp_ml_kem.c
+++ b/src/acvp_ml_kem.c
@@ -387,15 +387,6 @@ ACVP_RESULT acvp_ml_kem_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 rv = ACVP_INVALID_ARG;
                 goto err;
             }
-
-            if (type == ACVP_ML_KEM_TESTTYPE_VAL) {
-                dk_str = json_object_get_string(groupobj, "dk");
-                if (!dk_str) {
-                    ACVP_LOG_ERR("Server JSON missing 'dk'");
-                    rv = ACVP_MISSING_ARG;
-                    goto err;
-                }
-            }
         }
 
         ACVP_LOG_VERBOSE("           Test group: %d", i);
@@ -406,10 +397,6 @@ ACVP_RESULT acvp_ml_kem_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         if (func_str) {
             ACVP_LOG_VERBOSE("             function: %s", func_str);
         }
-        if (dk_str) {
-            ACVP_LOG_VERBOSE("                   dk: %s", dk_str);
-        }
-
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
@@ -455,6 +442,13 @@ ACVP_RESULT acvp_ml_kem_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                         goto err;
                     }
                 } else {
+                    dk_str = json_object_get_string(testobj, "dk");
+                    if (!dk_str) {
+                        ACVP_LOG_ERR("Server JSON missing 'dk'");
+                        rv = ACVP_MISSING_ARG;
+                        goto err;
+                    }
+
                     c_str = json_object_get_string(testobj, "c");
                     if (!c_str) {
                         ACVP_LOG_ERR("Server JSON missing 'c'");
@@ -480,6 +474,9 @@ ACVP_RESULT acvp_ml_kem_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             }
             if (c_str) {
                 ACVP_LOG_VERBOSE("                c: %s", c_str);
+            }
+            if (dk_str) {
+                ACVP_LOG_VERBOSE("                   dk: %s", dk_str);
             }
 
             /* Create a new test case in the response */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -81,6 +81,8 @@ APP_LINK += ../app/implementations/openssl/3/acvp_app-iut.o \
             ../app/implementations/openssl/3/acvp_app-iut_utils.o \
             ../app/implementations/openssl/3/registrations/acvp_app-fp_30X.o \
             ../app/implementations/openssl/3/registrations/acvp_app-fp_312.o \
+            ../app/implementations/openssl/3/registrations/acvp_app-fp_340.o \
+            ../app/implementations/openssl/3/registrations/acvp_app-fp_350.o \
             ../app/implementations/openssl/3/registrations/acvp_app-non_fips.o \
             ../app/implementations/openssl/3/acvp_app-iut_hash.o \
             ../app/implementations/openssl/3/acvp_app-iut_hmac.o \
@@ -92,9 +94,13 @@ APP_LINK += ../app/implementations/openssl/3/acvp_app-iut.o \
             ../app/implementations/openssl/3/acvp_app-iut_kas.o \
             ../app/implementations/openssl/3/acvp_app-iut_rsa.o \
             ../app/implementations/openssl/3/acvp_app-iut_ecdsa.o \
+            ../app/implementations/openssl/3/acvp_app-iut_eddsa.o \
             ../app/implementations/openssl/3/acvp_app-iut_drbg.o \
             ../app/implementations/openssl/3/acvp_app-iut_kda.o \
-            ../app/implementations/openssl/3/acvp_app-iut_kmac.o
+            ../app/implementations/openssl/3/acvp_app-iut_kmac.o \
+            ../app/implementations/openssl/3/acvp_app-iut_ml_dsa.o \
+            ../app/implementations/openssl/3/acvp_app-iut_ml_kem.o \
+            ../app/implementations/openssl/3/acvp_app-iut_slh_dsa.o
 
 endif
 

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -155,6 +155,8 @@ noinst_PROGRAMS = runtest$(EXEEXT)
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_utils.o \
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/registrations/acvp_app-fp_30X.o \
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/registrations/acvp_app-fp_312.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/registrations/acvp_app-fp_340.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/registrations/acvp_app-fp_350.o \
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/registrations/acvp_app-non_fips.o \
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_hash.o \
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_hmac.o \
@@ -166,9 +168,13 @@ noinst_PROGRAMS = runtest$(EXEEXT)
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_kas.o \
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_rsa.o \
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_ecdsa.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_eddsa.o \
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_drbg.o \
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_kda.o \
-@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_kmac.o
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_kmac.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_ml_dsa.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_ml_kem.o \
+@APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_slh_dsa.o
 
 @APP_NOT_SUPPORTED_FALSE@am__append_7 = $(IUT_CFLAGS) -I../app
 @APP_NOT_SUPPORTED_FALSE@am__append_8 = $(IUT_LDFLAGS)

--- a/test/implementations/openssl/3/test_iut_pbkdf.c
+++ b/test/implementations/openssl/3/test_iut_pbkdf.c
@@ -99,6 +99,8 @@ void free_pbkdf_tc(ACVP_PBKDF_TC *stc) {
     if (stc->salt) free(stc->salt);
     if (stc->password) free(stc->password);
     if (stc->key) free(stc->key);
+    free(stc);
+    stc = NULL;
 }
 
 /*


### PR DESCRIPTION
ML-KEM moved "dk" info into test case level instead of test group level; adjusting.
Fix version output command issues (Remove actual logic from CLI parsing too)
Misc. fixes for UTs
Registration fix for OpenSSL 3.5.0 (Minimum input key len is 112)