### PR TITLE
First part of adding alternate MCT support to libacvp

### DIFF
--- a/app/implementations/openssl/3/iut_hash.c
+++ b/app/implementations/openssl/3/iut_hash.c
@@ -165,10 +165,11 @@ end:
  */
 int app_sha_ldt_handler(ACVP_HASH_TC *tc, const EVP_MD *md) {
     unsigned char *large_data = NULL, *iter = NULL;
+    size_t gib = tc->exp_len / 1024 / 1024 / 1024;
     int numcopies = 0, i = 0, rv = 1;
     EVP_MD_CTX *md_ctx = NULL;
 
-    printf("Performing hash large data test (This may take time...)\n");
+    printf("Performing %lu GiB hash large data test (This may take time...)\n", gib);
 
     large_data = calloc(tc->exp_len, sizeof(unsigned char));
     if (!large_data) {

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -705,6 +705,13 @@ typedef enum acvp_kdf135_snmp_param {
 #define ACVP_STR_SHA3_512       "SHA3-512"
 #define ACVP_STR_SHA_MAX        12
 
+/** @enum ACVP_HASH_MCT_VERSION */
+typedef enum acvp_hash_mct_version {
+    ACVP_HASH_MCT_VERSION_STANDARD = 0,
+    ACVP_HASH_MCT_VERSION_ALTERNATE,
+    ACVP_HASH_MCT_VERSION_MAX
+} ACVP_HASH_MCT_VERSION;
+
 /** @enum ACVP_HASH_PARM */
 typedef enum acvp_hash_param {
     ACVP_HASH_IN_BIT = 1,
@@ -712,7 +719,8 @@ typedef enum acvp_hash_param {
     ACVP_HASH_OUT_BIT, /**< Used for ACVP_HASH_SHAKE_128, ACVP_HASH_SHAKE_256 */
     ACVP_HASH_OUT_LENGTH, /**< Used for ACVP_HASH_SHAKE_128, ACVP_HASH_SHAKE_256 */
     ACVP_HASH_MESSAGE_LEN,
-    ACVP_HASH_LARGE_DATA
+    ACVP_HASH_LARGE_DATA,
+    ACVP_HASH_MCT_VER
 } ACVP_HASH_PARM;
 
 /**
@@ -1284,6 +1292,11 @@ typedef struct acvp_hash_tc_t {
     unsigned int tc_id;           /**< Test case id */
     ACVP_HASH_TESTTYPE test_type; /**< KAT, MCT, VOT, or LDT */
     ACVP_HASH_EXPANSION_METHOD exp_method;  /**< LDT Expansion Technique  */
+    ACVP_HASH_MCT_VERSION mct_version; /**< MCT version, standard, alternate, or 0 for N/A */
+
+    unsigned int mct_shake_min_xof_bits;
+    unsigned int mct_shake_max_xof_bits;
+
     unsigned char *msg; /**< Message input */
     unsigned char *m1; /**< Message input #1
                             Provided when \ref ACVP_HASH_TC.test_type is MCT */

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -450,6 +450,10 @@
 #define ACVP_ALG_TLS12           "TLS-v1.2"
 #define ACVP_ALG_KDF_TLS12       "KDF"
 
+#define ACVP_STR_HASH_MCT "mctVersion"
+#define ACVP_STR_HASH_MCT_STANDARD "standard"
+#define ACVP_STR_HASH_MCT_ALTERNATE "alternate"
+
 #define ACVP_CAPABILITY_STR_MAX 512 /**< Arbitrary string length limit */
 
 #define ACVP_HEXSTR_MAX (ACVP_DRBG_ENTPY_IN_BIT_MAX >> 2) /**< Represents the largest hexstr that the client will accept.
@@ -1252,6 +1256,7 @@ typedef struct acvp_hash_capability {
     ACVP_JSON_DOMAIN_OBJ out_len; /**< Required for ACVP_HASH_SHAKE_* */
     ACVP_JSON_DOMAIN_OBJ msg_length;
     ACVP_SL_LIST *large_lens;
+    ACVP_HASH_MCT_VERSION mct_version;
 } ACVP_HASH_CAP;
 
 typedef struct acvp_kdf135_snmp_capability {
@@ -2139,6 +2144,12 @@ ACVP_RESULT acvp_build_registration_json(ACVP_CTX *ctx, JSON_Value **reg);
 ACVP_RESULT acvp_build_full_registration(ACVP_CTX *ctx, char **out, int *out_len);
 
 ACVP_RESULT acvp_build_validation(ACVP_CTX *ctx, char **out, int *out_len);
+
+/* ACVP handler-specific calls used internally */
+ACVP_RESULT acvp_hash_perform_mct(ACVP_CTX *ctx,
+                                  ACVP_TEST_CASE *tc,
+                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case),
+                                  JSON_Array *res_array);
 
 /*
  * Operating Environment functions

--- a/ms/resources/libacvp.vcxproj
+++ b/ms/resources/libacvp.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="..\..\src\acvp_ecdsa.c" />
     <ClCompile Include="..\..\src\acvp_eddsa.c" />
     <ClCompile Include="..\..\src\acvp_hash.c" />
+    <ClCompile Include="..\..\src\acvp_hash_mct.c" />
     <ClCompile Include="..\..\src\acvp_hmac.c" />
     <ClCompile Include="..\..\src\acvp_kas_ecc.c" />
     <ClCompile Include="..\..\src\acvp_kas_ffc.c" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,6 +12,7 @@ libacvp_la_SOURCES =  acvp.c \
                     acvp_aes.c \
                     acvp_des.c \
                     acvp_hash.c \
+                    acvp_hash_mct.c \
                     acvp_drbg.c \
                     acvp_transport.c \
                     acvp_util.c \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -137,17 +137,17 @@ am__DEPENDENCIES_1 =
 libacvp_la_DEPENDENCIES = $(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1)
 am_libacvp_la_OBJECTS = acvp.lo acvp_build_register.lo \
 	acvp_capabilities.lo acvp_operating_env.lo acvp_aes.lo \
-	acvp_des.lo acvp_hash.lo acvp_drbg.lo acvp_transport.lo \
-	acvp_util.lo parson.lo acvp_hmac.lo acvp_cmac.lo acvp_kmac.lo \
-	acvp_rsa_keygen.lo acvp_rsa_sig.lo acvp_rsa_prim.lo \
-	acvp_dsa.lo acvp_kdf135_snmp.lo acvp_kdf135_ssh.lo \
-	acvp_kdf135_srtp.lo acvp_kdf135_ikev2.lo acvp_kdf135_ikev1.lo \
-	acvp_kdf135_x942.lo acvp_kdf135_x963.lo acvp_kdf108.lo \
-	acvp_pbkdf.lo acvp_kdf_tls12.lo acvp_kdf_tls13.lo \
-	acvp_kas_ecc.lo acvp_kas_ffc.lo acvp_kas_ifc.lo acvp_kda.lo \
-	acvp_kts_ifc.lo acvp_safe_primes.lo acvp_ecdsa.lo \
-	acvp_eddsa.lo acvp_lms.lo acvp_ml_dsa.lo acvp_ml_kem.lo \
-	acvp_slh_dsa.lo
+	acvp_des.lo acvp_hash.lo acvp_hash_mct.lo acvp_drbg.lo \
+	acvp_transport.lo acvp_util.lo parson.lo acvp_hmac.lo \
+	acvp_cmac.lo acvp_kmac.lo acvp_rsa_keygen.lo acvp_rsa_sig.lo \
+	acvp_rsa_prim.lo acvp_dsa.lo acvp_kdf135_snmp.lo \
+	acvp_kdf135_ssh.lo acvp_kdf135_srtp.lo acvp_kdf135_ikev2.lo \
+	acvp_kdf135_ikev1.lo acvp_kdf135_x942.lo acvp_kdf135_x963.lo \
+	acvp_kdf108.lo acvp_pbkdf.lo acvp_kdf_tls12.lo \
+	acvp_kdf_tls13.lo acvp_kas_ecc.lo acvp_kas_ffc.lo \
+	acvp_kas_ifc.lo acvp_kda.lo acvp_kts_ifc.lo \
+	acvp_safe_primes.lo acvp_ecdsa.lo acvp_eddsa.lo acvp_lms.lo \
+	acvp_ml_dsa.lo acvp_ml_kem.lo acvp_slh_dsa.lo
 libacvp_la_OBJECTS = $(am_libacvp_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -174,10 +174,10 @@ am__depfiles_remade = ./$(DEPDIR)/acvp.Plo ./$(DEPDIR)/acvp_aes.Plo \
 	./$(DEPDIR)/acvp_des.Plo ./$(DEPDIR)/acvp_drbg.Plo \
 	./$(DEPDIR)/acvp_dsa.Plo ./$(DEPDIR)/acvp_ecdsa.Plo \
 	./$(DEPDIR)/acvp_eddsa.Plo ./$(DEPDIR)/acvp_hash.Plo \
-	./$(DEPDIR)/acvp_hmac.Plo ./$(DEPDIR)/acvp_kas_ecc.Plo \
-	./$(DEPDIR)/acvp_kas_ffc.Plo ./$(DEPDIR)/acvp_kas_ifc.Plo \
-	./$(DEPDIR)/acvp_kda.Plo ./$(DEPDIR)/acvp_kdf108.Plo \
-	./$(DEPDIR)/acvp_kdf135_ikev1.Plo \
+	./$(DEPDIR)/acvp_hash_mct.Plo ./$(DEPDIR)/acvp_hmac.Plo \
+	./$(DEPDIR)/acvp_kas_ecc.Plo ./$(DEPDIR)/acvp_kas_ffc.Plo \
+	./$(DEPDIR)/acvp_kas_ifc.Plo ./$(DEPDIR)/acvp_kda.Plo \
+	./$(DEPDIR)/acvp_kdf108.Plo ./$(DEPDIR)/acvp_kdf135_ikev1.Plo \
 	./$(DEPDIR)/acvp_kdf135_ikev2.Plo \
 	./$(DEPDIR)/acvp_kdf135_snmp.Plo \
 	./$(DEPDIR)/acvp_kdf135_srtp.Plo \
@@ -384,6 +384,7 @@ libacvp_la_SOURCES = acvp.c \
                     acvp_aes.c \
                     acvp_des.c \
                     acvp_hash.c \
+                    acvp_hash_mct.c \
                     acvp_drbg.c \
                     acvp_transport.c \
                     acvp_util.c \
@@ -514,6 +515,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_ecdsa.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_eddsa.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_hash.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_hash_mct.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_hmac.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_kas_ecc.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_kas_ffc.Plo@am__quote@ # am--include-marker
@@ -741,6 +743,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/acvp_ecdsa.Plo
 	-rm -f ./$(DEPDIR)/acvp_eddsa.Plo
 	-rm -f ./$(DEPDIR)/acvp_hash.Plo
+	-rm -f ./$(DEPDIR)/acvp_hash_mct.Plo
 	-rm -f ./$(DEPDIR)/acvp_hmac.Plo
 	-rm -f ./$(DEPDIR)/acvp_kas_ecc.Plo
 	-rm -f ./$(DEPDIR)/acvp_kas_ffc.Plo
@@ -827,6 +830,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/acvp_ecdsa.Plo
 	-rm -f ./$(DEPDIR)/acvp_eddsa.Plo
 	-rm -f ./$(DEPDIR)/acvp_hash.Plo
+	-rm -f ./$(DEPDIR)/acvp_hash_mct.Plo
 	-rm -f ./$(DEPDIR)/acvp_hmac.Plo
 	-rm -f ./$(DEPDIR)/acvp_kas_ecc.Plo
 	-rm -f ./$(DEPDIR)/acvp_kas_ffc.Plo

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -197,6 +197,18 @@ static ACVP_RESULT acvp_build_hash_register_cap(JSON_Object *cap_obj, ACVP_CAPS_
         }
     }
 
+    switch (cap_entry->cap.hash_cap->mct_version) {
+    case ACVP_HASH_MCT_VERSION_STANDARD:
+        json_object_set_string(cap_obj, ACVP_STR_HASH_MCT, ACVP_STR_HASH_MCT_STANDARD);
+        break;
+    case ACVP_HASH_MCT_VERSION_ALTERNATE:
+        json_object_set_string(cap_obj, ACVP_STR_HASH_MCT, ACVP_STR_HASH_MCT_ALTERNATE);
+        break;
+    case ACVP_HASH_MCT_VERSION_MAX:
+    default:
+        return ACVP_INVALID_ARG;
+    }
+
     return ACVP_SUCCESS;
 }
 

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -3614,7 +3614,13 @@ ACVP_RESULT acvp_cap_hash_set_parm(ACVP_CTX *ctx,
             return ACVP_MALLOC_FAIL;
         }
         break;
-
+    case ACVP_HASH_MCT_VER:
+        if (value < ACVP_HASH_MCT_VERSION_STANDARD || value >= ACVP_HASH_MCT_VERSION_MAX) {
+            ACVP_LOG_ERR("Invalid MCT version value specified for hash algorithm");
+            return ACVP_INVALID_ARG;
+        }
+        hash_cap->mct_version = value;
+        break;
     case ACVP_HASH_OUT_LENGTH:
     case ACVP_HASH_MESSAGE_LEN:
     default:
@@ -3710,8 +3716,9 @@ ACVP_RESULT acvp_cap_hash_set_domain(ACVP_CTX *ctx,
     case ACVP_HASH_IN_EMPTY:
     case ACVP_HASH_OUT_BIT:
     case ACVP_HASH_LARGE_DATA:
+    case ACVP_HASH_MCT_VER:
     default:
-        ACVP_LOG_ERR("Invalid 'parm'");
+        ACVP_LOG_ERR("Invalid parameter provided for hash domain");
         return ACVP_INVALID_ARG;
     }
     

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -29,6 +29,9 @@ static ACVP_RESULT acvp_hash_init_tc(ACVP_CTX *ctx,
                                      ACVP_HASH_TC *stc,
                                      unsigned int tc_id,
                                      ACVP_HASH_TESTTYPE test_type,
+                                     ACVP_HASH_MCT_VERSION mct_version,
+                                     unsigned int min_xof_len,
+                                     unsigned int max_xof_len,
                                      unsigned int msg_len,
                                      const char *msg,
                                      unsigned int xof_len,
@@ -37,340 +40,6 @@ static ACVP_RESULT acvp_hash_init_tc(ACVP_CTX *ctx,
                                      ACVP_CIPHER alg_id);
 
 static ACVP_RESULT acvp_hash_release_tc(ACVP_HASH_TC *stc);
-
-
-/*
- * After each hash for a Monte Carlo input
- * information may need to be modified.  This function
- * performs the iteration depdedent upon the hash type
- * and direction.
- */
-static ACVP_RESULT acvp_hash_mct_iterate_tc(ACVP_HASH_TC *stc) {
-
-    /* feed hash into the next message for MCT */
-    memcpy_s(stc->m1, ACVP_HASH_MD_BYTE_MAX, stc->m2, stc->md_len);
-    memcpy_s(stc->m2, ACVP_HASH_MD_BYTE_MAX, stc->m3, stc->md_len);
-    memcpy_s(stc->m3, ACVP_HASH_MD_BYTE_MAX, stc->md, stc->md_len);
-
-    return ACVP_SUCCESS;
-}
-
-/*
- * After the test case has been processed by the DUT, the results
- * need to be JSON formated to be included in the vector set results
- * file that will be uploaded to the server.  This routine handles
- * the JSON processing for a single test case for MCT.
- */
-static ACVP_RESULT acvp_hash_output_mct_tc(ACVP_CTX *ctx, ACVP_HASH_TC *stc, JSON_Object *r_tobj) {
-    ACVP_RESULT rv = ACVP_SUCCESS;
-    char *tmp = NULL;
-
-    if (stc->cipher == ACVP_HASH_SHAKE_128 || stc->cipher == ACVP_HASH_SHAKE_256) {
-        tmp = calloc(ACVP_HASH_XOF_MD_STR_MAX + 1, sizeof(char));
-    } else {
-        tmp = calloc(ACVP_HASH_MD_STR_MAX + 1, sizeof(char));
-    }
-    if (!tmp) {
-        ACVP_LOG_ERR("Unable to malloc in acvp_hash_output_tc");
-        return ACVP_MALLOC_FAIL;
-    }
-
-    if (stc->cipher == ACVP_HASH_SHAKE_128 || stc->cipher == ACVP_HASH_SHAKE_256) {
-        rv = acvp_bin_to_hexstr(stc->md, stc->md_len, tmp, ACVP_HASH_XOF_MD_STR_MAX);
-    } else {
-        rv = acvp_bin_to_hexstr(stc->md, stc->md_len, tmp, ACVP_HASH_MD_STR_MAX);
-    }
-    if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Hex conversion failure (md)");
-        goto end;
-    }
-
-    json_object_set_string(r_tobj, "md", tmp);
-    if (stc->cipher == ACVP_HASH_SHAKE_128 || stc->cipher == ACVP_HASH_SHAKE_256) {
-        json_object_set_number(r_tobj, "outLen", stc->md_len * 8);
-    }
-
-end:
-    if (tmp) free(tmp);
-
-    return rv;
-}
-
-/*
- * This is the handler for SHA MCT values.  This will parse
- * a JSON encoded vector set for DES.  Each test case is
- * parsed, processed, and a response is generated to be sent
- * back to the ACV server by the transport layer.
- */
-static ACVP_RESULT acvp_hash_mct_tc(ACVP_CTX *ctx,
-                                    ACVP_CAPS_LIST *cap,
-                                    ACVP_TEST_CASE *tc,
-                                    ACVP_HASH_TC *stc,
-                                    JSON_Array *res_array) {
-    int i, j;
-    ACVP_RESULT rv;
-    JSON_Value *r_tval = NULL;  /* Response testval */
-    JSON_Object *r_tobj = NULL; /* Response testobj */
-    char *tmp = NULL;
-
-    tmp = calloc(ACVP_HASH_MSG_STR_MAX * 3, sizeof(char));
-    if (!tmp) {
-        ACVP_LOG_ERR("Unable to malloc");
-        return ACVP_MALLOC_FAIL;
-    }
-
-    memcpy_s(stc->m1, ACVP_HASH_MD_BYTE_MAX, stc->msg, stc->msg_len);
-    memcpy_s(stc->m2, ACVP_HASH_MD_BYTE_MAX, stc->msg, stc->msg_len);
-    memcpy_s(stc->m3, ACVP_HASH_MD_BYTE_MAX, stc->msg, stc->msg_len);
-
-    for (i = 0; i < ACVP_HASH_MCT_OUTER; ++i) {
-        /*
-         * Create a new test case in the response
-         */
-        r_tval = json_value_init_object();
-        r_tobj = json_value_get_object(r_tval);
-
-        for (j = 0; j < ACVP_HASH_MCT_INNER; ++j) {
-            /* Process the current SHA test vector... */
-            rv = (cap->crypto_handler)(tc);
-            if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("crypto module failed the operation");
-                free(tmp);
-                json_value_free(r_tval);
-                return ACVP_CRYPTO_MODULE_FAIL;
-            }
-
-            /*
-             * Adjust the parameters for next iteration if needed.
-             */
-            rv = acvp_hash_mct_iterate_tc(stc);
-            if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("Failed the MCT iteration changes");
-                free(tmp);
-                json_value_free(r_tval);
-                return rv;
-            }
-        }
-        /*
-         * Output the test case request values using JSON
-         */
-        rv = acvp_hash_output_mct_tc(ctx, stc, r_tobj);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure in HASH module");
-            free(tmp);
-            json_value_free(r_tval);
-            return rv;
-        }
-
-        /* Append the test response value to array */
-        json_array_append_value(res_array, r_tval);
-
-        memcpy_s(stc->m1, ACVP_HASH_MD_BYTE_MAX, stc->m3, stc->msg_len);
-        memcpy_s(stc->m2, ACVP_HASH_MD_BYTE_MAX, stc->m3, stc->msg_len);
-
-    }
-
-    free(tmp);
-    return ACVP_SUCCESS;
-}
-
-/*
- * This is the handler for SHA MCT values.  This will parse
- * a JSON encoded vector set for DES.  Each test case is
- * parsed, processed, and a response is generated to be sent
- * back to the ACV server by the transport layer.
- */
-static ACVP_RESULT acvp_hash_sha3_mct(ACVP_CTX *ctx,
-                                      ACVP_CAPS_LIST *cap,
-                                      ACVP_TEST_CASE *tc,
-                                      ACVP_HASH_TC *stc,
-                                      JSON_Array *res_array) {
-    int i = 0, j = 0;
-    ACVP_RESULT rv = 0;
-    JSON_Value *r_tval = NULL;  /* Response testval */
-    JSON_Object *r_tobj = NULL; /* Response testobj */
-
-    /* ***********
-     * OUTER LOOP
-     * ***********
-     */
-    for (j = 0; j < ACVP_HASH_MCT_OUTER; j++) {
-        /*
-         * Create a new test case in the response
-         */
-        r_tval = json_value_init_object();
-        r_tobj = json_value_get_object(r_tval);
-
-        /* ***********
-         * INNER LOOP
-         * ***********
-         */
-        for (i = 0; i <= ACVP_HASH_MCT_INNER; i++) {
-            if (i != 0) {
-                /*
-                 * Use the MD[i-1] as the new Msg
-                 * Zeroize the msg buffer, and copy in the md.
-                 */
-                memzero_s(stc->msg, ACVP_HASH_MSG_BYTE_MAX);
-                memcpy_s(stc->msg, ACVP_HASH_MSG_BYTE_MAX, stc->md, stc->md_len);
-                stc->msg_len = stc->md_len;
-
-                if (i == ACVP_HASH_MCT_INNER) {
-                    /*
-                     * We will use the final MD as the starting MSG
-                     * for next outer loop. Break here before
-                     * doing another digest.
-                     */
-                    break;
-                }
-            }
-
-            /* Now clear the md buffer */
-            memzero_s(stc->md, ACVP_HASH_MD_BYTE_MAX);
-
-            /* Process the current SHA test vector... */
-            rv = (cap->crypto_handler)(tc);
-            if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("crypto module failed the operation");
-                rv = ACVP_CRYPTO_MODULE_FAIL;
-                goto end;
-            }
-        }
-
-        /*
-         * Output the test case request values using JSON
-         */
-        rv = acvp_hash_output_mct_tc(ctx, stc, r_tobj);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure");
-            goto end;
-        }
-
-        /* Append the test response value to array */
-        json_array_append_value(res_array, r_tval);
-    }
-
-end:
-    if (rv != ACVP_SUCCESS && r_tval) json_value_free(r_tval);
-
-    return rv;
-}
-
-/*
- * This is the handler for SHAKE MCT values.  This will parse
- * a JSON encoded vector set for DES.  Each test case is
- * parsed, processed, and a response is generated to be sent
- * back to the ACV server by the transport layer.
- */
-static ACVP_RESULT acvp_hash_shake_mct(ACVP_CTX *ctx,
-                                       ACVP_CAPS_LIST *cap,
-                                       ACVP_TEST_CASE *tc,
-                                       ACVP_HASH_TC *stc,
-                                       JSON_Array *res_array,
-                                       unsigned int min_xof_bits,
-                                       unsigned int max_xof_bits) {
-    int i = 0, j = 0;
-    ACVP_RESULT rv = 0;
-    JSON_Value *r_tval = NULL;  /* Response testval */
-    JSON_Object *r_tobj = NULL; /* Response testobj */
-    unsigned int xof_len = 0;
-    unsigned int leftmost_bytes = 16;
-    unsigned int min_xof_bytes = (min_xof_bits / 8);
-    unsigned int max_xof_bytes = (max_xof_bits / 8);
-    unsigned int range = max_xof_bytes - min_xof_bytes + 1;
-
-    /*
-     * Initial Outputlen = (floor(maxoutlen/8) )*8
-     */
-    xof_len = (max_xof_bits / 8) * 8;
-    /* Convert from bits to bytes */
-    stc->xof_len = (xof_len + 7) / 8;
-
-    /* ***********
-     * OUTER LOOP
-     * ***********
-     */
-    for (j = 0; j < ACVP_HASH_MCT_OUTER; j++) {
-        /*
-         * Create a new test case in the response
-         */
-        r_tval = json_value_init_object();
-        r_tobj = json_value_get_object(r_tval);
-
-        /* ***********
-         * INNER LOOP
-         * ***********
-         */
-        for (i = 0; i <= ACVP_HASH_MCT_INNER; i++) {
-            uint8_t   rob[2] = {0};
-            uint16_t *rightmost_out_bits = (uint16_t*) &rob;
-
-            if (i != 0) {
-                /*
-                 * Use the MD[i-1] as the new Msg
-                 * Zeroize the msg buffer, and copy in the md.
-                 */
-                memzero_s(stc->msg, ACVP_SHAKE_MSG_BYTE_MAX);
-                if (stc->md_len <= leftmost_bytes) {
-                    memcpy_s(stc->msg, ACVP_SHAKE_MSG_BYTE_MAX, stc->md, stc->md_len);
-                } else {
-                    /* Only copy the leftmost 128 bits */
-                    memcpy_s(stc->msg, ACVP_SHAKE_MSG_BYTE_MAX, stc->md, leftmost_bytes);
-                }
-
-                if (i == ACVP_HASH_MCT_INNER) {
-                    /*
-                     * We will use the final MD as the starting MSG
-                     * for next outer loop. Break here before
-                     * doing another digest.
-                     */
-                    break;
-                }
-            }
-            stc->msg_len = leftmost_bytes;
-
-            /* Now clear the md buffer */
-            memzero_s(stc->md, ACVP_HASH_XOF_MD_BYTE_MAX);
-
-            /* Process the current SHA test vector... */
-            rv = (cap->crypto_handler)(tc);
-            if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("crypto module failed the operation");
-                rv = ACVP_CRYPTO_MODULE_FAIL;
-                goto end;
-            }
-
-            /* Get the right-most 16bits and convert to an integer */
-#if ACVP_HOST_LITTLE_ENDIAN || defined(__WIN32) || defined(__APPLE__)
-            rob[0] = stc->md[stc->md_len-1];
-            rob[1] = stc->md[stc->md_len-2];
-#else
-            rob[0] = stc->md[stc->md_len-2];
-            rob[1] = stc->md[stc->md_len-1];
-#endif
-
-            /* Calculate the next expected outputLen */
-            stc->xof_len = min_xof_bytes + ((*rightmost_out_bits) % range);
-        }
-
-        /*
-         * Output the test case request values using JSON
-         */
-        rv = acvp_hash_output_mct_tc(ctx, stc, r_tobj);
-        if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure");
-            goto end;
-        }
-
-        /* Append the test response value to array */
-        json_array_append_value(res_array, r_tval);
-    }
-
-end:
-    if (rv != ACVP_SUCCESS && r_tval) json_value_free(r_tval);
-
-    return rv;
-}
 
 static ACVP_HASH_TESTTYPE read_test_type(const char *tt_str) {
     int diff = 0;
@@ -409,6 +78,17 @@ static ACVP_HASH_EXPANSION_METHOD read_exp_method(const char *exp_str) {
     return 0;
 }
 
+static ACVP_HASH_MCT_VERSION read_mct_version(const char *mct_str) {
+    int diff = 0;
+
+    strcmp_s(ACVP_STR_HASH_MCT_STANDARD, sizeof(ACVP_STR_HASH_MCT_STANDARD) - 1, mct_str, &diff);
+    if (!diff) return ACVP_HASH_MCT_VERSION_STANDARD;
+    strcmp_s(ACVP_STR_HASH_MCT_ALTERNATE, sizeof(ACVP_STR_HASH_MCT_ALTERNATE) - 1, mct_str, &diff);
+    if (!diff) return ACVP_HASH_MCT_VERSION_ALTERNATE;
+
+    return -1;
+}
+
 ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     unsigned int tc_id, msglen;
     JSON_Value *groupval;
@@ -438,10 +118,16 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     ACVP_CIPHER alg_id = 0;
     ACVP_HASH_EXPANSION_METHOD exp_method = 0;
+    ACVP_HASH_MCT_VERSION mct_version = 0;
+    ACVP_HASH_TESTTYPE test_type = 0;
+
+    int tgId = 0;
+    unsigned int min_xof_len = 0, max_xof_len = 0;
+    unsigned long long int exp_len = 0LL;
     char *json_result = NULL;
     const char *alg_str = NULL;
     const char *test_type_str, *msg = NULL;
-    const char *exp_method_str = NULL;
+    const char *exp_method_str = NULL, *mct_version_str = NULL;
 
     if (!ctx) {
         ACVP_LOG_ERR("No ctx for handler operation");
@@ -494,10 +180,6 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     groups = json_object_get_array(obj, "testGroups");
     g_cnt = json_array_get_count(groups);
     for (i = 0; i < g_cnt; i++) {
-        ACVP_HASH_TESTTYPE test_type = 0;
-        int tgId = 0;
-        unsigned int min_xof_len = 0, max_xof_len = 0;
-        unsigned long long int exp_len = 0LL;
 
         groupval = json_array_get_value(groups, i);
         groupobj = json_value_get_object(groupval);
@@ -540,21 +222,36 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             rv = ACVP_INVALID_ARG;
             goto err;
         }
-        if (test_type == ACVP_HASH_TEST_TYPE_MCT &&
-            (alg_id == ACVP_HASH_SHAKE_128 || alg_id == ACVP_HASH_SHAKE_256)) {
-            min_xof_len = json_object_get_number(groupobj, "minOutLen");
-            if (min_xof_len < ACVP_HASH_XOF_MD_BIT_MIN) {
-                ACVP_LOG_ERR("Server JSON invalid 'minOutLen' (%u)",
-                             min_xof_len);
-                rv = ACVP_INVALID_ARG;
+
+        if (test_type == ACVP_HASH_TEST_TYPE_MCT) {
+            mct_version_str = json_object_get_string(groupobj, ACVP_STR_HASH_MCT);
+            if (!mct_version_str) {
+                ACVP_LOG_ERR("Server JSON missing 'mctVersion'");
+                rv = ACVP_TC_MISSING_DATA;
                 goto err;
             }
-            max_xof_len = json_object_get_number(groupobj, "maxOutLen");
-            if (max_xof_len > ACVP_HASH_XOF_MD_BIT_MAX) {
-                ACVP_LOG_ERR("Server JSON invalid 'maxOutLen' (%u)",
-                             max_xof_len);
-                rv = ACVP_INVALID_ARG;
+            mct_version = read_mct_version(mct_version_str);
+            if (mct_version < 0) {
+                ACVP_LOG_ERR("Server JSON invalid 'mctVersion'");
+                rv = ACVP_TC_INVALID_DATA;
                 goto err;
+            }
+
+            if (alg_id == ACVP_HASH_SHAKE_128 || alg_id == ACVP_HASH_SHAKE_256) {
+                min_xof_len = json_object_get_number(groupobj, "minOutLen");
+                if (min_xof_len < ACVP_HASH_XOF_MD_BIT_MIN) {
+                    ACVP_LOG_ERR("Server JSON invalid 'minOutLen' (%u)",
+                                 min_xof_len);
+                    rv = ACVP_INVALID_ARG;
+                    goto err;
+                }
+                max_xof_len = json_object_get_number(groupobj, "maxOutLen");
+                if (max_xof_len > ACVP_HASH_XOF_MD_BIT_MAX) {
+                    ACVP_LOG_ERR("Server JSON invalid 'maxOutLen' (%u)",
+                                 max_xof_len);
+                    rv = ACVP_INVALID_ARG;
+                    goto err;
+                }
             }
         }
 
@@ -672,8 +369,8 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              * Setup the test case data that will be passed down to
              * the crypto module.
              */
-            rv = acvp_hash_init_tc(ctx, &stc, tc_id, test_type, msglen, msg, 
-                                    xof_len, exp_len, exp_method, alg_id);
+            rv = acvp_hash_init_tc(ctx, &stc, tc_id, test_type, mct_version, min_xof_len, max_xof_len, msglen, msg,
+                                   xof_len, exp_len, exp_method, alg_id);
             if (rv != ACVP_SUCCESS) {
                 ACVP_LOG_ERR("Init for stc (test case) failed");
                 acvp_hash_release_tc(&stc);
@@ -685,17 +382,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             if (stc.test_type == ACVP_HASH_TEST_TYPE_MCT) {
                 json_object_set_value(r_tobj, "resultsArray", json_value_init_array());
                 res_tarr = json_object_get_array(r_tobj, "resultsArray");
-
-                if (alg_id == ACVP_HASH_SHA3_224 || alg_id == ACVP_HASH_SHA3_256 ||
-                    alg_id == ACVP_HASH_SHA3_384 || alg_id == ACVP_HASH_SHA3_512) {
-                    rv = acvp_hash_sha3_mct(ctx, cap, &tc, &stc, res_tarr);
-                } else if (alg_id == ACVP_HASH_SHAKE_128 || alg_id == ACVP_HASH_SHAKE_256) {
-                    rv = acvp_hash_shake_mct(ctx, cap, &tc, &stc,
-                                             res_tarr, min_xof_len, max_xof_len);
-                } else {
-                    rv = acvp_hash_mct_tc(ctx, cap, &tc, &stc, res_tarr);
-                }
-
+                rv = acvp_hash_perform_mct(ctx, &tc, cap->crypto_handler, res_tarr);
                 if (rv != ACVP_SUCCESS) {
                     ACVP_LOG_ERR("crypto module failed the HASH MCT operation");
                     acvp_hash_release_tc(&stc);
@@ -792,6 +479,9 @@ static ACVP_RESULT acvp_hash_init_tc(ACVP_CTX *ctx,
                                      ACVP_HASH_TC *stc,
                                      unsigned int tc_id,
                                      ACVP_HASH_TESTTYPE test_type,
+                                     ACVP_HASH_MCT_VERSION mct_version,
+                                     unsigned int min_xof_len,
+                                     unsigned int max_xof_len,
                                      unsigned int msg_len,
                                      const char *msg,
                                      unsigned int xof_len,
@@ -801,6 +491,15 @@ static ACVP_RESULT acvp_hash_init_tc(ACVP_CTX *ctx,
     ACVP_RESULT rv;
 
     memzero_s(stc, sizeof(ACVP_HASH_TC));
+
+    if (test_type == ACVP_HASH_TEST_TYPE_MCT) {
+        stc->mct_version = mct_version;
+        if (alg_id == ACVP_HASH_SHAKE_128 || alg_id == ACVP_HASH_SHAKE_256) {
+            stc->mct_shake_min_xof_bits = min_xof_len;
+            stc->mct_shake_max_xof_bits = max_xof_len;
+        }
+    }
+
     if (alg_id != ACVP_HASH_SHAKE_128 && alg_id != ACVP_HASH_SHAKE_256) {
         stc->msg = calloc(1, ACVP_HASH_MSG_BYTE_MAX);
     } else {

--- a/src/acvp_hash_mct.c
+++ b/src/acvp_hash_mct.c
@@ -1,0 +1,426 @@
+/** @file */
+/*
+ * Copyright (c) 2025, Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/cisco/libacvp/LICENSE
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "acvp.h"
+#include "acvp_lcl.h"
+#include "parson.h"
+#include "safe_lib.h"
+
+#define ACVP_HOST_LITTLE_ENDIAN (__BYTE_ORDER == __LITTLE_ENDIAN)
+#define SWAP_16(x) ((x>>8) | (x<<8))
+
+/**
+ * This file handles monte-carlo testing logic for all hash algorithms (SHA1 through SHA3 and SHAKE).
+ * There are two different methods of MCT testing: standard and alternate. Standard is the default and
+ * is the same MCT algorithm that has been used since the beginning of ACVP. Alternate was introduced
+ * in 2023 to handle cases the original method could not; namely, some implementations could not handle
+ * the required 3 * digestSize message length for the standard method. The initial call functions
+ * are declared here and defined below.
+ */
+
+ACVP_RESULT acvp_hash_perform_mct(ACVP_CTX *ctx,
+                                  ACVP_TEST_CASE *tc,
+                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case),
+                                  JSON_Array *res_array);
+
+static ACVP_RESULT acvp_hash_output_mct_tc(ACVP_CTX *ctx, ACVP_HASH_TC *stc, JSON_Object *r_tobj) {
+    ACVP_RESULT rv = ACVP_SUCCESS;
+    char *tmp = NULL;
+
+    if (stc->cipher == ACVP_HASH_SHAKE_128 || stc->cipher == ACVP_HASH_SHAKE_256) {
+        tmp = calloc(ACVP_HASH_XOF_MD_STR_MAX + 1, sizeof(char));
+    } else {
+        tmp = calloc(ACVP_HASH_MD_STR_MAX + 1, sizeof(char));
+    }
+    if (!tmp) {
+        ACVP_LOG_ERR("Unable to malloc in acvp_hash_output_tc");
+        return ACVP_MALLOC_FAIL;
+    }
+
+    if (stc->cipher == ACVP_HASH_SHAKE_128 || stc->cipher == ACVP_HASH_SHAKE_256) {
+        rv = acvp_bin_to_hexstr(stc->md, stc->md_len, tmp, ACVP_HASH_XOF_MD_STR_MAX);
+    } else {
+        rv = acvp_bin_to_hexstr(stc->md, stc->md_len, tmp, ACVP_HASH_MD_STR_MAX);
+    }
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Hex conversion failure (md)");
+        goto end;
+    }
+
+    json_object_set_string(r_tobj, "md", tmp);
+    if (stc->cipher == ACVP_HASH_SHAKE_128 || stc->cipher == ACVP_HASH_SHAKE_256) {
+        json_object_set_number(r_tobj, "outLen", stc->md_len * 8);
+    }
+
+end:
+    if (tmp) free(tmp);
+    return rv;
+}
+
+static ACVP_RESULT acvp_hash_mct_sha_std(ACVP_CTX *ctx,
+                             int (*crypto_handler)(ACVP_TEST_CASE *test_case),
+                             ACVP_TEST_CASE *tc,
+                             JSON_Array *res_array) {
+    int i, j;
+    ACVP_RESULT rv;
+    JSON_Value *r_tval = NULL;  /* Response testval */
+    JSON_Object *r_tobj = NULL; /* Response testobj */
+    char *tmp = NULL;
+    ACVP_HASH_TC *stc = NULL;
+
+    stc = tc->tc.hash;
+    if (!stc) {
+        ACVP_LOG_ERR("Internal error - test case data missing for MCT");
+        return ACVP_INTERNAL_ERR;
+    }
+
+    tmp = calloc(ACVP_HASH_MSG_STR_MAX * 3, sizeof(char));
+    if (!tmp) {
+        ACVP_LOG_ERR("Unable to malloc");
+        return ACVP_MALLOC_FAIL;
+    }
+
+    memcpy_s(stc->m1, ACVP_HASH_MD_BYTE_MAX, stc->msg, stc->msg_len);
+    memcpy_s(stc->m2, ACVP_HASH_MD_BYTE_MAX, stc->msg, stc->msg_len);
+    memcpy_s(stc->m3, ACVP_HASH_MD_BYTE_MAX, stc->msg, stc->msg_len);
+
+    for (i = 0; i < ACVP_HASH_MCT_OUTER; ++i) {
+        /*
+         * Create a new test case in the response
+         */
+        r_tval = json_value_init_object();
+        r_tobj = json_value_get_object(r_tval);
+
+        for (j = 0; j < ACVP_HASH_MCT_INNER; ++j) {
+            /* Process the current SHA test vector... */
+            rv = (crypto_handler)(tc);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("crypto module failed the operation");
+                free(tmp);
+                json_value_free(r_tval);
+                return ACVP_CRYPTO_MODULE_FAIL;
+            }
+
+            /* feed hash into the next message for MCT */
+            rv = 0;
+            rv += memcpy_s(stc->m1, ACVP_HASH_MD_BYTE_MAX, stc->m2, stc->md_len);
+            rv += memcpy_s(stc->m2, ACVP_HASH_MD_BYTE_MAX, stc->m3, stc->md_len);
+            rv += memcpy_s(stc->m3, ACVP_HASH_MD_BYTE_MAX, stc->md, stc->md_len);
+            if (rv != 0) {
+                ACVP_LOG_ERR("Failed the MCT iteration changes");
+                rv = ACVP_INTERNAL_ERR;
+                free(tmp);
+                json_value_free(r_tval);
+                return rv;
+            }
+        }
+        /*
+         * Output the test case request values using JSON
+         */
+        rv = acvp_hash_output_mct_tc(ctx, stc, r_tobj);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("JSON output failure in HASH module");
+            free(tmp);
+            json_value_free(r_tval);
+            return rv;
+        }
+
+        /* Append the test response value to array */
+        json_array_append_value(res_array, r_tval);
+
+        memcpy_s(stc->m1, ACVP_HASH_MD_BYTE_MAX, stc->m3, stc->msg_len);
+        memcpy_s(stc->m2, ACVP_HASH_MD_BYTE_MAX, stc->m3, stc->msg_len);
+
+    }
+
+    free(tmp);
+    return ACVP_SUCCESS;
+}
+
+static ACVP_RESULT acvp_hash_mct_sha3_std(ACVP_CTX *ctx,
+                               int (*crypto_handler)(ACVP_TEST_CASE *test_case),
+                               ACVP_TEST_CASE *tc,
+                               JSON_Array *res_array) {
+    int i = 0, j = 0;
+    ACVP_RESULT rv = 0;
+    JSON_Value *r_tval = NULL;  /* Response testval */
+    JSON_Object *r_tobj = NULL; /* Response testobj */
+    ACVP_HASH_TC *stc = NULL;
+
+    stc = tc->tc.hash;
+    if (!stc) {
+        ACVP_LOG_ERR("Internal error - test case data missing for MCT");
+        return ACVP_INTERNAL_ERR;
+    }
+
+    /* ***********
+     * OUTER LOOP
+     * ***********
+     */
+    for (j = 0; j < ACVP_HASH_MCT_OUTER; j++) {
+        /*
+         * Create a new test case in the response
+         */
+        r_tval = json_value_init_object();
+        r_tobj = json_value_get_object(r_tval);
+
+        /* ***********
+         * INNER LOOP
+         * ***********
+         */
+        for (i = 0; i <= ACVP_HASH_MCT_INNER; i++) {
+            if (i != 0) {
+                /*
+                 * Use the MD[i-1] as the new Msg
+                 * Zeroize the msg buffer, and copy in the md.
+                 */
+                memzero_s(stc->msg, ACVP_HASH_MSG_BYTE_MAX);
+                memcpy_s(stc->msg, ACVP_HASH_MSG_BYTE_MAX, stc->md, stc->md_len);
+                stc->msg_len = stc->md_len;
+
+                if (i == ACVP_HASH_MCT_INNER) {
+                    /*
+                     * We will use the final MD as the starting MSG
+                     * for next outer loop. Break here before
+                     * doing another digest.
+                     */
+                    break;
+                }
+            }
+
+            /* Now clear the md buffer */
+            memzero_s(stc->md, ACVP_HASH_MD_BYTE_MAX);
+
+            /* Process the current SHA test vector... */
+            rv = (crypto_handler)(tc);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("crypto module failed the operation");
+                rv = ACVP_CRYPTO_MODULE_FAIL;
+                goto end;
+            }
+        }
+
+        /*
+         * Output the test case request values using JSON
+         */
+        rv = acvp_hash_output_mct_tc(ctx, stc, r_tobj);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("JSON output failure");
+            goto end;
+        }
+
+        /* Append the test response value to array */
+        json_array_append_value(res_array, r_tval);
+    }
+
+end:
+    if (rv != ACVP_SUCCESS && r_tval) json_value_free(r_tval);
+
+    return rv;
+}
+
+static ACVP_RESULT acvp_hash_mct_shake_std(ACVP_CTX *ctx,
+                                int (*crypto_handler)(ACVP_TEST_CASE *test_case),
+                                ACVP_TEST_CASE *tc,
+                                JSON_Array *res_array) {
+    int i = 0, j = 0;
+    ACVP_RESULT rv = 0;
+    JSON_Value *r_tval = NULL;  /* Response testval */
+    JSON_Object *r_tobj = NULL; /* Response testobj */
+    unsigned int xof_len = 0;
+    unsigned int leftmost_bytes = 16;
+    unsigned int min_xof_bytes = 0;
+    unsigned int max_xof_bytes = 0;
+    unsigned int range = 0;
+    ACVP_HASH_TC *stc = NULL;
+
+    stc = tc->tc.hash;
+    if (!stc) {
+        ACVP_LOG_ERR("Internal error - test case data missing for MCT");
+        return ACVP_INTERNAL_ERR;
+    }
+
+    min_xof_bytes = stc->mct_shake_min_xof_bits / 8;
+    max_xof_bytes = stc->mct_shake_max_xof_bits / 8;
+    range = max_xof_bytes - min_xof_bytes + 1;
+    /*
+     * Initial Outputlen = (floor(maxoutlen/8) )*8
+     */
+    xof_len = (stc->mct_shake_max_xof_bits / 8) * 8;
+    /* Convert from bits to bytes */
+    stc->xof_len = (xof_len + 7) / 8;
+
+    /* ***********
+     * OUTER LOOP
+     * ***********
+     */
+    for (j = 0; j < ACVP_HASH_MCT_OUTER; j++) {
+        /*
+         * Create a new test case in the response
+         */
+        r_tval = json_value_init_object();
+        r_tobj = json_value_get_object(r_tval);
+
+        /* ***********
+         * INNER LOOP
+         * ***********
+         */
+        for (i = 0; i <= ACVP_HASH_MCT_INNER; i++) {
+            uint8_t   rob[2] = {0};
+            uint16_t *rightmost_out_bits = (uint16_t*) &rob;
+
+            if (i != 0) {
+                /*
+                 * Use the MD[i-1] as the new Msg
+                 * Zeroize the msg buffer, and copy in the md.
+                 */
+                memzero_s(stc->msg, ACVP_SHAKE_MSG_BYTE_MAX);
+                if (stc->md_len <= leftmost_bytes) {
+                    memcpy_s(stc->msg, ACVP_SHAKE_MSG_BYTE_MAX, stc->md, stc->md_len);
+                } else {
+                    /* Only copy the leftmost 128 bits */
+                    memcpy_s(stc->msg, ACVP_SHAKE_MSG_BYTE_MAX, stc->md, leftmost_bytes);
+                }
+
+                if (i == ACVP_HASH_MCT_INNER) {
+                    /*
+                     * We will use the final MD as the starting MSG
+                     * for next outer loop. Break here before
+                     * doing another digest.
+                     */
+                    break;
+                }
+            }
+            stc->msg_len = leftmost_bytes;
+
+            /* Now clear the md buffer */
+            memzero_s(stc->md, ACVP_HASH_XOF_MD_BYTE_MAX);
+
+            /* Process the current SHA test vector... */
+            rv = (crypto_handler)(tc);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("crypto module failed the operation");
+                rv = ACVP_CRYPTO_MODULE_FAIL;
+                goto end;
+            }
+
+            /* Get the right-most 16bits and convert to an integer */
+#if ACVP_HOST_LITTLE_ENDIAN || defined(__WIN32) || defined(__APPLE__)
+            rob[0] = stc->md[stc->md_len-1];
+            rob[1] = stc->md[stc->md_len-2];
+#else
+            rob[0] = stc->md[stc->md_len-2];
+            rob[1] = stc->md[stc->md_len-1];
+#endif
+
+            /* Calculate the next expected outputLen */
+            stc->xof_len = min_xof_bytes + ((*rightmost_out_bits) % range);
+        }
+
+        /*
+         * Output the test case request values using JSON
+         */
+        rv = acvp_hash_output_mct_tc(ctx, stc, r_tobj);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("JSON output failure");
+            goto end;
+        }
+
+        /* Append the test response value to array */
+        json_array_append_value(res_array, r_tval);
+    }
+
+end:
+    if (rv != ACVP_SUCCESS && r_tval) json_value_free(r_tval);
+
+    return rv;
+}
+
+ACVP_RESULT acvp_hash_perform_mct(ACVP_CTX *ctx,
+                                  ACVP_TEST_CASE *tc,
+                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case),
+                                  JSON_Array *res_array) {
+
+    ACVP_RESULT rv = ACVP_SUCCESS;
+    ACVP_HASH_TC *stc = NULL;
+    ACVP_SUB_HASH alg = 0;
+    stc = tc->tc.hash;
+    if (!stc) {
+        ACVP_LOG_ERR("Internal error - test case data missing for MCT");
+        return ACVP_INTERNAL_ERR;
+    }
+
+    alg = acvp_get_hash_alg(stc->cipher);
+
+    switch (stc->mct_version) {
+    case ACVP_HASH_MCT_VERSION_STANDARD:
+        switch (alg) {
+        case ACVP_SUB_HASH_SHA1:
+        case ACVP_SUB_HASH_SHA2_224:
+        case ACVP_SUB_HASH_SHA2_256:
+        case ACVP_SUB_HASH_SHA2_384:
+        case ACVP_SUB_HASH_SHA2_512:
+        case ACVP_SUB_HASH_SHA2_512_224:
+        case ACVP_SUB_HASH_SHA2_512_256:
+            rv = acvp_hash_mct_sha_std(ctx, crypto_handler, tc, res_array);
+            break;
+        case ACVP_SUB_HASH_SHA3_224:
+        case ACVP_SUB_HASH_SHA3_256:
+        case ACVP_SUB_HASH_SHA3_384:
+        case ACVP_SUB_HASH_SHA3_512:
+            rv = acvp_hash_mct_sha3_std(ctx, crypto_handler, tc, res_array);
+            break;
+        case ACVP_SUB_HASH_SHAKE_128:
+        case ACVP_SUB_HASH_SHAKE_256:
+            rv = acvp_hash_mct_shake_std(ctx, crypto_handler, tc, res_array);
+            break;
+        default:
+            ACVP_LOG_ERR("Internal error - invalid cipher provided when initializing hash MCT test");
+            return ACVP_INTERNAL_ERR;
+        }
+        break;
+    case ACVP_HASH_MCT_VERSION_ALTERNATE:
+        switch (stc->cipher) {
+        case ACVP_SUB_HASH_SHA1:
+        case ACVP_SUB_HASH_SHA2_224:
+        case ACVP_SUB_HASH_SHA2_256:
+        case ACVP_SUB_HASH_SHA2_384:
+        case ACVP_SUB_HASH_SHA2_512:
+        case ACVP_SUB_HASH_SHA2_512_224:
+        case ACVP_SUB_HASH_SHA2_512_256:
+       //     rv = acvp_hash_mct_sha_alt(ctx, NULL, NULL, tc, NULL);
+         //   break;
+        case ACVP_SUB_HASH_SHA3_224:
+        case ACVP_SUB_HASH_SHA3_256:
+        case ACVP_SUB_HASH_SHA3_384:
+        case ACVP_SUB_HASH_SHA3_512:
+          //  rv = acvp_hash_mct_sha3_alt(ctx, NULL, NULL, tc, NULL);
+          //  break;
+        case ACVP_SUB_HASH_SHAKE_128:
+        case ACVP_SUB_HASH_SHAKE_256:
+        //    rv = acvp_hash_mct_shake_alt(ctx, NULL, NULL, tc, NULL,
+         //  break;
+        default:
+            ACVP_LOG_ERR("Internal error - invalid cipher provided when initializing hash MCT test");
+            return ACVP_INTERNAL_ERR;
+        }
+        break;
+    case ACVP_HASH_MCT_VERSION_MAX:
+    default:
+        ACVP_LOG_ERR("Internal error - invalid MCT version provided when initializing hash MCT test");
+        return ACVP_INTERNAL_ERR;
+    }
+
+    return rv;
+}


### PR DESCRIPTION
This is the first of two PRs to add support for the alternate monte-carlo testing mode for hash for libacvp.

- Adds registration support for MCT version (standard or alternate - standard done by default)
- Moves most MCT logic out of acvp_hash.c into a new source file, acvp_hash_mct.c (minor adjustments as needed)
- Adds common function for MCT test cases to delegate out to the correct MCT functions
- Tested with standard mode which continues to work with no app changes

Next PR will:
- Add actual functions and logic for running the alternate mode
- adjust any existing UTs if needed