### PR TITLE
Update readme, OpenSSL build rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ file for details.
 
 ## Recent Changes
 
-Libacvp has been updated to 2.0.0! The included acvp_app now supports OpenSSL 3.0. Various new
-algorithms are supported and tested on top of multiple other new features and improvements. Please
-see the release notes for more details.
-Support for OpenSSL 1.0.2 has been removed.
-
+In Libacvp 2.2.0, the application has been completely restructured with multiple benefits.
+- The application is now built around the idea of supporting different implementations
+  - Support for testing part of liboqs, and the SHA implementation within jitterentropy-library,
+    as well as OpenSSL 3.X, are now included
+- acvp_app is now no longer dependent on OpenSSL for running TOTP operations; the app no longer
+  requires a link to OpenSSL when testing other implementations
+- registrations are now split into different files for better readability and maintenance
+- Command line invocation is shared amongst different implementations for consistent behavior
 
 # Overview
 
@@ -36,21 +39,16 @@ libacvp will download each vector set, process the vectors, and send the results
 This is performed in real-time by default. The user can also use "offline" mode for non-realtime
 processing.
 
-The `app/` directory contains a sample application which uses libacvp. This app
-provides the glue between the crypto module DUT and the library itself.
-Depending upon the DUT, the crypto backend API, and other factors, the user
+The `app/` directory contains an application which uses libacvp. This app
+provides the glue between a crypto module and the library itself. This application includes
+support for OpenSSL, parts of liboqs, and an internal SHA implementation within jitterentropy-library.
+Depending upon the operating environment, the crypto backend API, and other factors, the user
 may need to enhance the reference application, or create a new one from scratch.
+app/implementations/README.md describes how support for a different implementation under test
+can be added.
 
-The application within `app/` demonstrates how to use libacvp to interface with a crypto module on
-top of providing a broad testing harness for OpenSSL.
-
-This application includes support for FIPS testing OpenSSL 3.X. Historically, support was included
-for FIPS testing OpenSSL's FIPS module for 1.0.2; this is end of life and support has been removed. Some
-artifacts have been left behind in case users have need to test a similar FOM structure for OpenSSL
-1.1.1 (OpenSSL does not support this themselves). For OpenSSL 3.X, testing the FIPS provider
-or the default provider is managed at runtime. If you are testing a different provider, you will need
-to modify the application code to fetch those algorithms accordingly. For previous versions, a build
-time argument providing a path to the FIPS module being tested was required.
+For more details about how to build and run against a certain supported implementation, view the
+`README.md` file within a given IUT's folder in `app/implementations`.
 
 The `certs/` directory contains the certificates used to establish a TLS
 session with well-known ACVP servers. If the ACVP server uses a self-signed certificate,
@@ -73,7 +71,6 @@ production environment.
 * gcc
 * make
 * curl (or substitution)
-* openssl (or substitution)
 * libcriterion (for unit tests only)
 * doxygen (for building documentation only)
 
@@ -84,28 +81,23 @@ Openssl is used for TLS transport by libcurl.
 Parson is used to parse and generate JSON data for the REST calls.
 The parson code is included and compiled as part of libacvp.
 
-libcurl, libssl and libcrypto are not included, and must
-be installed separately on your build/target host,
-including the header files.
+libcurl, and any of its dependencies, must be installed separately on your build/target host.
+Headers are also required for libcurl.
 
 ##### Dealing with system-default dependencies
-This codebase uses features in OpenSSL >= 1.1.1.
-If the system-default install does not meet this requirement,
-you will need to download, compile and install at least OpenSSL 1.1.1 on your system.
-The new OpenSSL resources should typically be installed into /usr/local/ssl to avoid
-overwriting the default OpenSSL that comes with your distro.
 
-Version 1.1.1 of OpenSSL reaches end of life officially on September 11, 2023. Updating to OpenSSL
-3.X is highly recommended when possible. All previous versions have reached end of life status.
+There are various cases where libacvp will need to link against OpenSSL.
+- You are testing the implementation of OpenSSL
+- libcurl is dependent on OpenSSL
+- another supported implementation has links to OpenSSL
 
-A potential source of issues is the default libcurl on the Linux distro, which may be linked against
-the previously mentioned default OpenSSL. This could result in linker failures when trying to use
-the system default libcurl with the new OpenSSL install (due to missing symbols).
-Therefore, you SHOULD download the Curl source, compile it against the "new" OpenSSL
-header files, and link libcurl against the "new" OpenSSL. 
-libacvp uses compile time macro logic to address differences in the APIs of different OpenSSL
-versions; therefore, it is important that you ensure libacvp is linking to the correct openSSL versions
-at run time as well.
+If you are using OpenSSL as the implementation under test, libcurl must be built against it. Without
+doing so, many platforms will attempt to link a built-in version of OpenSSL alongside the desired
+testing version, and create conflicts.
+
+It is the user's responsibility to ensure that the correct versions of implementations under test are
+linked, both at configure/build time and at runtime. The `acvp_app --version` command can help identify
+this, but should not be relied upon verbatim.
 
 Libacvp is designed to work with curl version 7.80.0 or newer. Some operating systems may ship with
 older versions of Curl which are missing certain features that libacvp depends on. In this case you
@@ -115,24 +107,33 @@ supported.
 
 ## Building
 
-The instructions below indicate how to build libacvp for OpenSSL 3.X testing. The process is the same
-for building 1.1.1 without FIPS. If you have a FIPS module for 1.1.1, we are unable to officially
-support it as OpenSSL does not have a FIPS for 1.1.1 and there is no standard format to follow.
-However, some support for building with a FOM (such as that included with 1.0.2) remains; for more
-details, see the README included with versions prior to 2.0. It will be up to the user to maintain an
-application capable of testing your implementation.
+The instructions below indicate how to build libacvp and/or acvp_app.
 
 `--prefix<path to install dir>` can be used with any configure options to specify where you would
 like the library and application to install to. 
 
+Regardless of which IUT is being linked, `--with-ssl-dir` can be provided if OpenSSL is a dependency
+and is installed in non-standard paths.  if `--with-ssl-dir` is provided on top of another IUT's
+link argument, the harness for the other IUT will be built. If `--with-ssl-dir` is provided alone,
+the OpenSSL harness will be built.
+
 #### To build app and library for supported algorithm testing
 
+One of the following should be provided in the `configure` command below.
+- `--with-ssl-dir=<path>`
+- `--with-liboqs-dir=<path>`
+- `--with-jent-dir=<path>`
+
 ```
-./configure --with-ssl-dir=<path to ssl dir> --with-libcurl-dir=<path to curl dir>
+./configure  --with-libcurl-dir=<path to curl dir>
 make clean
 make
 make install
 ```
+
+Note: `--with-libcurl-dir` can be excluded if a version of libcurl with headers exists in the
+system's default search paths. This can be helpful if you are not testing OpenSSL and do not
+have specific requirements from the library used for TLS.
 
 #### Building libacvp without the application code.
 Use the following ./configure command line option and only the library will be built and installed.
@@ -141,7 +142,7 @@ Use the following ./configure command line option and only the library will be b
 
 Note that this option is not useful when building for offline testing since the application is needed.
 Using this option, only a libcurl installation dir needs to be provided.
- 
+
 #### Building acvp_app only without the library code
 Use the following ./configure command line option and only the app will be built. Note that it depends
 on libacvp having already been built. The libacvp directory can be provided using --with-libacvp-dir=
@@ -149,23 +150,17 @@ Otherwise, it will look in the default build directory in the root folder for li
 
 --disable-lib
 
+#### Offline builds
+
+Adding `--enable-offline` to configure creates a library with no link to libcurl. This can be used for
+running tests in environments that have no or limited network connectivity; a traditional build can
+be used to request vectors outside of this environment which can then be copied over.
+
 #### Other build options
-More info about all available configure options can be found by using ./configure --help. Some important
-ones include:
---enable-offline : Removes the Curl dependency and builds a version of libacvp that can only work
- offline. In current versions of libacvp, this does not affect if libraries are linked statically
- or dynamically.
---disable-kdf : Will disable kdf registration and processing in the application, in cases where the given
- crypto implementation does not support it (E.g. all OpenSSL prior to 3.0)
---disable-lib-check : This will disable autoconf's attempts to automatically detect prerequisite libraries
- before building libacvp. This may be useful in some edge cases where the libraries exist but autoconf
- cannot detect them; however, it will give more cryptic error messages in the make stage if there are issues
---enable-force-static-linking : This will force a build of acvp_app to attempt to link to every
-dependency library, including libc, statically.
+More info about all available configure options can be found by using ./configure --help.
 
 Libacvp will attempt to link a shared library for a given dependency if it exists, and will use a static library
-if a shared one is not found. Statically linking the OpenSSL FIPS provider is not supported at this time as OpenSSL
-does not support static building of the FIPS provider.
+if a shared one is not found.
 
 #### Cross Compiling
 Requires options --build and --host.
@@ -216,16 +211,14 @@ locations you specify in config_windows.bat by default unless they are in your p
 in acvp_app not being able to run. An alternative to altering your path or moving libraries to
 system folders is moving/copying any needed .dll files to the same directory as acvp_app.
 
-If you are building statically, it is assumed for acvp_app that you have built Curl with OpenSSL, 
-and that you are linking acvp_app to the exact same version of OpenSSL that Curl is linked to. Other
-configurations are not supported, untested, and may not work. Libacvp itself is indifferent
-to which crypto and SSL libraries Curl uses, but any applications using libacvp statically
-need to link to those libraries.
+Windows currently has limited application IUT support. Expanding this support is a very low
+priority unless we receive substantial feedback about needs for further support.
 
-Murl is not supported in windows at this time.
 
 ## Running
-1. `export LD_LIBRARY_PATH="<path to ssl lib;path to curl lib>"`
+1. Ensure the runtime linker environment is aware of all dependency libraries, such as libcurl
+   and any IUT libraries. On Linux/GNU platforms, this is typically done by setting 
+   `LD_LIBRARY_PATH`.
 2. Modify scripts/nist_setup.sh and run `source scripts/nist_setup.sh`
 3. `./app/acvp_app --<options>`
 
@@ -236,26 +229,6 @@ of a session. By default, this is usually placed in the folder of the executable
 libacvp, though this can be different on some OS. The name, by default, is
 testSession_(ID number).json. The path and prefix can be controlled using ACV_SESSION_SAVE_PATH
 and ACV_SESSION_SAVE_PREFIX in your environment, respectively. 
-
-
-## FIPS and OpenSSL 3.X
-For OpenSSL 3.X, FIPS mode is determined by the acvp_app at runtime instead of
-build time. Acvp_app will attempt to utilize the OpenSSL FIPS provider by default; a runtime
-argument can be provided to not fetch FIPS crypto (CERTIFICATIONS MUST NOT BE PERFORMED THIS WAY).
-
-We cannot advise specifically how to configure OpenSSL 3.X as that will vary on a platform-specific
-basis. Generally, the OpenSSL config file must include the fipsmodule.cnf file, must explicitly
-include the fips section, and must explicitly activate the FIPS provider. When the FIPS provider is
-explicitly activated, the default provider is no longer implicitly activated and must also be
-explicitly activated in some cases. In our testing, offline sessions can be run without explicitly
-activating the default provider (since all the crypto tests seek the FIPS provider), but Curl (and
-thus any online sessions or requests) requires the default provider to be activated to function
-properly.
-
-acvp_app will perform a quick operation at startup using the FIPS provider to determine if FIPS
-crypto is working properly. If it fails, it will return an error; in this case please review your
-OpenSSL install, libacvp build steps, and especially your OpenSSL configuration before contacting
-the libacvp team.
 
 
 ### How to test offline
@@ -297,7 +270,7 @@ Any and all new API functions must also be added to ms\resources\source.def.
 
 `I get "unable to process test vectors" for certain algorithms. Why?`
 This usually indicates that you have requested to test certain algorithms or features within
-algorithms that cannot be tested with the given version of OpenSSL as built.
+algorithms that cannot be tested with the given version of the IUT as built.
 
 `I get some sort of hard crash while processing vector sets - why?`
 It is probable that acvp_app is linking to a different version of a dependency than the one

--- a/app/implementations/jitter_entropy/README.md
+++ b/app/implementations/jitter_entropy/README.md
@@ -32,6 +32,12 @@ Any of these steps can change depending on the version. These are known to work 
 To build acvp_app against this version of jent, just provide `--with-jent-dir=<install dir>` during `configure`.
 
 
+## Supported Algorithms
+
+### Secure Hash
+- SHA3-256
+
+
 ## Disclaimer
 The maintainers of this testing harness do not provide any guarantee of correctness or certification upon its use.
 Support for any given implementation does not imply an endorsement of the implementation.

--- a/app/implementations/liboqs/README.md
+++ b/app/implementations/liboqs/README.md
@@ -10,7 +10,20 @@ as long as they are thoroughly tested and cleanly written.
 ## Building
 
 This harness is tested to build against `liboqs.a` and `liboqs.so`. To do so, provide `--with-liboqs-dir=<install dir>`
-during `configure`.
+during `configure`. If liboqs is linked against OpenSSL, `--with-ssl-dir=<install dir>` can also be provided, and the
+liboqs harness will still be built. 
+
+
+## Supported Algorithms
+
+#### Digital Signature
+- ML-DSA mode: keyGen
+- ML-DSA mode: sigGen
+- ML-DSA mode: sigVer
+
+#### Key Encapsulation
+- ML-KEM mode: keyGen
+- ML-KEM mode: encapDecap
 
 
 ## Disclaimer

--- a/configure
+++ b/configure
@@ -841,7 +841,6 @@ with_libcurl_dir
 enable_cflags
 enable_gcov
 with_criterion_dir
-enable_lib_check
 enable_ssp
 enable_wrapper_library
 with_ssl_dir
@@ -1506,10 +1505,6 @@ Optional Features:
                           statically
   --enable-cflags         Flag to indicate use of enhanced CFLAGS
   --enable-gcov           Flag to indicate use of gcov tool
-  --disable-lib-check     Disables checking for presence of libraries during
-                          configure. This is ONLY recommended if you have
-                          issues with detection and you know the library
-                          exists
   --disable-ssp           Turn off fstack-protector cflag; not all platforms
                           support
   --enable-wrapper-library
@@ -12899,25 +12894,6 @@ else $as_nop
 fi
 
 
-# Disable check for library presence during configure stage
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking disable lib check" >&5
-printf %s "checking disable lib check... " >&6; }
-# Check whether --enable-lib-check was given.
-if test ${enable_lib_check+y}
-then :
-  enableval=$enable_lib_check; disable_lib_detection="yes"
-else $as_nop
-  disable_lib_detection="no"
-fi
-
-if test "x$disable_lib_detection" = "xyes"; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-else
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
-
 # Disable SSP, in case a platform does not support it
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking disable ssp" >&5
 printf %s "checking disable ssp... " >&6; }
@@ -12952,7 +12928,10 @@ fi
 # This does not apply for --disable-app builds
 # Set default value here, change based on args below
 # iut_lib_name should match the name of the library lib<name>. Multiple library names can be referenced using single space delimiter.
+# OpenSSL is a special case; we want users to be able to indicate a path even with other IUTs are being tested, in case libcurl depends
+# on it as well. So, we only set the iut flags for OpenSSL if no other IUTs are specified.
 acvp_app_iut=""
+ssl_dir=""
 iut_specified=0;
 # SSL dir only used if building app too
 if test "x$disable_app" = "xno" ; then
@@ -12961,7 +12940,7 @@ if test "x$disable_app" = "xno" ; then
 # Check whether --with-ssl-dir was given.
 if test ${with_ssl_dir+y}
 then :
-  withval=$with_ssl_dir; iut_dir="$withval"; iut_specified=$((iut_specified+1)); acvp_app_iut="openssl"; iut_lib_name="ssl crypto"; use_strict_linking="yes"
+  withval=$with_ssl_dir; ssl_dir="$withval"; use_openssl="yes"
 fi
 
 
@@ -12986,13 +12965,19 @@ fi
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "Multiple testable implementations provided. Please only provide a path to one testable implementation
 See \`config.log' for more details" "$LINENO" 5; }
-    fi
-
-    if test $iut_specified -eq 0 ; then
+    elif test $iut_specified -eq 0 ; then
+        if test "x$ssl_dir" != "x"; then
+            iut_dir="$ssl_dir"
+            iut_specified=$((iut_specified+1))
+            acvp_app_iut="openssl"
+            iut_lib_name="ssl crypto"
+            use_strict_linking="yes"
+        else
             { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "At least one testable implementation path must be provided or use --disable-app
 See \`config.log' for more details" "$LINENO" 5; }
+        fi
     fi
 fi
 
@@ -13125,6 +13110,12 @@ See \`config.log' for more details" "$LINENO" 5; }
                 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
             done
+
+            #if ssl_dir is set, but acvp_app_iut is not openssl, then set the additional dependency flags
+            if test "x$ssl_dir" != "x" && test "x$acvp_app_iut" != "xopenssl"; then
+                lib_dependencies="${lib_dependencies} -L$ssl_dir/lib -L$ssl_dir/lib64 -lssl -lcrypto"
+            fi
+
             IFS="$tmp_ifs"
             tmp_cflags="$CFLAGS"
             CFLAGS="$CFLAGS -I$iut_dir/include"

--- a/configure.ac
+++ b/configure.ac
@@ -143,18 +143,6 @@ AC_ARG_WITH([criterion-dir],
     [criteriondir="$withval"],
     [with_criteriondir="no"])
 
-# Disable check for library presence during configure stage
-AC_MSG_CHECKING([disable lib check])
-AC_ARG_ENABLE(lib-check,
-    [AS_HELP_STRING([--disable-lib-check],[Disables checking for presence of libraries during configure. This is ONLY recommended if you have issues with detection and you know the library exists])],
-    [disable_lib_detection="yes"],
-    [disable_lib_detection="no"])
-if test "x$disable_lib_detection" = "xyes"; then
-    AC_MSG_RESULT(yes)
-else
-    AC_MSG_RESULT(no)
-fi
-
 # Disable SSP, in case a platform does not support it
 AC_MSG_CHECKING([disable ssp])
 AC_ARG_ENABLE(ssp,
@@ -179,7 +167,10 @@ AC_ARG_ENABLE([wrapper-library],
 # This does not apply for --disable-app builds
 # Set default value here, change based on args below 
 # iut_lib_name should match the name of the library lib<name>. Multiple library names can be referenced using single space delimiter.
+# OpenSSL is a special case; we want users to be able to indicate a path even with other IUTs are being tested, in case libcurl depends
+# on it as well. So, we only set the iut flags for OpenSSL if no other IUTs are specified.
 acvp_app_iut=""
+ssl_dir=""
 iut_specified=0;
 # SSL dir only used if building app too 
 if test "x$disable_app" = "xno" ; then
@@ -187,7 +178,7 @@ if test "x$disable_app" = "xno" ; then
     AC_ARG_WITH([ssl-dir],
         [AS_HELP_STRING([--with-ssl-dir],
         [location of OpenSSL install folder])],
-        [iut_dir="$withval"; iut_specified=$((iut_specified+1)); acvp_app_iut="openssl"; iut_lib_name="ssl crypto"; use_strict_linking="yes"],
+        [ssl_dir="$withval"; use_openssl="yes"],
         [])
 
     AC_ARG_WITH([jent-dir],
@@ -204,10 +195,16 @@ if test "x$disable_app" = "xno" ; then
 
     if test $iut_specified -gt 1 ; then
         AC_MSG_FAILURE([Multiple testable implementations provided. Please only provide a path to one testable implementation])
-    fi
-
-    if test $iut_specified -eq 0 ; then
+    elif test $iut_specified -eq 0 ; then
+        if test "x$ssl_dir" != "x"; then
+            iut_dir="$ssl_dir"
+            iut_specified=$((iut_specified+1))
+            acvp_app_iut="openssl"
+            iut_lib_name="ssl crypto"
+            use_strict_linking="yes"
+        else
             AC_MSG_FAILURE([At least one testable implementation path must be provided or use --disable-app])
+        fi
     fi
 fi
 
@@ -277,6 +274,12 @@ if test "x$disable_lib_detection" = "xno"; then
                 fi
                 AC_MSG_RESULT(yes)
             done
+
+            #if ssl_dir is set, but acvp_app_iut is not openssl, then set the additional dependency flags
+            if test "x$ssl_dir" != "x" && test "x$acvp_app_iut" != "xopenssl"; then
+                lib_dependencies="${lib_dependencies} -L$ssl_dir/lib -L$ssl_dir/lib64 -lssl -lcrypto"
+            fi
+
             IFS="$tmp_ifs"
             tmp_cflags="$CFLAGS"
             CFLAGS="$CFLAGS -I$iut_dir/include"


### PR DESCRIPTION
- `--with-ssl-dir` can now be provided alongside other IUT link flags. The harness for the other IUT will still be built, but OpenSSL link flags will be integrated, which helps with linking to libcurl or liboqs that is built against OpenSSL.
- Updated README.md to indicate various 2.2.0 changes. 
- Added alg list to implementation README.mds.
- Remove disable-lib-check now that we have more strict dependency linking. All it really did was kick the can down the road and create more error variations. 