### PR TITLE
Various strict CFLAG fixes, build fixes, UT fixes

### DIFF
--- a/app/implementations/jitter_entropy/iut.c
+++ b/app/implementations/jitter_entropy/iut.c
@@ -53,13 +53,15 @@ end:
 ACVP_RESULT iut_setup(APP_CONFIG *cfg) {
     /* No specific setup needed */
     if (!cfg) {
-        return ACVP_INTERNAL_ERR;
+        printf("Error: missing app_config in IUT setup request\n");
+        return ACVP_MISSING_ARG;
     }
     return ACVP_SUCCESS;
 }
 
 void iut_print_version(APP_CONFIG *cfg) {
     if (!cfg) {
+        printf("Error: missing app_config in version request\n");
         return;
     }
     unsigned int jentver = 0, major = 0, minor = 0, patch = 0;

--- a/app/implementations/liboqs/iut.c
+++ b/app/implementations/liboqs/iut.c
@@ -15,7 +15,12 @@
 #include <oqs/common.h>
 
 void iut_print_version(APP_CONFIG *cfg) {
+    if (!cfg) {
+        printf("Error: missing app_config in version request\n");
+        return;
+    }
     printf("liboqs version: %s\n", OQS_version());
+
 }
 
 ACVP_RESULT iut_cleanup() {
@@ -25,6 +30,10 @@ ACVP_RESULT iut_cleanup() {
 
 
 ACVP_RESULT iut_setup(APP_CONFIG *cfg) {
+    if (!cfg) {
+        printf("Error: missing app_config in IUT setup request\n");
+        return ACVP_MISSING_ARG;
+    }
     return ACVP_SUCCESS;
 }
 

--- a/app/implementations/liboqs/iut_ml_dsa.c
+++ b/app/implementations/liboqs/iut_ml_dsa.c
@@ -70,7 +70,7 @@ static unsigned char *rng_buffer = NULL;
 /* Total size of the seed buffer */
 static size_t rng_buf_size = 0;
 /* Iterator for the seed buffer */
-static int rng_buf_pos = 0;
+static unsigned int rng_buf_pos = 0;
 
 void iut_ml_dsa_cleanup(void) {
     if (rng_buffer) free(rng_buffer);
@@ -84,9 +84,9 @@ void iut_ml_dsa_cleanup(void) {
  * of the buffer, it goes back to the beginning
  */
 static void oqs_rng_callback_acvp(uint8_t *random_array, size_t bytes_to_read) {
-    int remaining_bytes = bytes_to_read;
-    int bytes_sent = 0;
-    int bytes_going_this_round = 0;
+    unsigned int remaining_bytes = bytes_to_read;
+    unsigned int bytes_sent = 0;
+    unsigned int bytes_going_this_round = 0;
 
     if (!rng_buffer || !rng_buf_size) {
         return;

--- a/app/implementations/openssl/3/iut.c
+++ b/app/implementations/openssl/3/iut.c
@@ -25,6 +25,10 @@ int dsa_disabled = 0;
 int max_ldt_size = 0;
 
 void iut_print_version(APP_CONFIG *cfg) {
+    if (!cfg) {
+        printf("Error: missing app_config in version request\n");
+        return;
+    }
     const char *str = NULL;
     printf(" Compiled SSL version: %s\n", OPENSSL_VERSION_TEXT);
     printf("   Linked SSL version: %s\n\n", OpenSSL_version(OPENSSL_VERSION));
@@ -60,6 +64,11 @@ ACVP_RESULT iut_cleanup() {
 ACVP_RESULT iut_setup(APP_CONFIG *cfg) {
     const char *ver_str = NULL;
     ACVP_RESULT rv = -1;
+
+    if (!cfg) {
+        printf("Error: missing app_config in IUT setup request\n");
+        return ACVP_MISSING_ARG;
+    }
 
     if (!cfg->disable_fips) {
         /* sets the property "fips=yes" to be included implicitly in cipher fetches */

--- a/app/implementations/openssl/3/iut_aes.c
+++ b/app/implementations/openssl/3/iut_aes.c
@@ -125,6 +125,8 @@ int app_aes_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_SUB_AES_KW:
     case ACVP_SUB_AES_KWP:
     case ACVP_SUB_AES_GMAC:
+    case ACVP_SUB_AES_FF1:
+    case ACVP_SUB_AES_FF3:
     default:
         printf("Error: Unsupported AES mode requested by ACVP server\n");
         rv = 1;
@@ -333,6 +335,8 @@ int app_aes_keywrap_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_SUB_AES_CCM:
     case ACVP_SUB_AES_XPN:
     case ACVP_SUB_AES_GMAC:
+    case ACVP_SUB_AES_FF1:
+    case ACVP_SUB_AES_FF3:
     default:
         printf("Error: Unsupported AES mode requested by ACVP server\n");
         rv = 1;
@@ -551,6 +555,8 @@ int app_aes_handler_aead(ACVP_TEST_CASE *test_case) {
     case ACVP_SUB_AES_CBC_CS1:
     case ACVP_SUB_AES_CBC_CS2:
     case ACVP_SUB_AES_CBC_CS3:
+    case ACVP_SUB_AES_FF1:
+    case ACVP_SUB_AES_FF3:
     default:
         printf("Error: Unsupported AES AEAD mode requested by ACVP server\n");
         rc = 1;

--- a/app/implementations/openssl/3/iut_ml_dsa.c
+++ b/app/implementations/openssl/3/iut_ml_dsa.c
@@ -77,6 +77,8 @@ int app_ml_dsa_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_ML_DSA_PARAM_SET_ML_DSA_87:
         param_set = "ML-DSA-87";
         break;
+    case ACVP_ML_DSA_PARAM_SET_NONE:
+    case ACVP_ML_DSA_PARAM_SET_MAX:
     default:
         printf("Invalid param set in ML-DSA handler\n");
         goto end;

--- a/app/implementations/openssl/3/iut_ml_kem.c
+++ b/app/implementations/openssl/3/iut_ml_kem.c
@@ -70,6 +70,8 @@ int app_ml_kem_handler(ACVP_TEST_CASE *test_case) {
     case ACVP_ML_KEM_PARAM_SET_ML_KEM_1024:
         param_set = "ML-KEM-1024";
         break;
+    case ACVP_ML_KEM_PARAM_SET_NONE:
+    case ACVP_ML_KEM_PARAM_SET_MAX:
     default:
         printf("Invalid param set in ML-KEM handler\n");
         goto end;

--- a/app/totp/sha256.c
+++ b/app/totp/sha256.c
@@ -190,15 +190,15 @@ void Sha256Update(Sha256Context* Context,  // [in out]
 
   while (BufferSize > 0) {
     if (Context->curlen == 0 && BufferSize >= BLOCK_SIZE) {
-      TransformFunction(Context, (uint8_t*)Buffer);
+      TransformFunction(Context, (const uint8_t*)Buffer);
       Context->length += BLOCK_SIZE * 8;
-      Buffer = (uint8_t*)Buffer + BLOCK_SIZE;
+      Buffer = (const uint8_t*)Buffer + BLOCK_SIZE;
       BufferSize -= BLOCK_SIZE;
     } else {
       n = MIN(BufferSize, (BLOCK_SIZE - Context->curlen));
       memcpy_s(Context->buf + Context->curlen, BufferSize - Context->curlen, Buffer, (size_t)n);
       Context->curlen += n;
-      Buffer = (uint8_t*)Buffer + n;
+      Buffer = (const uint8_t*)Buffer + n;
       BufferSize -= n;
       if (Context->curlen == BLOCK_SIZE) {
         TransformFunction(Context, Context->buf);

--- a/configure
+++ b/configure
@@ -12795,7 +12795,6 @@ fi
 
 
 # libacvp library installation dir - only used when building just the app
-if test "x$disable_lib" = "xyes" ; then
 
 # Check whether --with-libacvp-dir was given.
 if test ${with_libacvp_dir+y}
@@ -12805,7 +12804,7 @@ else $as_nop
   with_libacvpdir=no
 fi
 
-fi
+
 
 # Offline mode
 # Check whether --enable-offline was given.
@@ -13335,7 +13334,7 @@ fi
 
 if test "x$disable_lib" = "xyes" ; then
     if test "x$libacvpdir" != "x" ; then
-        LDFLAGS="$LDFLAGS -L$libalibcvpdir/lib"
+        LDFLAGS="$LDFLAGS -L$libacvpdir/lib"
     else
         LDFLAGS="$LDFLAGS -Lsrc/.libs"
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -85,13 +85,12 @@ AC_ARG_ENABLE([lib],
 AM_CONDITIONAL([LIB_NOT_SUPPORTED], [test "x$disable_lib" == "xyes"])
 
 # libacvp library installation dir - only used when building just the app
-if test "x$disable_lib" = "xyes" ; then
-    AC_ARG_WITH([libacvp-dir],
-        [AS_HELP_STRING([--with-libacvp-dir],
-        [Path to libacvp install directory, for use when building the app only])],
-        [libacvpdir="$withval"],
-        [with_libacvpdir=no])
-fi
+AC_ARG_WITH([libacvp-dir],
+    [AS_HELP_STRING([--with-libacvp-dir],
+    [Path to libacvp install directory, for use when building the app only])],
+    [libacvpdir="$withval"],
+    [with_libacvpdir=no])
+
 
 # Offline mode
 AC_ARG_ENABLE([offline],
@@ -340,7 +339,7 @@ fi
 
 if test "x$disable_lib" = "xyes" ; then
     if test "x$libacvpdir" != "x" ; then
-        LDFLAGS="$LDFLAGS -L$libalibcvpdir/lib"
+        LDFLAGS="$LDFLAGS -L$libacvpdir/lib"
     else
         LDFLAGS="$LDFLAGS -Lsrc/.libs"
     fi

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -1279,6 +1279,7 @@ typedef struct acvp_sym_cipher_tc_t {
     unsigned int fpe_len;
     char* fpe_in;
     char* fpe_out;
+    char *alphabet; /**< For FPE, the alphabet used for the input and output */
 } ACVP_SYM_CIPHER_TC;
 
 /**

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -520,6 +520,7 @@
 #define ACVP_SYM_AAD_MAX (ACVP_SYM_AAD_BIT_MAX >> 2)      /**< 16384 characters */
 #define ACVP_SYM_AAD_BYTE_MAX (ACVP_SYM_AAD_BIT_MAX >> 3) /**< 8192 bytes */
 
+#define ACVP_AES_FPE_ALPHABET_MAX 64
 #define ACVP_AES_XPN_SALTLEN 96
 
 #define ACVP_AES_CCM_IV_BIT_MIN 56   /**< 56 bits */

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -1324,7 +1324,7 @@ ACVP_RESULT acvp_run_vectors_from_file_offline(ACVP_CTX *ctx, const char *req_fi
         * libacvp-style and acvpproxy-style files.
         */
         while (((obj = json_array_get_object(reg_array, n)) != NULL) &&
-               (json_object_get_number(obj, "vsId") == 0)) {
+               (!json_object_has_value(obj, "vsId"))) {
             n++;
         }
         if (!obj) {
@@ -3160,6 +3160,7 @@ static ACVP_RESULT acvp_process_vsid(ACVP_CTX *ctx, char *vsid_url, int count) {
     JSON_Object *ts_obj = NULL;
     JSON_Object *obj = NULL;
     ACVP_STRING_LIST *vs_entry = NULL;
+    double tmp_num = 0.0;
     int retry_period = 0;
     int retry = 1;
     unsigned int time_waited_so_far = 0;
@@ -3181,7 +3182,8 @@ static ACVP_RESULT acvp_process_vsid(ACVP_CTX *ctx, char *vsid_url, int count) {
         /*
          * Check if we received a retry response
          */
-        retry_period = (int) json_object_get_number(obj, "retry");
+        tmp_num = json_object_get_number(obj, "retry");
+        retry_period = (int)tmp_num;
         if (retry_period) {
             /*
              * Wait and try again to retrieve the VectorSet
@@ -3263,11 +3265,12 @@ end:
  * is looked up in the alg_tbl[] and invoked here.
  */
 static ACVP_RESULT acvp_dispatch_vector_set(ACVP_CTX *ctx, JSON_Object *obj) {
-    int i;
+    int i = 0, vs_id = 0;
+    double tmp = json_object_get_number(obj, "vsId");
     const char *err = json_object_get_string(obj, "error");
     const char *alg = json_object_get_string(obj, "algorithm");
     const char *mode = json_object_get_string(obj, "mode");
-    int vs_id = (int) json_object_get_number(obj, "vsId");
+    vs_id = (int)tmp;
     int diff = 1;
 
     ctx->vs_id = vs_id;

--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -170,6 +170,8 @@ static ACVP_RESULT acvp_aes_mct_iterate_tc(ACVP_CTX *ctx, ACVP_SYM_CIPHER_TC *st
     case ACVP_SUB_AES_KW:
     case ACVP_SUB_AES_KWP:
     case ACVP_SUB_AES_GMAC:
+    case ACVP_SUB_AES_FF1:
+    case ACVP_SUB_AES_FF3:
     default:
         break;
     }
@@ -1475,6 +1477,7 @@ static ACVP_RESULT acvp_aes_init_tc(ACVP_CTX *ctx,
                                     ACVP_SYM_CIPH_SALT_SRC salt_src) {
 
     ACVP_RESULT rv;
+    size_t alphabet_len = 0;
 
     memzero_s(stc, sizeof(ACVP_SYM_CIPHER_TC));
 
@@ -1623,6 +1626,15 @@ static ACVP_RESULT acvp_aes_init_tc(ACVP_CTX *ctx,
         }
     }
 
+    if (alphabet) {
+        stc->alphabet = calloc(ACVP_AES_FPE_ALPHABET_MAX + 1, sizeof(char));
+        if (!stc->alphabet) {
+            return ACVP_MALLOC_FAIL;
+        }
+        alphabet_len = strnlen_s(alphabet, ACVP_AES_FPE_ALPHABET_MAX);
+        strncpy_s(stc->alphabet, ACVP_AES_FPE_ALPHABET_MAX + 1, alphabet, alphabet_len);
+    }
+
     return ACVP_SUCCESS;
 }
 
@@ -1640,6 +1652,7 @@ static ACVP_RESULT acvp_aes_release_tc(ACVP_SYM_CIPHER_TC *stc) {
     if (stc->salt) free(stc->salt);
     if (stc->fpe_in) free(stc->fpe_in);
     if (stc->fpe_out) free(stc->fpe_out);
+    if (stc->alphabet) free(stc->alphabet);
     memzero_s(stc, sizeof(ACVP_SYM_CIPHER_TC));
 
     return ACVP_SUCCESS;

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -1070,6 +1070,125 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
                 retval = ACVP_SUCCESS;
             }
             break;
+        case ACVP_CIPHER_START:
+        case ACVP_AES_GCM:
+        case ACVP_AES_GCM_SIV:
+        case ACVP_AES_CCM:
+        case ACVP_AES_ECB:
+        case ACVP_AES_CBC:
+        case ACVP_AES_CBC_CS1:
+        case ACVP_AES_CBC_CS2:
+        case ACVP_AES_CBC_CS3:
+        case ACVP_AES_CFB1:
+        case ACVP_AES_CFB8:
+        case ACVP_AES_CFB128:
+        case ACVP_AES_OFB:
+        case ACVP_AES_CTR:
+        case ACVP_AES_XTS:
+        case ACVP_AES_KW:
+        case ACVP_AES_KWP:
+        case ACVP_AES_GMAC:
+        case ACVP_AES_XPN:
+        case ACVP_TDES_ECB:
+        case ACVP_TDES_CBC:
+        case ACVP_TDES_CBCI:
+        case ACVP_TDES_OFB:
+        case ACVP_TDES_OFBI:
+        case ACVP_TDES_CFB1:
+        case ACVP_TDES_CFB8:
+        case ACVP_TDES_CFB64:
+        case ACVP_TDES_CFBP1:
+        case ACVP_TDES_CFBP8:
+        case ACVP_TDES_CFBP64:
+        case ACVP_TDES_CTR:
+        case ACVP_TDES_KW:
+        case ACVP_HASH_SHA1:
+        case ACVP_HASH_SHA224:
+        case ACVP_HASH_SHA256:
+        case ACVP_HASH_SHA384:
+        case ACVP_HASH_SHA512:
+        case ACVP_HASH_SHA512_224:
+        case ACVP_HASH_SHA512_256:
+        case ACVP_HASH_SHA3_224:
+        case ACVP_HASH_SHA3_256:
+        case ACVP_HASH_SHA3_384:
+        case ACVP_HASH_SHA3_512:
+        case ACVP_HASH_SHAKE_128:
+        case ACVP_HASH_SHAKE_256:
+        case ACVP_HASHDRBG:
+        case ACVP_HMACDRBG:
+        case ACVP_CTRDRBG:
+        case ACVP_HMAC_SHA1:
+        case ACVP_HMAC_SHA2_224:
+        case ACVP_HMAC_SHA2_256:
+        case ACVP_HMAC_SHA2_384:
+        case ACVP_HMAC_SHA2_512:
+        case ACVP_HMAC_SHA2_512_224:
+        case ACVP_HMAC_SHA2_512_256:
+        case ACVP_HMAC_SHA3_224:
+        case ACVP_HMAC_SHA3_256:
+        case ACVP_HMAC_SHA3_384:
+        case ACVP_HMAC_SHA3_512:
+        case ACVP_CMAC_AES:
+        case ACVP_CMAC_TDES:
+        case ACVP_KMAC_128:
+        case ACVP_KMAC_256:
+        case ACVP_DSA_KEYGEN:
+        case ACVP_DSA_PQGGEN:
+        case ACVP_DSA_PQGVER:
+        case ACVP_DSA_SIGGEN:
+        case ACVP_DSA_SIGVER:
+        case ACVP_RSA_KEYGEN:
+        case ACVP_RSA_SIGGEN:
+        case ACVP_RSA_SIGVER:
+        case ACVP_RSA_SIGPRIM:
+        case ACVP_RSA_DECPRIM:
+        case ACVP_ECDSA_KEYGEN:
+        case ACVP_ECDSA_KEYVER:
+        case ACVP_ECDSA_SIGGEN:
+        case ACVP_ECDSA_SIGVER:
+        case ACVP_DET_ECDSA_SIGGEN:
+        case ACVP_EDDSA_KEYGEN:
+        case ACVP_EDDSA_KEYVER:
+        case ACVP_EDDSA_SIGGEN:
+        case ACVP_EDDSA_SIGVER:
+        case ACVP_KDF135_SNMP:
+        case ACVP_KDF135_SSH:
+        case ACVP_KDF135_SRTP:
+        case ACVP_KDF135_IKEV2:
+        case ACVP_KDF135_IKEV1:
+        case ACVP_KDF135_X942:
+        case ACVP_KDF135_X963:
+        case ACVP_KDF108:
+        case ACVP_PBKDF:
+        case ACVP_KDF_TLS12:
+        case ACVP_KDF_TLS13:
+        case ACVP_KAS_ECC_CDH:
+        case ACVP_KAS_ECC_COMP:
+        case ACVP_KAS_ECC_NOCOMP:
+        case ACVP_KAS_ECC_SSC:
+        case ACVP_KAS_FFC_COMP:
+        case ACVP_KAS_FFC_NOCOMP:
+        case ACVP_KDA_ONESTEP:
+        case ACVP_KDA_TWOSTEP:
+        case ACVP_KDA_HKDF:
+        case ACVP_KAS_FFC_SSC:
+        case ACVP_KAS_IFC_SSC:
+        case ACVP_KTS_IFC:
+        case ACVP_SAFE_PRIMES_KEYGEN:
+        case ACVP_SAFE_PRIMES_KEYVER:
+        case ACVP_LMS_SIGGEN:
+        case ACVP_LMS_SIGVER:
+        case ACVP_LMS_KEYGEN:
+        case ACVP_ML_DSA_KEYGEN:
+        case ACVP_ML_DSA_SIGGEN:
+        case ACVP_ML_DSA_SIGVER:
+        case ACVP_ML_KEM_KEYGEN:
+        case ACVP_ML_KEM_XCAP:
+        case ACVP_SLH_DSA_KEYGEN:
+        case ACVP_SLH_DSA_SIGGEN:
+        case ACVP_SLH_DSA_SIGVER:
+        case ACVP_CIPHER_END:
         default:
             break;
         }
@@ -1201,6 +1320,9 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_ML_DSA_SIGVER:
         case ACVP_ML_KEM_KEYGEN:
         case ACVP_ML_KEM_XCAP:
+        case ACVP_SLH_DSA_KEYGEN:
+        case ACVP_SLH_DSA_SIGGEN:
+        case ACVP_SLH_DSA_SIGVER:
         case ACVP_CIPHER_END:
         default:
             break;
@@ -1329,6 +1451,9 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_ML_DSA_SIGVER:
         case ACVP_ML_KEM_KEYGEN:
         case ACVP_ML_KEM_XCAP:
+        case ACVP_SLH_DSA_KEYGEN:
+        case ACVP_SLH_DSA_SIGGEN:
+        case ACVP_SLH_DSA_SIGVER:
         case ACVP_CIPHER_END:
         default:
             break;
@@ -1457,6 +1582,9 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_ML_DSA_SIGVER:
         case ACVP_ML_KEM_KEYGEN:
         case ACVP_ML_KEM_XCAP:
+        case ACVP_SLH_DSA_KEYGEN:
+        case ACVP_SLH_DSA_SIGGEN:
+        case ACVP_SLH_DSA_SIGVER:
         case ACVP_CIPHER_END:
         default:
             break;
@@ -1595,6 +1723,9 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_ML_DSA_SIGVER:
         case ACVP_ML_KEM_KEYGEN:
         case ACVP_ML_KEM_XCAP:
+        case ACVP_SLH_DSA_KEYGEN:
+        case ACVP_SLH_DSA_SIGGEN:
+        case ACVP_SLH_DSA_SIGVER:
         case ACVP_CIPHER_END:
         default:
             break;
@@ -1720,6 +1851,9 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_ML_DSA_SIGVER:
         case ACVP_ML_KEM_KEYGEN:
         case ACVP_ML_KEM_XCAP:
+        case ACVP_SLH_DSA_KEYGEN:
+        case ACVP_SLH_DSA_SIGGEN:
+        case ACVP_SLH_DSA_SIGVER:
         case ACVP_CIPHER_END:
         default:
             if (value >= 0 && value <= 65536) {
@@ -1739,6 +1873,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
     case ACVP_SYM_CIPH_PARM_SALT_SRC:
     case ACVP_SYM_CIPH_PARM_CONFORMANCE:
     case ACVP_SYM_CIPH_PARM_DULEN_MATCHES_PAYLOADLEN:
+    case ACVP_SYM_CIPH_PARM_ALPHABET:
     default:
         break;
     }
@@ -1780,6 +1915,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
             }
             break;
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -1798,6 +1934,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
             break;
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -1820,6 +1957,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
             }
             break;
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -1836,6 +1974,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -1850,6 +1989,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -1868,6 +2008,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
             break;
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         case ACVP_SYM_CIPH_DOMAIN_AADLEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -1882,6 +2023,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -1896,6 +2038,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -1914,6 +2057,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
             break;
         case ACVP_SYM_CIPH_DOMAIN_PTLEN:
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -1936,6 +2080,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
             }
             break;
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -1989,6 +2134,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -2006,6 +2152,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -2020,6 +2167,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -2034,6 +2182,7 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
         case ACVP_SYM_CIPH_DOMAIN_IVLEN:
         case ACVP_SYM_CIPH_DOMAIN_AADLEN:
         case ACVP_SYM_CIPH_DOMAIN_DULEN:
+        case ACVP_SYM_CIPH_DOMAIN_TWEAKLEN:
         default:
             break;
         }
@@ -2133,6 +2282,9 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
     case ACVP_ML_DSA_SIGVER:
     case ACVP_ML_KEM_KEYGEN:
     case ACVP_ML_KEM_XCAP:
+    case ACVP_SLH_DSA_KEYGEN:
+    case ACVP_SLH_DSA_SIGGEN:
+    case ACVP_SLH_DSA_SIGVER:
     case ACVP_CIPHER_END:
     default:
         break;
@@ -2421,6 +2573,15 @@ static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG 
             return ACVP_SUCCESS;
         }
         break;
+    case ACVP_SLH_DSA_KEYGEN:
+    case ACVP_SLH_DSA_SIGGEN:
+    case ACVP_SLH_DSA_SIGVER:
+        if (pre_req == ACVP_PREREQ_DRBG ||
+            pre_req == ACVP_PREREQ_SHA ||
+            pre_req == ACVP_PREREQ_HMAC) {
+            return ACVP_SUCCESS;
+        }
+        break;
     case ACVP_CIPHER_START:
     case ACVP_TDES_CBCI:
     case ACVP_TDES_OFBI:
@@ -2647,6 +2808,9 @@ ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
     case ACVP_ML_DSA_SIGVER:
     case ACVP_ML_KEM_KEYGEN:
     case ACVP_ML_KEM_XCAP:
+    case ACVP_SLH_DSA_KEYGEN:
+    case ACVP_SLH_DSA_SIGGEN:
+    case ACVP_SLH_DSA_SIGVER:
     case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
@@ -2809,6 +2973,22 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
         case ACVP_SYM_CIPH_PARM_DIR:
         case ACVP_SYM_CIPH_PARM_RADIX:
             break;
+        case ACVP_SYM_CIPH_TAGLEN:
+        case ACVP_SYM_CIPH_IVLEN:
+        case ACVP_SYM_CIPH_PTLEN:
+        case ACVP_SYM_CIPH_TWEAK:
+        case ACVP_SYM_CIPH_AADLEN:
+        case ACVP_SYM_CIPH_KW_MODE:
+        case ACVP_SYM_CIPH_PARM_KO:
+        case ACVP_SYM_CIPH_PARM_PERFORM_CTR:
+        case ACVP_SYM_CIPH_PARM_CTR_INCR:
+        case ACVP_SYM_CIPH_PARM_CTR_OVRFLW:
+        case ACVP_SYM_CIPH_PARM_IVGEN_MODE:
+        case ACVP_SYM_CIPH_PARM_IVGEN_SRC:
+        case ACVP_SYM_CIPH_PARM_SALT_SRC:
+        case ACVP_SYM_CIPH_PARM_CONFORMANCE:
+        case ACVP_SYM_CIPH_PARM_DULEN_MATCHES_PAYLOADLEN:
+        case ACVP_SYM_CIPH_PARM_ALPHABET:
         default:
             ACVP_LOG_ERR("Invalid parameter 'parm' for AES-FPE; try domain-type for all others.\n");
             return ACVP_INVALID_ARG;
@@ -2898,6 +3078,9 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
     case ACVP_ML_DSA_SIGVER:
     case ACVP_ML_KEM_KEYGEN:
     case ACVP_ML_KEM_XCAP:
+    case ACVP_SLH_DSA_KEYGEN:
+    case ACVP_SLH_DSA_SIGGEN:
+    case ACVP_SLH_DSA_SIGVER:
     case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
@@ -3049,6 +3232,9 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
         }
         cap->cap.sym_cap->radix = value;
         return ACVP_SUCCESS;
+    case ACVP_SYM_CIPH_PARM_ALPHABET:
+        ACVP_LOG_ERR("Alphabet paramter is string and can only be set with string API for sym ciphers");
+        return ACVP_INVALID_ARG;
     case ACVP_SYM_CIPH_KEYLEN:
     case ACVP_SYM_CIPH_TAGLEN:
     case ACVP_SYM_CIPH_IVLEN:
@@ -3109,6 +3295,8 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
     case ACVP_SYM_CIPH_PARM_CONFORMANCE:
     case ACVP_SYM_CIPH_PARM_SALT_SRC:
     case ACVP_SYM_CIPH_PARM_DULEN_MATCHES_PAYLOADLEN:
+    case ACVP_SYM_CIPH_PARM_ALPHABET:
+    case ACVP_SYM_CIPH_PARM_RADIX:
     default:
         return ACVP_INVALID_ARG;
     }
@@ -3209,6 +3397,11 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm_string(ACVP_CTX *ctx,
     case ACVP_ECDSA_KEYVER:
     case ACVP_ECDSA_SIGGEN:
     case ACVP_ECDSA_SIGVER:
+    case ACVP_DET_ECDSA_SIGGEN:
+    case ACVP_EDDSA_KEYGEN:
+    case ACVP_EDDSA_KEYVER:
+    case ACVP_EDDSA_SIGGEN:
+    case ACVP_EDDSA_SIGVER:
     case ACVP_KDF135_SNMP:
     case ACVP_KDF135_SSH:
     case ACVP_KDF135_SRTP:
@@ -3237,6 +3430,14 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm_string(ACVP_CTX *ctx,
     case ACVP_LMS_SIGGEN:
     case ACVP_LMS_SIGVER:
     case ACVP_LMS_KEYGEN:
+    case ACVP_ML_DSA_KEYGEN:
+    case ACVP_ML_DSA_SIGGEN:
+    case ACVP_ML_DSA_SIGVER:
+    case ACVP_ML_KEM_KEYGEN:
+    case ACVP_ML_KEM_XCAP:
+    case ACVP_SLH_DSA_KEYGEN:
+    case ACVP_SLH_DSA_SIGGEN:
+    case ACVP_SLH_DSA_SIGVER:
     case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
@@ -3287,6 +3488,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm_string(ACVP_CTX *ctx,
     case ACVP_SYM_CIPH_PTLEN:
     case ACVP_SYM_CIPH_TWEAK:
     case ACVP_SYM_CIPH_AADLEN:
+    case ACVP_SYM_CIPH_PARM_RADIX:
     default:
         ACVP_LOG_ERR("Invalid param");
         return ACVP_INVALID_ARG;
@@ -3387,6 +3589,11 @@ ACVP_RESULT acvp_cap_sym_cipher_set_iv_modes(ACVP_CTX *ctx,
     case ACVP_ECDSA_KEYVER:
     case ACVP_ECDSA_SIGGEN:
     case ACVP_ECDSA_SIGVER:
+    case ACVP_DET_ECDSA_SIGGEN:
+    case ACVP_EDDSA_KEYGEN:
+    case ACVP_EDDSA_KEYVER:
+    case ACVP_EDDSA_SIGGEN:
+    case ACVP_EDDSA_SIGVER:
     case ACVP_KDF135_SNMP:
     case ACVP_KDF135_SSH:
     case ACVP_KDF135_SRTP:
@@ -3415,6 +3622,14 @@ ACVP_RESULT acvp_cap_sym_cipher_set_iv_modes(ACVP_CTX *ctx,
     case ACVP_LMS_SIGGEN:
     case ACVP_LMS_SIGVER:
     case ACVP_LMS_KEYGEN:
+    case ACVP_ML_DSA_KEYGEN:
+    case ACVP_ML_DSA_SIGGEN:
+    case ACVP_ML_DSA_SIGVER:
+    case ACVP_ML_KEM_KEYGEN:
+    case ACVP_ML_KEM_XCAP:
+    case ACVP_SLH_DSA_KEYGEN:
+    case ACVP_SLH_DSA_SIGGEN:
+    case ACVP_SLH_DSA_SIGVER:
     case ACVP_CIPHER_END:
     default:
         ACVP_LOG_ERR("Unsupported cipher for setting IV modes/sources");
@@ -3596,6 +3811,9 @@ ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
     case ACVP_ML_DSA_SIGVER:
     case ACVP_ML_KEM_KEYGEN:
     case ACVP_ML_KEM_XCAP:
+    case ACVP_SLH_DSA_KEYGEN:
+    case ACVP_SLH_DSA_SIGGEN:
+    case ACVP_SLH_DSA_SIGVER:
     case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
@@ -6982,7 +7200,7 @@ ACVP_RESULT acvp_cap_kdf108_set_parm(ACVP_CTX *ctx,
                 return ACVP_INVALID_ARG;
             }
         } else {
-            if ( (value == ACVP_KDF108_MAC_MODE_KMAC_128) || 
+            if ( (value == ACVP_KDF108_MAC_MODE_KMAC_128) ||
                  (value == ACVP_KDF108_MAC_MODE_KMAC_256)) {
                 return ACVP_INVALID_ARG;
             }
@@ -8357,8 +8575,7 @@ ACVP_RESULT acvp_cap_kas_ecc_set_scheme(ACVP_CTX *ctx,
 /*
  * Append a KAS-FFC pre req val to the capabilities
  */
-static ACVP_RESULT acvp_add_kas_ffc_prereq_val(ACVP_CTX *ctx, ACVP_KAS_FFC_CAP_MODE *kas_ffc_mode,
-                                               ACVP_KAS_FFC_MODE mode,
+static ACVP_RESULT acvp_add_kas_ffc_prereq_val(ACVP_KAS_FFC_CAP_MODE *kas_ffc_mode,
                                                ACVP_PREREQ_ALG pre_req,
                                                char *value) {
     ACVP_PREREQ_LIST *prereq_entry, *prereq_entry_2;
@@ -8440,7 +8657,7 @@ ACVP_RESULT acvp_cap_kas_ffc_set_prereq(ACVP_CTX *ctx,
     /*
      * Add the value to the cap
      */
-    return acvp_add_kas_ffc_prereq_val(ctx, kas_ffc_mode, mode, pre_req, value);
+    return acvp_add_kas_ffc_prereq_val(kas_ffc_mode, pre_req, value);
 }
 
 ACVP_RESULT acvp_cap_kas_ffc_enable(ACVP_CTX *ctx,
@@ -10717,6 +10934,7 @@ ACVP_RESULT acvp_cap_slh_dsa_set_parm(ACVP_CTX *ctx,
         case ACVP_SLH_DSA_PARAM_SIG_INTERFACE:
         case ACVP_SLH_DSA_PARAM_PREHASH:
         case ACVP_SLH_DSA_PARAM_CONTEXT_LEN:
+        case ACVP_SLH_DSA_PARAM_HASH_ALG:
             ACVP_LOG_ERR("Tried setting non-applicable parameter for SLH-DSA KeyGen");
             return ACVP_INVALID_ARG;
         case ACVP_SLH_DSA_PARAM_PARAMETER_SET:

--- a/src/acvp_kas_ifc.c
+++ b/src/acvp_kas_ifc.c
@@ -419,7 +419,7 @@ static ACVP_KAS_IFC_TEST_TYPE read_test_type(const char *str) {
     return 0;
 }
 
-static ACVP_RSA_KEY_FORMAT read_key_gen(const char *str){
+static ACVP_KAS_IFC_KEYGEN read_key_gen(const char *str){
     int diff;
 
     strcmp_s("rsakpg1-basic", 13, str, &diff);

--- a/src/acvp_kts_ifc.c
+++ b/src/acvp_kts_ifc.c
@@ -205,21 +205,21 @@ static ACVP_KTS_IFC_TEST_TYPE read_test_type(const char *str) {
     return 0;
 }
 
-static ACVP_RSA_KEY_FORMAT read_key_gen(const char *str){
+static ACVP_KTS_IFC_KEYGEN read_key_gen(const char *str){
     int diff;
 
     strcmp_s("rsakpg1-basic", 13, str, &diff);
-    if (!diff) return ACVP_KAS_IFC_RSAKPG1_BASIC;
+    if (!diff) return ACVP_KTS_IFC_RSAKPG1_BASIC;
     strcmp_s("rsakpg1-crt", 11, str, &diff);
-    if (!diff) return ACVP_KAS_IFC_RSAKPG1_CRT;
+    if (!diff) return ACVP_KTS_IFC_RSAKPG1_CRT;
     strcmp_s("rsakpg1-prime-factor", 20, str, &diff);
-    if (!diff) return ACVP_KAS_IFC_RSAKPG1_PRIME_FACTOR;
+    if (!diff) return ACVP_KTS_IFC_RSAKPG1_PRIME_FACTOR;
     strcmp_s("rsakpg2-basic", 13, str, &diff);
-    if (!diff) return ACVP_KAS_IFC_RSAKPG2_BASIC;
+    if (!diff) return ACVP_KTS_IFC_RSAKPG2_BASIC;
     strcmp_s("rsakpg2-crt", 11, str, &diff);
-    if (!diff) return ACVP_KAS_IFC_RSAKPG2_CRT;
+    if (!diff) return ACVP_KTS_IFC_RSAKPG2_CRT;
     strcmp_s("rsakpg2-prime-factor", 20, str, &diff);
-    if (!diff) return ACVP_KAS_IFC_RSAKPG2_PRIME_FACTOR;
+    if (!diff) return ACVP_KTS_IFC_RSAKPG2_PRIME_FACTOR;
 
     return 0;
 }

--- a/src/acvp_rsa_prim.c
+++ b/src/acvp_rsa_prim.c
@@ -753,7 +753,7 @@ ACVP_RESULT acvp_rsa_decprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                     goto err;
                 }
 
-                rv = acvp_rsa_decprim_init_tc_rev_56br2(ctx, &stc, keyformat, mod, keyformat, d_str, e_str, n_str, p_str,
+                rv = acvp_rsa_decprim_init_tc_rev_56br2(ctx, &stc, pub_exp_mode, mod, keyformat, d_str, e_str, n_str, p_str,
                                                         q_str, dmp1_str, dmq1_str, iqmp_str, cipher);
                 if (rv == ACVP_SUCCESS) {
                     if ((cap->crypto_handler)(&tc)) {

--- a/src/acvp_safe_primes.c
+++ b/src/acvp_safe_primes.c
@@ -29,7 +29,7 @@ static ACVP_SAFE_PRIMES_TEST_TYPE read_test_type(const char *str) {
     return 0;
 }
 
-static ACVP_SAFE_PRIMES_PARAM acvp_convert_dgm_string(const char *dgm_str)
+static ACVP_SAFE_PRIMES_MODE acvp_convert_dgm_string(const char *dgm_str)
 {
     int diff = 0;
 
@@ -118,7 +118,7 @@ static ACVP_RESULT acvp_safe_primes_init_tc(ACVP_CTX *ctx,
                                             int tc_id,
                                             ACVP_CIPHER alg_id,
                                             ACVP_SAFE_PRIMES_TC *stc,
-                                            ACVP_SAFE_PRIMES_PARAM dgm,
+                                            ACVP_SAFE_PRIMES_MODE dgm,
                                             const char *x,
                                             const char *y,
                                             ACVP_SAFE_PRIMES_TEST_TYPE test_type) {
@@ -178,7 +178,7 @@ ACVP_RESULT acvp_safe_primes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     const char *alg_str = NULL, *dgm_str = NULL, *test_type_str = NULL;
     char *json_result = NULL;
     ACVP_CIPHER alg_id;
-    ACVP_SAFE_PRIMES_PARAM dgm;
+    ACVP_SAFE_PRIMES_MODE dgm;
     ACVP_SAFE_PRIMES_TEST_TYPE test_type;
     const char *mode_str = NULL, *x = NULL, *y = NULL;
     unsigned int i, g_cnt;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -104,6 +104,15 @@ APP_LINK += ../app/implementations/openssl/3/acvp_app-iut.o \
 
 endif
 
+if APP_IUT_LIBOQS
+APP_LINK += ../app/implementations/liboqs/acvp_app-iut.o \
+            ../app/implementations/liboqs/acvp_app-iut_ml_kem.o \
+            ../app/implementations/liboqs/acvp_app-iut_ml_dsa.o
+endif
+
+if APP_IUT_JENT
+APP_LINK += ../app/implementations/jitter_entropy/acvp_app-iut.o
+endif
 
 tmp_cflags += $(IUT_CFLAGS) -I../app
 tmp_ldflags += $(IUT_LDFLAGS)
@@ -112,9 +121,11 @@ endif
 runtest_CFLAGS = ${tmp_cflags}
 runtest_LDFLAGS = ${tmp_ldflags}
 
+ldadd = $(ADDL_LIB_DEPENDENCIES)
 if ! APP_NOT_SUPPORTED
-runtest_LDADD = $(APP_LINK) $(IUT_LIBS)
+ldadd += $(APP_LINK) $(IUT_LIBS)
 endif
+runtest_LDADD = $(ldadd)
 
 runtestdir=
 runtest_HEADERS = ut_common.h

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -176,9 +176,15 @@ noinst_PROGRAMS = runtest$(EXEEXT)
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_ml_kem.o \
 @APP_IUT_OPENSSL_3_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/openssl/3/acvp_app-iut_slh_dsa.o
 
-@APP_NOT_SUPPORTED_FALSE@am__append_7 = $(IUT_CFLAGS) -I../app
-@APP_NOT_SUPPORTED_FALSE@am__append_8 = $(IUT_LDFLAGS)
-@APP_NOT_SUPPORTED_FALSE@am__append_9 = app_common.h
+@APP_IUT_LIBOQS_TRUE@@APP_NOT_SUPPORTED_FALSE@am__append_7 = ../app/implementations/liboqs/acvp_app-iut.o \
+@APP_IUT_LIBOQS_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/liboqs/acvp_app-iut_ml_kem.o \
+@APP_IUT_LIBOQS_TRUE@@APP_NOT_SUPPORTED_FALSE@            ../app/implementations/liboqs/acvp_app-iut_ml_dsa.o
+
+@APP_IUT_JENT_TRUE@@APP_NOT_SUPPORTED_FALSE@am__append_8 = ../app/implementations/jitter_entropy/acvp_app-iut.o
+@APP_NOT_SUPPORTED_FALSE@am__append_9 = $(IUT_CFLAGS) -I../app
+@APP_NOT_SUPPORTED_FALSE@am__append_10 = $(IUT_LDFLAGS)
+@APP_NOT_SUPPORTED_FALSE@am__append_11 = $(APP_LINK) $(IUT_LIBS)
+@APP_NOT_SUPPORTED_FALSE@am__append_12 = app_common.h
 subdir = test
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
@@ -292,8 +298,10 @@ am_runtest_OBJECTS = runtest-ut_common.$(OBJEXT) $(am__objects_1) \
 	$(am__objects_2) $(am__objects_3)
 runtest_OBJECTS = $(am_runtest_OBJECTS)
 am__DEPENDENCIES_1 =
-@APP_NOT_SUPPORTED_FALSE@runtest_DEPENDENCIES = $(APP_LINK) \
+@APP_NOT_SUPPORTED_FALSE@am__DEPENDENCIES_2 = $(APP_LINK) \
 @APP_NOT_SUPPORTED_FALSE@	$(am__DEPENDENCIES_1)
+am__DEPENDENCIES_3 = $(am__DEPENDENCIES_1) $(am__DEPENDENCIES_2)
+runtest_DEPENDENCIES = $(am__DEPENDENCIES_3)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
@@ -589,20 +597,22 @@ runtest_SOURCES = ut_common.c $(am__append_1) $(am__append_4) \
 	$(am__append_5)
 tmp_cflags = -g -O0 -Wall -DNO_SSL_DL $(SAFEC_CFLAGS) \
 	$(CRITERION_CFLAGS) $(LIBACVP_CFLAGS) -I../include \
-	$(am__append_2) $(am__append_7)
+	$(am__append_2) $(am__append_9)
 tmp_ldflags = $(CRITERION_LDFLAGS) $(SAFEC_LDFLAGS) $(LIBACVP_LDFLAGS) \
-	$(am__append_3) $(am__append_8)
+	$(am__append_3) $(am__append_10)
 @APP_NOT_SUPPORTED_FALSE@APP_LINK = ../app/acvp_app-app_cli.o \
 @APP_NOT_SUPPORTED_FALSE@	../app/acvp_app-app_utils.o \
 @APP_NOT_SUPPORTED_FALSE@	../app/totp/acvp_app-hmac_sha256.o \
 @APP_NOT_SUPPORTED_FALSE@	../app/totp/acvp_app-sha256.o \
 @APP_NOT_SUPPORTED_FALSE@	../app/totp/acvp_app-totp.o \
-@APP_NOT_SUPPORTED_FALSE@	$(am__append_6)
+@APP_NOT_SUPPORTED_FALSE@	$(am__append_6) $(am__append_7) \
+@APP_NOT_SUPPORTED_FALSE@	$(am__append_8)
 runtest_CFLAGS = ${tmp_cflags}
 runtest_LDFLAGS = ${tmp_ldflags}
-@APP_NOT_SUPPORTED_FALSE@runtest_LDADD = $(APP_LINK) $(IUT_LIBS)
+ldadd = $(ADDL_LIB_DEPENDENCIES) $(am__append_11)
+runtest_LDADD = $(ldadd)
 runtestdir = 
-runtest_HEADERS = ut_common.h $(am__append_9)
+runtest_HEADERS = ut_common.h $(am__append_12)
 all: all-am
 
 .SUFFIXES:

--- a/test/json/hash/hash.json
+++ b/test/json/hash/hash.json
@@ -665,7 +665,8 @@
             "tcId": 130
           }
         ], 
-        "testType": "MCT"
+        "testType": "MCT",
+        "mctVersion": "standard"
       }
     ]
   }

--- a/test/json/hash/hash_8.json
+++ b/test/json/hash/hash_8.json
@@ -662,7 +662,8 @@
             "tcId": 130
           }
         ], 
-        "testType": "MCT"
+        "testType": "MCT",
+        "mctVersion": "standard"
       }
     ], 
     "algorithm": "SHA2-256", 


### PR DESCRIPTION
- Add lots of missing enum cases to switches
- Add null parameter checks to some functions
- fix several casting warnings
- Add missing alphabet variable to aes fpe test cases
- fix several cases of wrong enum type declarations
- Fix UT builds for cases where app has no UTs yet; fix some MCT has UTs
- some misc build system fixes, other small misc fixes