### PR TITLE
Return behavior changes, more fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,13 @@ For these steps, use the Visual Studio Command Prompt for your platform (x64, x8
 x64_86)
 
 Steps:
-1.) Edit and run ms\config_windows.bat
+1. Edit and run ms\config_windows.bat
     -Add all of the directories for your dependencies
-	-Change any needed settings
-2.) Open libacvp.sln and acvp_app.sln in Visual Studio and allow the dialog to update the projects'
-    versions of MSVC and windows SDK to the latest installed (May be unnecessary if versions match)
-3.) run ms/make_lib.bat
-4.) run ms/make_app.bat
+    -Change any needed settings
+2. Open libacvp.sln and acvp_app.sln in Visual Studio and allow the dialog to update the projects'
+   versions of MSVC and windows SDK to the latest installed (May be unnecessary if versions match)
+3. run ms/make_lib.bat
+4. run ms/make_app.bat
 
 The library files and app files will be placed in the ms/build/ directory.
 
@@ -290,26 +290,12 @@ intense load, anywhere from a few seconds to a few days. If there is an issue an
 is lost or the server experiences an error, the library output will indicate it.
 
 `I received a vector set from somewhere other than libacvp, such as a lab. How can I process it?`
-Libacvp expects vector set json files to have a specific formatting. It is possible to manually
-modify the JSON file to make it work though we do not officially support or endorse this process.
-We plan to add support for this usage soon.
+Libacvp by default expects vector set json files to have the same specific formatting it uses to store
+those vector set files.
 
-Moving your vector set into a json array, and putting this as the json object before the vector set
-should allow libacvp to process it using the offline testing process described above; you would
-also need to remove these entries from the output file.
-```
-{
-    "jwt": "NA",
-    "url": "NA",
-    "isSample": false,
-    "vectorSetUrls": [
-        "NA"
-    ]
-}
-```
-Note that this file will not be able to be submitted using libacvp unless you manually input all
-of the correct information in the above object; we do not recommend this and you should instead
-try to submit via wherever you originally got the vector set from.
+If you have a single object vector set file without this formatting, you should be able to run it by
+providing `--generic` alongside the `--vector_req` and `--vector_rsp` commands you would normally use
+to run vectors offline.
 
 ## Credits
 This package was initially written by John Foley of Cisco Systems.

--- a/app/implementations/openssl/3/iut_aes.c
+++ b/app/implementations/openssl/3/iut_aes.c
@@ -661,7 +661,7 @@ int app_aes_handler_gmac(ACVP_TEST_CASE *test_case) {
     }
 
 err:
-    if (rv != 0) ERR_print_errors_fp(stderr);
+    if (rv != 0 && tc->direction != ACVP_SYM_CIPH_DIR_DECRYPT) ERR_print_errors_fp(stderr);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
     if (gmac_ctx) EVP_MAC_CTX_free(gmac_ctx);

--- a/app/implementations/openssl/3/iut_cmac.c
+++ b/app/implementations/openssl/3/iut_cmac.c
@@ -8,14 +8,15 @@
  */
 
 
-#include <openssl/evp.h>
-#include <openssl/cmac.h>
 #include "acvp/acvp.h"
 #include "app_lcl.h"
 #include "safe_lib.h"
+
+#include <openssl/evp.h>
+#include <openssl/cmac.h>
 #include <openssl/param_build.h>
 #include <openssl/core_names.h>
-
+#include <openssl/err.h>
 
 int app_cmac_handler(ACVP_TEST_CASE *test_case) {
     ACVP_CMAC_TC *tc;
@@ -146,6 +147,7 @@ int app_cmac_handler(ACVP_TEST_CASE *test_case) {
     rv = 0;
 
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (cmac_ctx) EVP_MAC_CTX_free(cmac_ctx);
     if (mac) EVP_MAC_free(mac);
     if (pbld) OSSL_PARAM_BLD_free(pbld);

--- a/app/implementations/openssl/3/iut_des.c
+++ b/app/implementations/openssl/3/iut_des.c
@@ -22,12 +22,12 @@ void app_des_cleanup(void) {
 }
 
 int app_des_handler(ACVP_TEST_CASE *test_case) {
-    ACVP_SYM_CIPHER_TC *tc;
-    EVP_CIPHER_CTX *cipher_ctx;
-    const EVP_CIPHER *cipher;
+    ACVP_SYM_CIPHER_TC *tc = NULL;
+    EVP_CIPHER_CTX *cipher_ctx = NULL;
+    const EVP_CIPHER *cipher = NULL;
     unsigned char *iv = 0;
     unsigned char *ctx_iv = NULL;
-    ACVP_SUB_TDES alg;
+    ACVP_SUB_TDES alg = 0;
     int rv = 1;
 
     if (!test_case) {

--- a/app/implementations/openssl/3/iut_drbg.c
+++ b/app/implementations/openssl/3/iut_drbg.c
@@ -10,10 +10,12 @@
 
 
 #include <stdlib.h>
-#include <openssl/rand.h>
 #include "app_lcl.h"
 #include "safe_mem_lib.h"
+
+#include <openssl/rand.h>
 #include <openssl/core_names.h>
+#include <openssl/err.h>
 
 int app_drbg_handler(ACVP_TEST_CASE *test_case) {
     int rv = 1, der_func = 0;
@@ -210,6 +212,7 @@ int app_drbg_handler(ACVP_TEST_CASE *test_case) {
 
     rv = 0;
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (test) EVP_RAND_CTX_free(test);
     if (rctx) EVP_RAND_CTX_free(rctx);
     if (rand) EVP_RAND_free(rand);

--- a/app/implementations/openssl/3/iut_dsa.c
+++ b/app/implementations/openssl/3/iut_dsa.c
@@ -10,6 +10,7 @@
 
 #include "app_lcl.h"
 #include "implementations/openssl/3/iut.h"
+#include "safe_lib.h"
 
 #if !defined OPENSSL_NO_DSA
 #include <openssl/param_build.h>
@@ -17,7 +18,7 @@
 #include <openssl/evp.h>
 #include <openssl/bn.h>
 #include <openssl/dsa.h>
-#include "safe_lib.h"
+#include <openssl/err.h>
 
 #define DSA_MAX_SEED 1024
 
@@ -72,10 +73,12 @@ static int init_group_pkey_paramgen(int l, int n) {
     }
     rv = 0;
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     return rv;
 }
 
 int app_dsa_handler(ACVP_TEST_CASE *test_case) {
+    int rv = 1;
     size_t seed_len = 0, sig_len = 0;
     const char *md = NULL;
     unsigned char *sig = NULL, *sig_iter = NULL;
@@ -488,7 +491,10 @@ int app_dsa_handler(ACVP_TEST_CASE *test_case) {
     default:
         break;
     }
+
+    rv = 0;
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (sig) free(sig);
     if (x) BN_free(x);
     if (y) BN_free(y);
@@ -504,7 +510,7 @@ err:
     if (param_key) EVP_PKEY_free(param_key);
     if (pkey) EVP_PKEY_free(pkey);
     if (sig_ctx) EVP_MD_CTX_free(sig_ctx);
-    return 0;
+    return rv;
 }
 
 #else

--- a/app/implementations/openssl/3/iut_ecdsa.c
+++ b/app/implementations/openssl/3/iut_ecdsa.c
@@ -9,6 +9,7 @@
 
 #include "app_lcl.h"
 #include "implementations/openssl/3/iut.h"
+#include "safe_lib.h"
 
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
@@ -16,7 +17,7 @@
 #include <openssl/bn.h>
 #include <openssl/ecdsa.h>
 #include <openssl/ec.h>
-#include "safe_lib.h"
+#include <openssl/err.h>
 
 static BIGNUM *ecdsa_group_Qx = NULL;
 static BIGNUM *ecdsa_group_Qy = NULL;
@@ -366,6 +367,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
 
     rv = 0;
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (qx) BN_free(qx);
     if (qy) BN_free(qy);
     if (d) BN_free(d);

--- a/app/implementations/openssl/3/iut_eddsa.c
+++ b/app/implementations/openssl/3/iut_eddsa.c
@@ -301,6 +301,7 @@ int app_eddsa_handler(ACVP_TEST_CASE *test_case) {
 
     rv = 0;
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (q) free(q);
     if (d) free(d);
     if (pub_key) free(pub_key);
@@ -310,6 +311,5 @@ err:
     if (pkey) EVP_PKEY_free(pkey);
     if (sig_ctx) EVP_MD_CTX_free(sig_ctx);
     if (pkey_ctx) EVP_PKEY_CTX_free(pkey_ctx);
-    ERR_print_errors_fp(stdout);
     return rv;
 }

--- a/app/implementations/openssl/3/iut_hmac.c
+++ b/app/implementations/openssl/3/iut_hmac.c
@@ -7,14 +7,15 @@
  * https://github.com/cisco/libacvp/LICENSE
  */
 
+#include "acvp/acvp.h"
+#include "app_lcl.h"
+#include "safe_lib.h"
 
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
-#include "acvp/acvp.h"
-#include "app_lcl.h"
-#include "safe_lib.h"
+#include <openssl/err.h>
 
 int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     ACVP_HMAC_TC    *tc;
@@ -24,15 +25,15 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
     OSSL_PARAM *params = NULL;
     const char *md_name = NULL;
     int msg_len;
-    int rc = 1;
+    int rv = 1;
     ACVP_SUB_HMAC alg;
 
     if (!test_case) {
-        return rc;
+        return rv;
     }
 
     tc = test_case->tc.hmac;
-    if (!tc) return rc;
+    if (!tc) return rv;
 
     alg = acvp_get_hmac_alg(tc->cipher);
     if (alg == 0) {
@@ -78,7 +79,7 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
         break;
     default:
         printf("Error: Unsupported hash algorithm requested by ACVP server\n");
-        return rc;
+        return rv;
 
         break;
     }
@@ -123,13 +124,14 @@ int app_hmac_handler(ACVP_TEST_CASE *test_case) {
         goto end;
     }
 
-    rc = 0;
+    rv = 0;
 
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (hmac_ctx) EVP_MAC_CTX_free(hmac_ctx);
     if (mac) EVP_MAC_free(mac);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
-    return rc;
+    return rv;
 }
 

--- a/app/implementations/openssl/3/iut_kas.c
+++ b/app/implementations/openssl/3/iut_kas.c
@@ -9,6 +9,7 @@
 
 #include "app_lcl.h"
 #include "implementations/openssl/3/iut.h"
+#include "safe_mem_lib.h"
 
 #include<openssl/err.h>
 #include <openssl/evp.h>
@@ -18,7 +19,6 @@
 #include <openssl/rand.h>
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
-#include "safe_mem_lib.h"
 
 #define KAS_ECC_Z_MAX 512
 #define KAS_FFC_Z_MAX 2048
@@ -193,7 +193,7 @@ int app_kas_ecc_handler(ACVP_TEST_CASE *test_case) {
     }
     rv = 0;
 err:
-    ERR_print_errors_fp(stdout);
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (s_pub_key) free(s_pub_key);
     if (i_pub_key) free(i_pub_key);
     if (z) free (z);
@@ -434,6 +434,7 @@ int app_kas_ffc_handler(ACVP_TEST_CASE *test_case) {
     memcpy_s(tc->chash, KAS_FFC_Z_MAX, z, z_len);
     rv = 0;
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (z) free (z);
     if (serv_pbld) OSSL_PARAM_BLD_free(serv_pbld);
     if (iut_pbld) OSSL_PARAM_BLD_free(iut_pbld);
@@ -782,6 +783,7 @@ int app_kas_ifc_handler(ACVP_TEST_CASE *test_case) {
     }
     rv = 0;
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (z) free(z);
     if (encap_s) free(encap_s);
     if (server_n) BN_free(server_n);
@@ -1003,6 +1005,7 @@ int app_kts_ifc_handler(ACVP_TEST_CASE *test_case) {
     }
     rv = 0;
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (e) BN_free(e);
     if (n) BN_free(n);
     if (p) BN_free(p);

--- a/app/implementations/openssl/3/iut_kda.c
+++ b/app/implementations/openssl/3/iut_kda.c
@@ -8,15 +8,16 @@
  */
 
 #include "app_lcl.h"
+#include "acvp/acvp.h"
+#include "safe_lib.h"
+#include "implementations/openssl/3/iut.h"
 
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/kdf.h>
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
-#include "acvp/acvp.h"
-#include "safe_lib.h"
-#include "implementations/openssl/3/iut.h"
+#include <openssl/err.h>
 
 static unsigned char *fixed_info_gen_concat(ACVP_KDA_PATTERN_CANDIDATE *fixedInfoPattern,
                                             unsigned char *literalCandidate,
@@ -154,7 +155,7 @@ end:
 
 int app_kda_hkdf_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KDA_HKDF_TC *stc = NULL;
-    int rc = 1, fixedInfoLen = 0;
+    int rv = 1, fixedInfoLen = 0;
     unsigned char *fixedInfo = NULL;
     OSSL_PARAM_BLD *pbld = NULL;
     OSSL_PARAM *params = NULL;
@@ -217,20 +218,21 @@ int app_kda_hkdf_handler(ACVP_TEST_CASE *test_case) {
         printf("Failure deriving key material in KDA-HKDF\n");
         goto end;
     }
-    rc = 0;
+    rv = 0;
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
     if (fixedInfo) free(fixedInfo);
     if (kdf) EVP_KDF_free(kdf);
     if (kctx) EVP_KDF_CTX_free(kctx);
-    return rc;
+    return rv;
 }
 
 
 int app_kda_onestep_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KDA_ONESTEP_TC *stc = NULL;
-    int rc = 1, fixedInfoLen = 0;
+    int rv = 1, fixedInfoLen = 0;
     unsigned char *fixedInfo = NULL;
     OSSL_PARAM_BLD *pbld = NULL;
     OSSL_PARAM *params = NULL;
@@ -392,19 +394,20 @@ int app_kda_onestep_handler(ACVP_TEST_CASE *test_case) {
         printf("Failure deriving key material in KDA-OneStep\n");
         goto end;
     }
-    rc = 0;
+    rv = 0;
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     OSSL_PARAM_BLD_free(pbld);
     OSSL_PARAM_free(params);
     if (fixedInfo) free(fixedInfo);
     if (kdf) EVP_KDF_free(kdf);
     if (kctx) EVP_KDF_CTX_free(kctx);
-    return rc;
+    return rv;
 }
 
 int app_kda_twostep_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KDA_TWOSTEP_TC *stc = NULL;
-    int rc = 1, fixedInfoLen = 0;
+    int rv = 1, fixedInfoLen = 0;
     unsigned char *fixedInfo = NULL;
     OSSL_PARAM_BLD *pbld = NULL;
     OSSL_PARAM *params = NULL;
@@ -508,12 +511,13 @@ int app_kda_twostep_handler(ACVP_TEST_CASE *test_case) {
         printf("Failure deriving key material in KDA twostep\n");
         goto end;
     }
-    rc = 0;
+    rv = 0;
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
     if (fixedInfo) free(fixedInfo);
     if (kdf) EVP_KDF_free(kdf);
     if (kctx) EVP_KDF_CTX_free(kctx);
-    return rc;
+    return rv;
 }

--- a/app/implementations/openssl/3/iut_kdf.c
+++ b/app/implementations/openssl/3/iut_kdf.c
@@ -9,6 +9,7 @@
 
 #include "app_lcl.h"
 #include "implementations/openssl/3/iut.h"
+#include "safe_lib.h"
 
 #include <openssl/evp.h>
 #include <openssl/bn.h>
@@ -16,7 +17,7 @@
 #include <openssl/rand.h>
 #include <openssl/param_build.h>
 #include <openssl/kdf.h>
-#include "safe_lib.h"
+#include <openssl/err.h>
 
 #define TLS_EXT_MASTER_SECRET_CONST      "extended master secret"
 #define TLS_EXT_MASTER_SECRET_CONST_SIZE 22
@@ -51,7 +52,7 @@ static char tls13_expand[] = "EXPAND_ONLY";
 
 int app_kdf135_x942_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KDF135_X942_TC *stc = NULL;
-    int rc = 1, info_len = 0, iter = 0;
+    int rv = 1, info_len = 0, iter = 0;
     OSSL_PARAM_BLD *pbld = NULL;
     OSSL_PARAM *params = NULL;
     EVP_KDF *kdf = NULL;
@@ -151,19 +152,20 @@ int app_kdf135_x942_handler(ACVP_TEST_CASE *test_case) {
     }
 
     stc->dkm_len = stc->key_len;
-    rc = 0;
+    rv = 0;
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (acvp_info) free(acvp_info);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
     if (kdf) EVP_KDF_free(kdf);
     if (kctx) EVP_KDF_CTX_free(kctx);
-    return rc;
+    return rv;
 }
 
 int app_kdf135_x963_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KDF135_X963_TC *stc = NULL;
-    int rc = 1;
+    int rv = 1;
     char *aname = NULL;
     OSSL_PARAM_BLD *pbld = NULL;
     OSSL_PARAM *params = NULL;
@@ -219,19 +221,20 @@ int app_kdf135_x963_handler(ACVP_TEST_CASE *test_case) {
         printf("Failure deriving key material in KDF X963\n");
         goto end;
     }
-    rc = 0;
+    rv = 0;
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (aname) free(aname);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
     if (kdf) EVP_KDF_free(kdf);
     if (kctx) EVP_KDF_CTX_free(kctx);
-    return rc;
+    return rv;
 }
 
 int app_kdf108_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KDF108_TC *stc = NULL;
-    int rc = 1, isHmac = 1, fixed_len = 64;
+    int rv = 1, isHmac = 1, fixed_len = 64;
     char *aname = NULL;
     unsigned char *fixed = NULL;
     OSSL_PARAM_BLD *pbld = NULL;
@@ -408,20 +411,21 @@ int app_kdf108_handler(ACVP_TEST_CASE *test_case) {
         goto end;
     }
 
-    rc = 0;
+    rv = 0;
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (aname) free(aname);
     if (fixed) free(fixed);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
     if (kdf) EVP_KDF_free(kdf);
     if (kctx) EVP_KDF_CTX_free(kctx);
-    return rc;
+    return rv;
 }
 
 int app_kdf135_ssh_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KDF135_SSH_TC *stc = NULL;
-    int rc = 1;
+    int rv = 1;
     char *aname = NULL;
     OSSL_PARAM params[6];
     EVP_KDF *kdf = NULL;
@@ -506,17 +510,18 @@ int app_kdf135_ssh_handler(ACVP_TEST_CASE *test_case) {
         goto end;
     }
 
-    rc = 0;
+    rv = 0;
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (aname) free(aname);
     if (kdf) EVP_KDF_free(kdf);
     if (kctx) EVP_KDF_CTX_free(kctx);
-    return rc;
+    return rv;
 }
 
 int app_pbkdf_handler(ACVP_TEST_CASE *test_case) {
     ACVP_PBKDF_TC *stc = NULL;
-    int rc = 1;
+    int rv = 1;
     char *aname = NULL;
     OSSL_PARAM_BLD *pbld = NULL;
     OSSL_PARAM *params = NULL;
@@ -592,20 +597,21 @@ int app_pbkdf_handler(ACVP_TEST_CASE *test_case) {
     if (EVP_KDF_derive(kctx, stc->key, stc->key_len, params) != 1) {
         printf("Failure deriving key material in PBKDF\n");
     }
-    rc = 0;
+    rv = 0;
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (aname) free(aname);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
     if (kdf) EVP_KDF_free(kdf);
     if (kctx) EVP_KDF_CTX_free(kctx);
-    return rc;
+    return rv;
 }
 
 int app_kdf_tls12_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KDF_TLS12_TC *tc;
     unsigned char *seed = NULL;
-    int rc = 1, ret = 0, seed_len = 0;
+    int rv = 1, ret = 0, seed_len = 0;
     const char *alg = NULL;
     EVP_KDF *kdf = NULL;
     EVP_KDF_CTX *kctx = NULL;
@@ -715,14 +721,15 @@ int app_kdf_tls12_handler(ACVP_TEST_CASE *test_case) {
         goto end;
     }
 
-    rc = 0;
+    rv = 0;
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
     if (kctx) EVP_KDF_CTX_free(kctx);
     if (kdf) EVP_KDF_free(kdf);
     if (seed) free(seed);
-    return rc;
+    return rv;
 }
 
 int app_kdf_tls13_handler(ACVP_TEST_CASE *test_case) {
@@ -1034,6 +1041,7 @@ int app_kdf_tls13_handler(ACVP_TEST_CASE *test_case) {
     rv = 0;
 
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (zero_input) free(zero_input);
     if (handshake_secret) free(handshake_secret);
     if (master_secret) free(master_secret);

--- a/app/implementations/openssl/3/iut_kmac.c
+++ b/app/implementations/openssl/3/iut_kmac.c
@@ -8,11 +8,12 @@
  */
 
 #include "app_lcl.h"
+#include "safe_lib.h"
 
 #include <openssl/evp.h>
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
-#include "safe_lib.h"
+#include <openssl/err.h>
 
 int app_kmac_handler(ACVP_TEST_CASE *test_case) {
     ACVP_KMAC_TC *tc;
@@ -140,6 +141,7 @@ int app_kmac_handler(ACVP_TEST_CASE *test_case) {
     rv = 0;
 
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (kmac_ctx) EVP_MAC_CTX_free(kmac_ctx);
     if (mac) EVP_MAC_free(mac);
     if (pbld) OSSL_PARAM_BLD_free(pbld);

--- a/app/implementations/openssl/3/iut_ml_dsa.c
+++ b/app/implementations/openssl/3/iut_ml_dsa.c
@@ -299,6 +299,7 @@ int app_ml_dsa_handler(ACVP_TEST_CASE *test_case) {
 
     rv = 0;
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
     if (pkey_ctx) EVP_PKEY_CTX_free(pkey_ctx);

--- a/app/implementations/openssl/3/iut_ml_kem.c
+++ b/app/implementations/openssl/3/iut_ml_kem.c
@@ -8,13 +8,14 @@
  */
 
 #include "app_lcl.h"
+#include "acvp/acvp.h"
+#include "safe_lib.h"
+#include "implementations/openssl/3/iut.h"
 
 #include <openssl/evp.h>
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
-#include "acvp/acvp.h"
-#include "safe_lib.h"
-#include "implementations/openssl/3/iut.h"
+#include <openssl/err.h>
 
 
 #define ML_KEM_MAX_BUF_SIZE 8192
@@ -277,6 +278,7 @@ int app_ml_kem_handler(ACVP_TEST_CASE *test_case) {
 
     rv = 0;
 end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
     if (pkey_ctx) EVP_PKEY_CTX_free(pkey_ctx);

--- a/app/implementations/openssl/3/iut_rsa.c
+++ b/app/implementations/openssl/3/iut_rsa.c
@@ -9,13 +9,14 @@
 
 #include "app_lcl.h"
 #include "implementations/openssl/3/iut.h"
+#include "safe_lib.h"
 
 #include <openssl/evp.h>
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
-#include "safe_lib.h"
+#include <openssl/err.h>
 
 #define RSA_BUF_MAX 8192
 
@@ -130,6 +131,7 @@ int app_rsa_keygen_handler(ACVP_TEST_CASE *test_case) {
 
     rv = 0;
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (p) BN_free(p);
     if (q) BN_free(q);
     if (n) BN_free(n);
@@ -352,6 +354,7 @@ int app_rsa_sig_handler(ACVP_TEST_CASE *test_case) {
     rv = 0;
 
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (md_ctx) EVP_MD_CTX_free(md_ctx);
     if (pkey_ctx) EVP_PKEY_CTX_free(pkey_ctx);
     if (pkey) EVP_PKEY_free(pkey);
@@ -501,6 +504,7 @@ int app_rsa_sigprim_handler(ACVP_TEST_CASE *test_case) {
     rv = 0;
 
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (e) BN_free(e);
     if (n) BN_free(n);
     if (d) BN_free(d);
@@ -519,7 +523,7 @@ err:
 }
 
 int app_rsa_decprim_handler(ACVP_TEST_CASE *test_case) {
- BIGNUM *e = NULL, *n = NULL, *d = NULL;
+    BIGNUM *e = NULL, *n = NULL, *d = NULL;
     BIGNUM *p = NULL, *q = NULL, *dmp1 = NULL, *dmq1 = NULL, *iqmp = NULL;
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *pkey_ctx = NULL, *dec_ctx = NULL;
@@ -616,6 +620,7 @@ int app_rsa_decprim_handler(ACVP_TEST_CASE *test_case) {
 
     rv = 0;
 err:
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (e) BN_free(e);
     if (n) BN_free(n);
     if (d) BN_free(d);

--- a/app/implementations/openssl/3/iut_slh_dsa.c
+++ b/app/implementations/openssl/3/iut_slh_dsa.c
@@ -296,7 +296,7 @@ int app_slh_dsa_handler(ACVP_TEST_CASE *test_case) {
 
     rv = 0;
 end:
-    ERR_print_errors_fp(stderr);
+    if (rv != 0) ERR_print_errors_fp(stderr);
     if (pbld) OSSL_PARAM_BLD_free(pbld);
     if (params) OSSL_PARAM_free(params);
     if (pkey_ctx) EVP_PKEY_CTX_free(pkey_ctx);

--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -16,6 +16,8 @@
 #ifndef acvp_h
 #define acvp_h
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/migration_guide.md
+++ b/migration_guide.md
@@ -1,5 +1,9 @@
 # Libacvp 2.0 Migration Guide
 
+## New in 2.2.0
+
+The included acvp_app application has had a restructure. For details on how to integrate a harness
+into the new structure, view app/implementations/README.md.
 
 ## About
 With the release of libacvp 2.0.0, various changes have been made that are not backwards-compatible

--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -3,6 +3,8 @@ EXPORTS
   acvp_cap_sym_cipher_enable
   acvp_cap_sym_cipher_set_parm
   acvp_cap_sym_cipher_set_domain
+  acvp_cap_sym_cipher_set_parm_string
+  acvp_cap_sym_cipher_set_iv_modes
   acvp_cap_hash_enable
   acvp_cap_hash_set_parm
   acvp_cap_hash_set_domain
@@ -119,6 +121,7 @@ EXPORTS
   acvp_get_current_registration
   acvp_upload_vectors_from_file
   acvp_run_vectors_from_file
+  acvp_run_vectors_from_file_offline
   acvp_put_data_from_file
   acvp_get_results_from_server
   acvp_resume_test_session


### PR DESCRIPTION
This release is now ready unless any issues are found in remaining testing. 

This PR:
- Organize header 'includes' at top of OpenSSL harness files
- Make OpenSSL harness consistently use "rv" for return values
- Consistently dump OpenSSL errors to stderr if a test claims to have failed
- Add missing APIs to windows build system file
- Misc documentation updates