### PR TITLE
Fix typos; Fix/update error messages

### DIFF
--- a/include/acvp/acvp.h
+++ b/include/acvp/acvp.h
@@ -161,7 +161,7 @@ typedef enum acvp_cipher {
     ACVP_AES_CBC_CS2,
     ACVP_AES_CBC_CS3,
     ACVP_AES_CFB1,
-    ACVP_AES_CFB8,
+    ACVP_AES_CFB8,     /* 10 */
     ACVP_AES_CFB128,
     ACVP_AES_OFB,
     ACVP_AES_CTR,
@@ -171,7 +171,7 @@ typedef enum acvp_cipher {
     ACVP_AES_GMAC,
     ACVP_AES_XPN,
     ACVP_AES_FF1,
-    ACVP_AES_FF3,
+    ACVP_AES_FF3,     /* 20 */
     ACVP_TDES_ECB,
     ACVP_TDES_CBC,
     ACVP_TDES_CBCI,
@@ -181,7 +181,7 @@ typedef enum acvp_cipher {
     ACVP_TDES_CFB8,
     ACVP_TDES_CFB64,
     ACVP_TDES_CFBP1,
-    ACVP_TDES_CFBP8,
+    ACVP_TDES_CFBP8,    /* 30 */
     ACVP_TDES_CFBP64,
     ACVP_TDES_CTR,
     ACVP_TDES_KW,
@@ -191,7 +191,7 @@ typedef enum acvp_cipher {
     ACVP_HASH_SHA384,
     ACVP_HASH_SHA512,
     ACVP_HASH_SHA512_224,
-    ACVP_HASH_SHA512_256,
+    ACVP_HASH_SHA512_256,  /* 40 */
     ACVP_HASH_SHA3_224,
     ACVP_HASH_SHA3_256,
     ACVP_HASH_SHA3_384,
@@ -201,7 +201,7 @@ typedef enum acvp_cipher {
     ACVP_HASHDRBG,
     ACVP_HMACDRBG,
     ACVP_CTRDRBG,
-    ACVP_HMAC_SHA1,
+    ACVP_HMAC_SHA1,         /* 50 */
     ACVP_HMAC_SHA2_224,
     ACVP_HMAC_SHA2_256,
     ACVP_HMAC_SHA2_384,
@@ -211,7 +211,7 @@ typedef enum acvp_cipher {
     ACVP_HMAC_SHA3_224,
     ACVP_HMAC_SHA3_256,
     ACVP_HMAC_SHA3_384,
-    ACVP_HMAC_SHA3_512,
+    ACVP_HMAC_SHA3_512,    /* 60 */
     ACVP_CMAC_AES,
     ACVP_CMAC_TDES,
     ACVP_KMAC_128,
@@ -221,7 +221,7 @@ typedef enum acvp_cipher {
     ACVP_DSA_PQGVER,
     ACVP_DSA_SIGGEN,
     ACVP_DSA_SIGVER,
-    ACVP_RSA_KEYGEN,
+    ACVP_RSA_KEYGEN,     /* 70 */
     ACVP_RSA_SIGGEN,
     ACVP_RSA_SIGVER,
     ACVP_RSA_DECPRIM,
@@ -231,7 +231,7 @@ typedef enum acvp_cipher {
     ACVP_ECDSA_SIGGEN,
     ACVP_ECDSA_SIGVER,
     ACVP_DET_ECDSA_SIGGEN,
-    ACVP_EDDSA_KEYGEN,
+    ACVP_EDDSA_KEYGEN,    /* 80 */
     ACVP_EDDSA_KEYVER,
     ACVP_EDDSA_SIGGEN,
     ACVP_EDDSA_SIGVER,
@@ -241,7 +241,7 @@ typedef enum acvp_cipher {
     ACVP_KDF135_IKEV2,
     ACVP_KDF135_IKEV1,
     ACVP_KDF135_X942,
-    ACVP_KDF135_X963,
+    ACVP_KDF135_X963,    /* 90 */
     ACVP_KDF108,
     ACVP_PBKDF,
     ACVP_KDF_TLS12,
@@ -251,7 +251,7 @@ typedef enum acvp_cipher {
     ACVP_KAS_ECC_NOCOMP,
     ACVP_KAS_ECC_SSC,
     ACVP_KAS_FFC_COMP,
-    ACVP_KAS_FFC_NOCOMP,
+    ACVP_KAS_FFC_NOCOMP,   /* 100 */
     ACVP_KAS_FFC_SSC,
     ACVP_KAS_IFC_SSC,
     ACVP_KDA_ONESTEP,
@@ -261,7 +261,7 @@ typedef enum acvp_cipher {
     ACVP_SAFE_PRIMES_KEYGEN,
     ACVP_SAFE_PRIMES_KEYVER,
     ACVP_LMS_KEYGEN,
-    ACVP_LMS_SIGGEN,
+    ACVP_LMS_SIGGEN,      /* 110 */
     ACVP_LMS_SIGVER,
     ACVP_ML_DSA_KEYGEN,
     ACVP_ML_DSA_SIGGEN,
@@ -675,7 +675,6 @@ typedef enum acvp_sym_cipher_ivgen_mode {
     ACVP_SYM_CIPH_IVGEN_MODE_NA,
     ACVP_SYM_CIPH_IVGEN_MODE_MAX
 } ACVP_SYM_CIPH_IVGEN_MODE;
-
 
 /**
  * @enum ACVP_SYM_CIPH_DIR

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -2403,7 +2403,6 @@ int acvp_get_vector_set_count(ACVP_CTX *ctx) {
     count = (int)json_array_get_count(tmp_array);
     json_value_free(reg);
     return count;
-
 }
 
 /*

--- a/src/acvp_aes.c
+++ b/src/acvp_aes.c
@@ -291,7 +291,7 @@ static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx,
          */
         rv = acvp_aes_output_mct_tc(ctx, stc, r_tobj);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure in AES module");
+            ACVP_LOG_ERR("JSON output failure recording test response");
             json_value_free(r_tval);
             free(tmp);
             return rv;
@@ -301,7 +301,7 @@ static ACVP_RESULT acvp_aes_mct_tc(ACVP_CTX *ctx,
             stc->mct_index = j;    /* indicates init vs. update */
             /* Process the current AES encrypt test vector... */
             if ((cap->crypto_handler)(tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 free(tmp);
                 json_value_free(r_tval);
                 return ACVP_CRYPTO_MODULE_FAIL;
@@ -678,7 +678,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     /* Get the crypto module handler for AES mode */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id == 0) {
-        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("Unsupported algorithm (%s)", alg_str);
         return ACVP_TC_INVALID_DATA;
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
@@ -1260,7 +1260,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 res_tarr = json_object_get_array(r_tobj, "resultsArray");
                 rv = acvp_aes_mct_tc(ctx, cap, &tc, &stc, res_tarr);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("crypto module failed the MCT operation");
+                    ACVP_LOG_ERR("Crypto module failed the MCT operation");
                     json_value_free(r_tval);
                     acvp_aes_release_tc(&stc);
                     goto err;
@@ -1275,7 +1275,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                             alg_id != ACVP_AES_CCM &&
                             alg_id != ACVP_AES_KWP && 
                             alg_id != ACVP_AES_GMAC) {
-                        ACVP_LOG_ERR("crypto module failed the operation");
+                        ACVP_LOG_ERR("Crypto module failed the operation");
                         acvp_aes_release_tc(&stc);
                         json_value_free(r_tval);
                         rv = ACVP_CRYPTO_MODULE_FAIL;
@@ -1288,7 +1288,7 @@ ACVP_RESULT acvp_aes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                  */
                 rv = acvp_aes_output_tc(ctx, &stc, r_tobj, t_rv);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("JSON output failure in AES module");
+                    ACVP_LOG_ERR("JSON output failure recording test response");
                     json_value_free(r_tval);
                     acvp_aes_release_tc(&stc);
                     goto err;

--- a/src/acvp_build_register.c
+++ b/src/acvp_build_register.c
@@ -1604,7 +1604,6 @@ static ACVP_RESULT acvp_build_ecdsa_register_cap(ACVP_CTX *ctx, ACVP_CIPHER ciph
         if (!cap_entry->cap.ecdsa_sigver_cap) {
             return ACVP_NO_CAP;
         }
-
         current_curve = ecdsa_cap->curves;
         //add "universally" set hash algs here instead of later to be resliant to different combos of API calls
         while (current_curve) {

--- a/src/acvp_cmac.c
+++ b/src/acvp_cmac.c
@@ -222,7 +222,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id == 0) {
-        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("Unsupported algorithm (%s)", alg_str);
         return ACVP_UNSUPPORTED_OP;
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
@@ -301,7 +301,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         if (!diff) {
             testtype = ACVP_CMAC_TEST_TYPE_AFT;
         } else {
-            ACVP_LOG_ERR("invalid 'testType' in server JSON.");
+            ACVP_LOG_ERR("Invalid 'testType' in server JSON.");
             rv = ACVP_UNSUPPORTED_OP;
             goto err;
         }
@@ -456,7 +456,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 acvp_cmac_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
@@ -468,7 +468,7 @@ ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_cmac_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_cmac_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_des.c
+++ b/src/acvp_des.c
@@ -431,7 +431,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
     case ACVP_SUB_TDES_CTR:
     case ACVP_SUB_TDES_KW:
     default:
-        ACVP_LOG_ERR("unsupported algorithm (%d)", stc->cipher);
+        ACVP_LOG_ERR("Unsupported algorithm (%d)", stc->cipher);
         free(tmp);
         return ACVP_UNSUPPORTED_OP;
     }
@@ -449,7 +449,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
          */
         rv = acvp_des_output_mct_tc(ctx, stc, r_tobj);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure in DES module");
+            ACVP_LOG_ERR("JSON output failure recording test response");
             free(tmp);
             json_value_free(r_tval);
             return rv;
@@ -462,7 +462,7 @@ static ACVP_RESULT acvp_des_mct_tc(ACVP_CTX *ctx,
             stc->mct_index = j;    /* indicates init vs. update */
             /* Process the current DES encrypt test vector... */
             if ((cap->crypto_handler)(tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 free(tmp);
                 json_value_free(r_tval);
                 return ACVP_CRYPTO_MODULE_FAIL;
@@ -680,7 +680,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id == 0) {
-        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("Unsupported algorithm (%s)", alg_str);
         return ACVP_UNSUPPORTED_OP;
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
@@ -982,7 +982,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 rv = acvp_des_mct_tc(ctx, cap, &tc, &stc, res_tarr);
                 if (rv != ACVP_SUCCESS) {
                     json_value_free(r_tval);
-                    ACVP_LOG_ERR("crypto module failed the DES MCT operation");
+                    ACVP_LOG_ERR("Crypto module failed the DES MCT operation");
                     acvp_des_release_tc(&stc);
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     goto err;
@@ -991,7 +991,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 /* Process the current DES encrypt test vector... */
                 int t_rv = (cap->crypto_handler)(&tc);
                 if (t_rv) {
-                    ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     json_value_free(r_tval);
                     acvp_des_release_tc(&stc);
                     rv = ACVP_CRYPTO_MODULE_FAIL;
@@ -1003,7 +1003,7 @@ ACVP_RESULT acvp_des_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                  */
                 rv = acvp_des_output_tc(ctx, &stc, r_tobj, t_rv);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("JSON output failure in 3DES module");
+                    ACVP_LOG_ERR("JSON output failure recording test response");
                     acvp_des_release_tc(&stc);
                     goto err;
                 }
@@ -1148,7 +1148,7 @@ static ACVP_RESULT acvp_des_init_tc(ACVP_CTX *ctx,
 
     rv = acvp_hexstr_to_bin(j_key, stc->key, ACVP_SYM_KEY_MAX_BYTES, NULL);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Hex converstion failure (key)");
+        ACVP_LOG_ERR("Hex conversion failure (key)");
         return rv;
     }
 
@@ -1162,7 +1162,7 @@ static ACVP_RESULT acvp_des_init_tc(ACVP_CTX *ctx,
         } else {
             rv = acvp_hexstr_to_bin(j_pt, stc->pt, ACVP_SYM_PT_BYTE_MAX, NULL);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("Hex converstion failure (pt)");
+                ACVP_LOG_ERR("Hex conversion failure (pt)");
                 return rv;
             }
         }
@@ -1178,7 +1178,7 @@ static ACVP_RESULT acvp_des_init_tc(ACVP_CTX *ctx,
         } else {
             rv = acvp_hexstr_to_bin(j_ct, stc->ct, ACVP_SYM_CT_BYTE_MAX, NULL);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("Hex converstion failure (ct)");
+                ACVP_LOG_ERR("Hex conversion failure (ct)");
                 return rv;
             }
         }
@@ -1187,7 +1187,7 @@ static ACVP_RESULT acvp_des_init_tc(ACVP_CTX *ctx,
     if (j_iv) {
         rv = acvp_hexstr_to_bin(j_iv, stc->iv, ACVP_SYM_IV_BYTE_MAX, NULL);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("Hex converstion failure (iv)");
+            ACVP_LOG_ERR("Hex conversion failure (iv)");
             return rv;
         }
     }

--- a/src/acvp_drbg.c
+++ b/src/acvp_drbg.c
@@ -103,7 +103,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if ((alg_id < ACVP_HASHDRBG) || (alg_id > ACVP_CTRDRBG)) {
-        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("Unsupported algorithm (%s)", alg_str);
         return ACVP_UNSUPPORTED_OP;
     }
 
@@ -534,7 +534,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 acvp_drbg_release_tc(&stc);
                 json_value_free(r_tval);
@@ -546,7 +546,7 @@ ACVP_RESULT acvp_drbg_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_drbg_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in DRBG module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_drbg_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_dsa.c
+++ b/src/acvp_dsa.c
@@ -571,7 +571,7 @@ static ACVP_RESULT acvp_dsa_keygen_handler(ACVP_CTX *ctx,
 
         /* Process the current DSA test vector... */
         if ((cap->crypto_handler)(&tc)) {
-            ACVP_LOG_ERR("crypto module failed the operation");
+            ACVP_LOG_ERR("Crypto module failed the operation");
             rv = ACVP_CRYPTO_MODULE_FAIL;
             goto err;
         }
@@ -621,7 +621,7 @@ static ACVP_RESULT acvp_dsa_keygen_handler(ACVP_CTX *ctx,
          */
         rv = acvp_dsa_output_tc(ctx, stc, mobj);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure in DSA module");
+            ACVP_LOG_ERR("JSON output failure recording test response");
             goto err;
         }
 
@@ -838,7 +838,7 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
 
             /* Process the current DSA test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 acvp_dsa_release_tc(stc);
                 json_value_free(r_tval);
                 return ACVP_CRYPTO_MODULE_FAIL;
@@ -849,7 +849,7 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
              */
             rv = acvp_dsa_output_tc(ctx, stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in DSA module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 acvp_dsa_release_tc(stc);
                 return rv;
@@ -879,7 +879,7 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
             }
 
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 acvp_dsa_release_tc(stc);
                 json_value_free(r_tval);
                 return ACVP_CRYPTO_MODULE_FAIL;
@@ -890,7 +890,7 @@ ACVP_RESULT acvp_dsa_pqggen_handler(ACVP_CTX *ctx,
              */
             rv = acvp_dsa_output_tc(ctx, stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in DSA module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_dsa_release_tc(stc);
                 json_value_free(r_tval);
                 return rv;
@@ -1003,7 +1003,7 @@ static ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
 
         /* Process the current DSA test vector... */
         if ((cap->crypto_handler)(&tc)) {
-            ACVP_LOG_ERR("crypto module failed the operation");
+            ACVP_LOG_ERR("Crypto module failed the operation");
             rv = ACVP_CRYPTO_MODULE_FAIL;
             goto err;
         }
@@ -1063,7 +1063,7 @@ static ACVP_RESULT acvp_dsa_siggen_handler(ACVP_CTX *ctx,
          */
         rv = acvp_dsa_output_tc(ctx, stc, mobj);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure in DSA module");
+            ACVP_LOG_ERR("JSON output failure recording test response");
             goto err;
         }
         acvp_dsa_release_tc(stc);
@@ -1251,7 +1251,7 @@ static ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
 
         /* Process the current DSA test vector... */
         if ((cap->crypto_handler)(&tc)) {
-            ACVP_LOG_ERR("crypto module failed the operation");
+            ACVP_LOG_ERR("Crypto module failed the operation");
             acvp_dsa_release_tc(stc);
             return ACVP_CRYPTO_MODULE_FAIL;
         }
@@ -1264,7 +1264,7 @@ static ACVP_RESULT acvp_dsa_pqgver_handler(ACVP_CTX *ctx,
          */
         rv = acvp_dsa_output_tc(ctx, stc, mobj);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure in DSA module");
+            ACVP_LOG_ERR("JSON output failure recording test response");
             acvp_dsa_release_tc(stc);
             return rv;
         }
@@ -1413,7 +1413,7 @@ static ACVP_RESULT acvp_dsa_sigver_handler(ACVP_CTX *ctx,
 
         /* Process the current DSA test vector... */
         if ((cap->crypto_handler)(&tc)) {
-            ACVP_LOG_ERR("crypto module failed the operation");
+            ACVP_LOG_ERR("Crypto module failed the operation");
             acvp_dsa_release_tc(stc);
             return ACVP_CRYPTO_MODULE_FAIL;
         }
@@ -1426,7 +1426,7 @@ static ACVP_RESULT acvp_dsa_sigver_handler(ACVP_CTX *ctx,
          */
         rv = acvp_dsa_output_tc(ctx, stc, mobj);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure in DSA module");
+            ACVP_LOG_ERR("JSON output failure recording test response");
             acvp_dsa_release_tc(stc);
             return rv;
         }

--- a/src/acvp_ecdsa.c
+++ b/src/acvp_ecdsa.c
@@ -295,7 +295,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -474,7 +474,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -513,7 +513,7 @@ static ACVP_RESULT acvp_ecdsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
             }
             rv = acvp_ecdsa_output_tc(ctx, alg_id, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 goto err;
             }

--- a/src/acvp_eddsa.c
+++ b/src/acvp_eddsa.c
@@ -442,7 +442,7 @@ static ACVP_RESULT acvp_eddsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -474,7 +474,7 @@ static ACVP_RESULT acvp_eddsa_kat_handler_internal(ACVP_CTX *ctx, JSON_Object *o
             }
             rv = acvp_eddsa_output_tc(ctx, alg_id, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 goto err;
             }

--- a/src/acvp_hash.c
+++ b/src/acvp_hash.c
@@ -130,7 +130,7 @@ static ACVP_RESULT acvp_hash_mct_tc(ACVP_CTX *ctx,
             /* Spec: MD = SHA(MSG) */
             rv = (cap->crypto_handler)(tc);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 json_value_free(r_tval);
                 return ACVP_CRYPTO_MODULE_FAIL;
             }
@@ -156,7 +156,7 @@ static ACVP_RESULT acvp_hash_mct_tc(ACVP_CTX *ctx,
         /* Internal: output the test case request values using JSON, append to array */
         rv = acvp_hash_output_mct_tc(ctx, stc, r_tobj);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure in HASH module");
+            ACVP_LOG_ERR("JSON output failure recording test response");
             json_value_free(r_tval);
             return rv;
         }
@@ -235,7 +235,7 @@ static ACVP_RESULT acvp_hash_sha3_mct(ACVP_CTX *ctx,
             /* Process the current SHA test vector... */
             rv = (cap->crypto_handler)(tc);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 goto end;
             }
@@ -246,7 +246,7 @@ static ACVP_RESULT acvp_hash_sha3_mct(ACVP_CTX *ctx,
          */
         rv = acvp_hash_output_mct_tc(ctx, stc, r_tobj);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure");
+            ACVP_LOG_ERR("JSON output failure recording test response");
             goto end;
         }
 
@@ -339,7 +339,7 @@ static ACVP_RESULT acvp_hash_shake_mct(ACVP_CTX *ctx,
             /* Process the current SHA test vector... */
             rv = (cap->crypto_handler)(tc);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 goto end;
             }
@@ -362,7 +362,7 @@ static ACVP_RESULT acvp_hash_shake_mct(ACVP_CTX *ctx,
          */
         rv = acvp_hash_output_mct_tc(ctx, stc, r_tobj);
         if (rv != ACVP_SUCCESS) {
-            ACVP_LOG_ERR("JSON output failure");
+            ACVP_LOG_ERR("JSON output failure recording test response");
             goto end;
         }
 
@@ -480,7 +480,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id == 0) {
-        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("Unsupported algorithm (%s)", alg_str);
         return ACVP_UNSUPPORTED_OP;
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
@@ -727,7 +727,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 }
 
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("crypto module failed the HASH MCT operation");
+                    ACVP_LOG_ERR("Crypto module failed the HASH MCT operation");
                     acvp_hash_release_tc(&stc);
                     json_value_free(r_tval);
                     goto err;
@@ -735,7 +735,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             } else {
                 /* Process the current test vector... */
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     acvp_hash_release_tc(&stc);
                     json_value_free(r_tval);
                     rv = ACVP_CRYPTO_MODULE_FAIL;
@@ -747,7 +747,7 @@ ACVP_RESULT acvp_hash_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                  */
                 rv = acvp_hash_output_tc(ctx, &stc, r_tobj);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("JSON output failure in hash module");
+                    ACVP_LOG_ERR("JSON output failure recording test response");
                     acvp_hash_release_tc(&stc);
                     json_value_free(r_tval);
                     goto err;

--- a/src/acvp_hmac.c
+++ b/src/acvp_hmac.c
@@ -39,13 +39,13 @@ static ACVP_RESULT acvp_hmac_init_tc(ACVP_CTX *ctx,
 
     rv = acvp_hexstr_to_bin(msg, stc->msg, ACVP_HMAC_MSG_MAX, NULL);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Hex converstion failure (msg)");
+        ACVP_LOG_ERR("Hex conversion failure (msg)");
         return rv;
     }
 
     rv = acvp_hexstr_to_bin(key, stc->key, ACVP_HMAC_KEY_BYTE_MAX, NULL);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Hex converstion failure (key)");
+        ACVP_LOG_ERR("Hex conversion failure (key)");
         return rv;
     }
 
@@ -155,7 +155,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id == 0) {
-        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("Unsupported algorithm (%s)", alg_str);
         return ACVP_UNSUPPORTED_OP;
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
@@ -316,7 +316,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 acvp_hmac_release_tc(&stc);
                 json_value_free(r_tval);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
@@ -328,7 +328,7 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_hmac_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 acvp_hmac_release_tc(&stc);
                 goto err;

--- a/src/acvp_kas_ecc.c
+++ b/src/acvp_kas_ecc.c
@@ -431,7 +431,7 @@ static ACVP_RESULT acvp_kas_ecc_cdh(ACVP_CTX *ctx,
             /* Process the current KAT test vector... */
             if ((cap->crypto_handler)(tc)) {
                 acvp_kas_ecc_release_tc(stc);
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
                 goto err;
@@ -442,7 +442,7 @@ static ACVP_RESULT acvp_kas_ecc_cdh(ACVP_CTX *ctx,
              */
             rv = acvp_kas_ecc_output_cdh_tc(ctx, stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in KAS-ECC module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kas_ecc_release_tc(stc);
                 json_value_free(r_tval);
                 goto err;
@@ -696,7 +696,7 @@ static ACVP_RESULT acvp_kas_ecc_comp(ACVP_CTX *ctx,
             /* Process the current KAT test vector... */
             if ((cap->crypto_handler)(tc)) {
                 acvp_kas_ecc_release_tc(stc);
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
                 goto err;
@@ -707,7 +707,7 @@ static ACVP_RESULT acvp_kas_ecc_comp(ACVP_CTX *ctx,
              */
             rv = acvp_kas_ecc_output_comp_tc(ctx, stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in KAS-ECC module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kas_ecc_release_tc(stc);
                 json_value_free(r_tval);
                 goto err;
@@ -1211,7 +1211,7 @@ static ACVP_RESULT acvp_kas_ecc_ssc(ACVP_CTX *ctx,
             /* Process the current KAT test vector... */
             if ((cap->crypto_handler)(tc)) {
                 acvp_kas_ecc_release_tc(stc);
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
                 goto err;
@@ -1222,7 +1222,7 @@ static ACVP_RESULT acvp_kas_ecc_ssc(ACVP_CTX *ctx,
              */
             rv = acvp_kas_ecc_output_ssc_tc(ctx, stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in KAS-ECC module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kas_ecc_release_tc(stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kas_ffc.c
+++ b/src/acvp_kas_ffc.c
@@ -506,7 +506,7 @@ static ACVP_RESULT acvp_kas_ffc_comp(ACVP_CTX *ctx,
             /* Process the current KAT test vector... */
             if ((cap->crypto_handler)(tc)) {
                 acvp_kas_ffc_release_tc(stc);
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
                 goto err;
@@ -517,7 +517,7 @@ static ACVP_RESULT acvp_kas_ffc_comp(ACVP_CTX *ctx,
              */
             rv = acvp_kas_ffc_output_comp_tc(ctx, stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in KAS-FFC module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kas_ffc_release_tc(stc);
                 json_value_free(r_tval);
                 goto err;
@@ -929,7 +929,7 @@ static ACVP_RESULT acvp_kas_ffc_ssc(ACVP_CTX *ctx,
             /* Process the current KAT test vector... */
             if ((cap->crypto_handler)(tc)) {
                 acvp_kas_ffc_release_tc(stc);
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
                 goto err;
@@ -940,7 +940,7 @@ static ACVP_RESULT acvp_kas_ffc_ssc(ACVP_CTX *ctx,
              */
             rv = acvp_kas_ffc_output_ssc_tc(ctx, stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in KAS-FFC module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kas_ffc_release_tc(stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kas_ifc.c
+++ b/src/acvp_kas_ifc.c
@@ -886,7 +886,7 @@ static ACVP_RESULT acvp_kas_ifc_ssc(ACVP_CTX *ctx,
             /* Process the current KAT test vector... */
             if ((cap->crypto_handler)(tc)) {
                 acvp_kas_ifc_release_tc(stc);
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
                 goto err;
@@ -901,7 +901,7 @@ static ACVP_RESULT acvp_kas_ifc_ssc(ACVP_CTX *ctx,
                 rv = acvp_kas_ifc_ssc_output_tc(ctx, stc, r_tobj);
             }
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in KAS-IFC module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kas_ifc_release_tc(stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kda.c
+++ b/src/acvp_kda.c
@@ -1409,7 +1409,7 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
                 } else {
                     acvp_kda_release_tc(ACVP_KDA_TWOSTEP, tc);
                 }
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
                 goto err;
@@ -1421,7 +1421,7 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
             if (cipher == ACVP_KDA_HKDF) {
                 rv = acvp_kda_hkdf_output_tc(ctx, tc->tc.kda_hkdf, r_tobj);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("JSON output failure in KDA module");
+                    ACVP_LOG_ERR("JSON output failure recording test response");
                     acvp_kda_release_tc(ACVP_KDA_HKDF, tc);
                     json_value_free(r_tval);
                     goto err;
@@ -1429,7 +1429,7 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
             } else if (cipher == ACVP_KDA_ONESTEP) {
                 rv = acvp_kda_onestep_output_tc(ctx, tc->tc.kda_onestep, r_tobj);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("JSON output failure in KDA module");
+                    ACVP_LOG_ERR("JSON output failure recording test response");
                     acvp_kda_release_tc(ACVP_KDA_ONESTEP, tc);
                     json_value_free(r_tval);
                     goto err;
@@ -1437,7 +1437,7 @@ static ACVP_RESULT acvp_kda_process(ACVP_CTX *ctx,
             } else {
                 rv = acvp_kda_twostep_output_tc(ctx, tc->tc.kda_twostep, r_tobj);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("JSON output failure in KDA module");
+                    ACVP_LOG_ERR("JSON output failure recording test response");
                     acvp_kda_release_tc(ACVP_KDA_TWOSTEP, tc);
                     json_value_free(r_tval);
                     goto err;

--- a/src/acvp_kdf108.c
+++ b/src/acvp_kdf108.c
@@ -663,7 +663,7 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 acvp_kdf108_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 goto err;
@@ -682,7 +682,7 @@ ACVP_RESULT acvp_kdf108_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kdf108_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in kdf135 tpm module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 acvp_kdf108_release_tc(&stc);
                 goto err;

--- a/src/acvp_kdf135_ikev1.c
+++ b/src/acvp_kdf135_ikev1.c
@@ -512,7 +512,7 @@ ACVP_RESULT acvp_kdf135_ikev1_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the KDF IKEv1 operation");
+                ACVP_LOG_ERR("Crypto module failed the KDF IKEv1 operation");
                 acvp_kdf135_ikev1_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
@@ -524,7 +524,7 @@ ACVP_RESULT acvp_kdf135_ikev1_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kdf135_ikev1_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kdf135_ikev1_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kdf135_ikev2.c
+++ b/src/acvp_kdf135_ikev2.c
@@ -485,7 +485,7 @@ ACVP_RESULT acvp_kdf135_ikev2_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed");
+                ACVP_LOG_ERR("Crypto module failed");
                 acvp_kdf135_ikev2_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
@@ -497,7 +497,7 @@ ACVP_RESULT acvp_kdf135_ikev2_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kdf135_ikev2_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kdf135_ikev2_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kdf135_snmp.c
+++ b/src/acvp_kdf135_snmp.c
@@ -230,7 +230,7 @@ ACVP_RESULT acvp_kdf135_snmp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 acvp_kdf135_snmp_release_tc(&stc);
                 json_value_free(r_tval);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
@@ -242,7 +242,7 @@ ACVP_RESULT acvp_kdf135_snmp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kdf135_snmp_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kdf135_snmp_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kdf135_srtp.c
+++ b/src/acvp_kdf135_srtp.c
@@ -376,7 +376,7 @@ ACVP_RESULT acvp_kdf135_srtp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed");
+                ACVP_LOG_ERR("Crypto module failed");
                 acvp_kdf135_srtp_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
@@ -388,7 +388,7 @@ ACVP_RESULT acvp_kdf135_srtp_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kdf135_srtp_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kdf135_srtp_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kdf135_ssh.c
+++ b/src/acvp_kdf135_ssh.c
@@ -314,7 +314,7 @@ ACVP_RESULT acvp_kdf135_ssh_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the KDF SSH operation");
+                ACVP_LOG_ERR("Crypto module failed the KDF SSH operation");
                 acvp_kdf135_ssh_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
@@ -326,7 +326,7 @@ ACVP_RESULT acvp_kdf135_ssh_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kdf135_ssh_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kdf135_ssh_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kdf135_x942.c
+++ b/src/acvp_kdf135_x942.c
@@ -441,7 +441,7 @@ ACVP_RESULT acvp_kdf135_x942_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the KDF X942 operation");
+                ACVP_LOG_ERR("Crypto module failed the KDF X942 operation");
                 acvp_kdf135_x942_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
@@ -453,7 +453,7 @@ ACVP_RESULT acvp_kdf135_x942_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kdf135_x942_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kdf135_x942_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kdf135_x963.c
+++ b/src/acvp_kdf135_x963.c
@@ -328,7 +328,7 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the KDF SSH operation");
+                ACVP_LOG_ERR("Crypto module failed the KDF SSH operation");
                 acvp_kdf135_x963_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
@@ -340,7 +340,7 @@ ACVP_RESULT acvp_kdf135_x963_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kdf135_x963_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kdf135_x963_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kdf_tls12.c
+++ b/src/acvp_kdf_tls12.c
@@ -252,7 +252,7 @@ ACVP_RESULT acvp_kdf_tls12_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 acvp_kdf_tls12_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
@@ -264,7 +264,7 @@ ACVP_RESULT acvp_kdf_tls12_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kdf_tls12_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kdf_tls12_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kdf_tls13.c
+++ b/src/acvp_kdf_tls13.c
@@ -318,7 +318,7 @@ ACVP_RESULT acvp_kdf_tls13_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 acvp_kdf_tls13_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
@@ -330,7 +330,7 @@ ACVP_RESULT acvp_kdf_tls13_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kdf_tls13_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kdf_tls13_release_tc(&stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_kmac.c
+++ b/src/acvp_kmac.c
@@ -213,7 +213,7 @@ ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     /* Get the crypto module handler for this kmac algorithm */
     alg_id = acvp_lookup_cipher_index(alg_str);
     if (alg_id == 0) {
-        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
+        ACVP_LOG_ERR("Unsupported algorithm (%s)", alg_str);
         return ACVP_UNSUPPORTED_OP;
     }
     cap = acvp_locate_cap_entry(ctx, alg_id);
@@ -440,7 +440,7 @@ ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 acvp_kmac_release_tc(&stc);
                 json_value_free(r_tval);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
@@ -452,7 +452,7 @@ ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_kmac_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in kmac module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 acvp_kmac_release_tc(&stc);
                 goto err;

--- a/src/acvp_kts_ifc.c
+++ b/src/acvp_kts_ifc.c
@@ -596,7 +596,7 @@ static ACVP_RESULT acvp_kts_ifc(ACVP_CTX *ctx,
             /* Process the current KAT test vector... */
             if ((cap->crypto_handler)(tc)) {
                 acvp_kts_ifc_release_tc(stc);
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 json_value_free(r_tval);
                 goto err;
@@ -607,7 +607,7 @@ static ACVP_RESULT acvp_kts_ifc(ACVP_CTX *ctx,
              */
             rv = acvp_kts_ifc_output_tc(ctx, stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure in KTS-IFC module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 acvp_kts_ifc_release_tc(stc);
                 json_value_free(r_tval);
                 goto err;

--- a/src/acvp_lms.c
+++ b/src/acvp_lms.c
@@ -227,7 +227,7 @@ ACVP_RESULT acvp_lms_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     alg_str = json_object_get_string(obj, "algorithm");
     if (!alg_str) {
-        ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return ACVP_MALFORMED_JSON;
     }
 
@@ -247,7 +247,7 @@ ACVP_RESULT acvp_lms_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
     ACVP_LOG_VERBOSE("    LMS mode: %s", mode_str);
@@ -257,7 +257,7 @@ ACVP_RESULT acvp_lms_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
         return rv;
     }
 
@@ -422,7 +422,7 @@ ACVP_RESULT acvp_lms_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -451,7 +451,7 @@ ACVP_RESULT acvp_lms_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             }
             rv = acvp_lms_output_tc(ctx, alg_id, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 goto err;
             }

--- a/src/acvp_ml_dsa.c
+++ b/src/acvp_ml_dsa.c
@@ -245,7 +245,6 @@ static ACVP_RESULT acvp_ml_dsa_init_tc(ACVP_CTX *ctx,
         }
     }
 
-
     return ACVP_SUCCESS;
 
 err:
@@ -330,7 +329,7 @@ ACVP_RESULT acvp_ml_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     alg_str = json_object_get_string(obj, "algorithm");
     if (!alg_str) {
-        ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return ACVP_MALFORMED_JSON;
     }
 
@@ -350,14 +349,14 @@ ACVP_RESULT acvp_ml_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
 
     /* Create ACVP array for response */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
         return rv;
     }
 
@@ -633,7 +632,7 @@ ACVP_RESULT acvp_ml_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -648,7 +647,7 @@ ACVP_RESULT acvp_ml_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             rv = acvp_ml_dsa_output_tc(ctx, alg_id, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 goto err;
             }

--- a/src/acvp_ml_kem.c
+++ b/src/acvp_ml_kem.c
@@ -279,7 +279,7 @@ ACVP_RESULT acvp_ml_kem_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     alg_str = json_object_get_string(obj, "algorithm");
     if (!alg_str) {
-        ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return ACVP_MALFORMED_JSON;
     }
 
@@ -299,7 +299,7 @@ ACVP_RESULT acvp_ml_kem_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
     ACVP_LOG_VERBOSE("    ML-KEM mode: %s", mode_str);
@@ -307,7 +307,7 @@ ACVP_RESULT acvp_ml_kem_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     /* Create ACVP array for response */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
         return rv;
     }
 
@@ -397,6 +397,10 @@ ACVP_RESULT acvp_ml_kem_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
         if (func_str) {
             ACVP_LOG_VERBOSE("             function: %s", func_str);
         }
+        if (dk_str) {
+            ACVP_LOG_VERBOSE("                   dk: %s", dk_str);
+        }
+
 
         tests = json_object_get_array(groupobj, "tests");
         t_cnt = json_array_get_count(tests);
@@ -491,7 +495,7 @@ ACVP_RESULT acvp_ml_kem_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -505,7 +509,7 @@ ACVP_RESULT acvp_ml_kem_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             /* Output the test case results using JSON */
             rv = acvp_ml_kem_output_tc(ctx, alg_id, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 goto err;
             }

--- a/src/acvp_pbkdf.c
+++ b/src/acvp_pbkdf.c
@@ -421,7 +421,7 @@ ACVP_RESULT acvp_pbkdf_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
             /* Process the current test vector... */
             if ((cap->crypto_handler)(&tc)) {
-                ACVP_LOG_ERR("crypto module failed the operation");
+                ACVP_LOG_ERR("Crypto module failed the operation");
                 acvp_pbkdf_release_tc(&stc);
                 rv = ACVP_CRYPTO_MODULE_FAIL;
                 goto err;
@@ -440,7 +440,7 @@ ACVP_RESULT acvp_pbkdf_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_pbkdf_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("JSON output failure for pbkdf tc");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 acvp_pbkdf_release_tc(&stc);
                 goto err;

--- a/src/acvp_rsa_keygen.c
+++ b/src/acvp_rsa_keygen.c
@@ -104,7 +104,6 @@ static ACVP_RESULT acvp_rsa_output_tc(ACVP_CTX *ctx, ACVP_RSA_KEYGEN_TC *stc, JS
         memzero_s(tmp, ACVP_RSA_EXP_LEN_MAX);
     }
 
-    // Aux data only if genereated by IUT
     if (stc->rand_pq == ACVP_RSA_KEYGEN_B32 ||
         stc->rand_pq == ACVP_RSA_KEYGEN_B34 ||
         stc->rand_pq == ACVP_RSA_KEYGEN_B35 ||
@@ -490,7 +489,7 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -840,7 +839,7 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -852,7 +851,7 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_rsa_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 goto err;
             }

--- a/src/acvp_rsa_prim.c
+++ b/src/acvp_rsa_prim.c
@@ -505,7 +505,7 @@ ACVP_RESULT acvp_rsa_decprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -678,7 +678,7 @@ ACVP_RESULT acvp_rsa_decprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                        pass = stc.pass;
                        do {
                            if ((cap->crypto_handler)(&tc)) {
-                               ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+		                       ACVP_LOG_ERR("Crypto module failed the operation");
                                rv = ACVP_CRYPTO_MODULE_FAIL;
                                json_value_free(r_tval);
                                json_value_free(r_cval);
@@ -695,7 +695,7 @@ ACVP_RESULT acvp_rsa_decprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                      */
                     rv = acvp_rsa_decprim_output_tc_rev_1(ctx, &stc, r_cobj);
                     if (rv != ACVP_SUCCESS) {
-                        ACVP_LOG_ERR("ERROR: JSON output failure in primitive module");
+		                ACVP_LOG_ERR("JSON output failure recording test response");
                         json_value_free(r_tval);
                         json_value_free(r_cval);
                         goto err;
@@ -757,7 +757,7 @@ ACVP_RESULT acvp_rsa_decprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                                                         q_str, dmp1_str, dmq1_str, iqmp_str, cipher);
                 if (rv == ACVP_SUCCESS) {
                     if ((cap->crypto_handler)(&tc)) {
-                        ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                        ACVP_LOG_ERR("Crypto module failed the operation");
                         rv = ACVP_CRYPTO_MODULE_FAIL;
                         json_value_free(r_tval);
                         goto err;
@@ -767,7 +767,7 @@ ACVP_RESULT acvp_rsa_decprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 /* Output the test case results using JSON */
                 rv = acvp_rsa_decprim_output_tc_rev_56br2(ctx, &stc, r_tobj);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("ERROR: JSON output failure in primitive module");
+                    ACVP_LOG_ERR("JSON output failure recording test response");
                     json_value_free(r_tval);
                     goto err;
                 }
@@ -841,7 +841,7 @@ ACVP_RESULT acvp_rsa_sigprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     alg_str = json_object_get_string(obj, "algorithm");
     if (!alg_str) {
-        ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return ACVP_MALFORMED_JSON;
     }
 
@@ -869,7 +869,7 @@ ACVP_RESULT acvp_rsa_sigprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
 
@@ -883,7 +883,7 @@ ACVP_RESULT acvp_rsa_sigprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
+        ACVP_LOG_ERR("Failed to create JSON response struct.");
         return rv;
     }
 
@@ -1064,7 +1064,7 @@ ACVP_RESULT acvp_rsa_sigprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -1076,7 +1076,7 @@ ACVP_RESULT acvp_rsa_sigprim_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
              */
             rv = acvp_rsa_sigprim_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 goto err;
             }

--- a/src/acvp_rsa_sig.c
+++ b/src/acvp_rsa_sig.c
@@ -231,7 +231,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
 
     alg_str = json_object_get_string(obj, "algorithm");
     if (!alg_str) {
-        ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return ACVP_MALFORMED_JSON;
     }
 
@@ -262,7 +262,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
 
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
 
@@ -273,7 +273,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
      */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
         return rv;
     }
 
@@ -488,7 +488,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -528,7 +528,7 @@ static ACVP_RESULT acvp_rsa_sig_kat_handler_internal(ACVP_CTX *ctx, JSON_Object 
              */
             rv = acvp_rsa_sig_output_tc(ctx, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 goto err;
             }

--- a/src/acvp_safe_primes.c
+++ b/src/acvp_safe_primes.c
@@ -341,7 +341,7 @@ ACVP_RESULT acvp_safe_primes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 /* Process the current KAT test vector... */
                 if ((cap->crypto_handler)(&tc)) {
                     acvp_safe_primes_release_tc(&stc);
-                    ACVP_LOG_ERR("crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -352,7 +352,7 @@ ACVP_RESULT acvp_safe_primes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                  */
                 rv = acvp_safe_primes_output_tc(ctx, &stc, r_tobj);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("JSON output failure in KAS-FFC module");
+                    ACVP_LOG_ERR("JSON output failure recording test response");
                     acvp_safe_primes_release_tc(&stc);
                     json_value_free(r_tval);
                     goto err;
@@ -438,7 +438,7 @@ ACVP_RESULT acvp_safe_primes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                 /* Process the current KAT test vector... */
                 if ((cap->crypto_handler)(&tc)) {
                     acvp_safe_primes_release_tc(&stc);
-                    ACVP_LOG_ERR("crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -449,7 +449,7 @@ ACVP_RESULT acvp_safe_primes_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                  */
                 rv = acvp_safe_primes_output_tc(ctx, &stc, r_tobj);
                 if (rv != ACVP_SUCCESS) {
-                    ACVP_LOG_ERR("JSON output failure in KAS-FFC module");
+                    ACVP_LOG_ERR("JSON output failure recording test response");
                     acvp_safe_primes_release_tc(&stc);
                     json_value_free(r_tval);
                     goto err;

--- a/src/acvp_slh_dsa.c
+++ b/src/acvp_slh_dsa.c
@@ -312,7 +312,7 @@ ACVP_RESULT acvp_slh_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     alg_str = json_object_get_string(obj, "algorithm");
     if (!alg_str) {
-        ACVP_LOG_ERR("ERROR: unable to parse 'algorithm' from JSON");
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
         return ACVP_MALFORMED_JSON;
     }
 
@@ -332,7 +332,7 @@ ACVP_RESULT acvp_slh_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
 
     cap = acvp_locate_cap_entry(ctx, alg_id);
     if (!cap) {
-        ACVP_LOG_ERR("ERROR: ACVP server requesting unsupported capability");
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability");
         return ACVP_UNSUPPORTED_OP;
     }
     ACVP_LOG_VERBOSE("    SLH-DSA mode: %s", mode_str);
@@ -340,7 +340,7 @@ ACVP_RESULT acvp_slh_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
     /* Create ACVP array for response */
     rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
     if (rv != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("ERROR: Failed to create JSON response struct.");
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
         return rv;
     }
 
@@ -592,7 +592,7 @@ ACVP_RESULT acvp_slh_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             /* Process the current test vector... */
             if (rv == ACVP_SUCCESS) {
                 if ((cap->crypto_handler)(&tc)) {
-                    ACVP_LOG_ERR("ERROR: crypto module failed the operation");
+                    ACVP_LOG_ERR("Crypto module failed the operation");
                     rv = ACVP_CRYPTO_MODULE_FAIL;
                     json_value_free(r_tval);
                     goto err;
@@ -606,7 +606,7 @@ ACVP_RESULT acvp_slh_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
             /* Output the test case results using JSON */
             rv = acvp_slh_dsa_output_tc(ctx, alg_id, &stc, r_tobj);
             if (rv != ACVP_SUCCESS) {
-                ACVP_LOG_ERR("ERROR: JSON output failure in hash module");
+                ACVP_LOG_ERR("JSON output failure recording test response");
                 json_value_free(r_tval);
                 goto err;
             }


### PR DESCRIPTION
I recently synced and saw updates to some error message to remove the "ERROR: " prefix.  I've carried on that work to all files.  I've also updated various error messages for capitalization and standardization.

This is all just changes to error messages and a few comments, so it shouldn't be a hard review.