### PR TITLE
Consolidate algorithm enable APIs into acvp_enable_algorithm

### DIFF
--- a/app/implementations/jitter_entropy/iut.c
+++ b/app/implementations/jitter_entropy/iut.c
@@ -77,7 +77,7 @@ ACVP_RESULT iut_register_capabilities(ACVP_CTX *ctx, APP_CONFIG *cfg) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     if (cfg->hash || cfg->testall) {
-        rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
+        rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
         CHECK_ENABLE_CAP_RV(rv);
         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_IN_BIT, 0);
         CHECK_ENABLE_CAP_RV(rv);

--- a/app/implementations/liboqs/iut.c
+++ b/app/implementations/liboqs/iut.c
@@ -41,7 +41,7 @@ ACVP_RESULT iut_register_capabilities(ACVP_CTX *ctx, APP_CONFIG *cfg) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     if (cfg->ml_kem || cfg->testall) {
-        rv = acvp_cap_ml_kem_enable(ctx, ACVP_ML_KEM_KEYGEN, &app_ml_kem_handler);
+        rv = acvp_enable_algorithm(ctx, ACVP_ML_KEM_KEYGEN, &app_ml_kem_handler);
         CHECK_ENABLE_CAP_RV(rv);
         rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_KEYGEN, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_512);
         CHECK_ENABLE_CAP_RV(rv);
@@ -50,7 +50,7 @@ ACVP_RESULT iut_register_capabilities(ACVP_CTX *ctx, APP_CONFIG *cfg) {
         rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_KEYGEN, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_1024);
         CHECK_ENABLE_CAP_RV(rv);
 
-        rv = acvp_cap_ml_kem_enable(ctx, ACVP_ML_KEM_XCAP, &app_ml_kem_handler);
+        rv = acvp_enable_algorithm(ctx, ACVP_ML_KEM_XCAP, &app_ml_kem_handler);
         CHECK_ENABLE_CAP_RV(rv);
         rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_512);
         CHECK_ENABLE_CAP_RV(rv);
@@ -69,7 +69,7 @@ ACVP_RESULT iut_register_capabilities(ACVP_CTX *ctx, APP_CONFIG *cfg) {
      * or external interfaces without prehash mode. Should support deterministic and non-deterministic modes.
      */
     if (cfg->ml_dsa || cfg->testall) {
-        rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_KEYGEN, &app_ml_dsa_handler);
+        rv = acvp_enable_algorithm(ctx, ACVP_ML_DSA_KEYGEN, &app_ml_dsa_handler);
         CHECK_ENABLE_CAP_RV(rv);
         rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_KEYGEN, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_44);
         CHECK_ENABLE_CAP_RV(rv);
@@ -78,7 +78,7 @@ ACVP_RESULT iut_register_capabilities(ACVP_CTX *ctx, APP_CONFIG *cfg) {
         rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_KEYGEN, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_87);
         CHECK_ENABLE_CAP_RV(rv);
 
-        rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_SIGGEN, &app_ml_dsa_handler);
+        rv = acvp_enable_algorithm(ctx, ACVP_ML_DSA_SIGGEN, &app_ml_dsa_handler);
         CHECK_ENABLE_CAP_RV(rv);
         rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_DETERMINISTIC_MODE, ACVP_DETERMINISTIC_BOTH);
         CHECK_ENABLE_CAP_RV(rv);
@@ -99,7 +99,7 @@ ACVP_RESULT iut_register_capabilities(ACVP_CTX *ctx, APP_CONFIG *cfg) {
         rv = acvp_cap_ml_dsa_set_domain(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_CONTEXT_LEN, 0, 2040, 8);
         CHECK_ENABLE_CAP_RV(rv);
 
-        rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_SIGVER, &app_ml_dsa_handler);
+        rv = acvp_enable_algorithm(ctx, ACVP_ML_DSA_SIGVER, &app_ml_dsa_handler);
         CHECK_ENABLE_CAP_RV(rv);
         rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_SIG_INTERFACE, ACVP_SIG_INTERFACE_BOTH);
         CHECK_ENABLE_CAP_RV(rv);

--- a/app/implementations/openssl/3/registrations/fp_30X.c
+++ b/app/implementations/openssl/3/registrations/fp_30X.c
@@ -68,7 +68,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable AES_GCM */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &app_aes_handler_aead);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &app_aes_handler_aead);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -111,7 +111,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-ECB 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_ECB, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_ECB, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -129,7 +129,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CBC 128 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -147,7 +147,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CBC-CS1, CS2, and CS3 */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS1, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS1, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -160,7 +160,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -173,7 +173,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -187,7 +187,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB1 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB1, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -205,7 +205,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB8 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB8, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB8, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -223,7 +223,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB128 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB128, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB128, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -241,7 +241,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-OFB 128, 192, 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_OFB, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_OFB, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -259,7 +259,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Register AES CCM capabilities */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CCM, &app_aes_handler_aead);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CCM, &app_aes_handler_aead);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -299,7 +299,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* AES-KW */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KW, &app_aes_keywrap_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KW, &app_aes_keywrap_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -321,7 +321,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -339,7 +339,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-XTS 128 and 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XTS, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XTS, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -354,7 +354,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CTR 128, 192, 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CTR, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CTR, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -378,7 +378,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     //GMAC
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GMAC, &app_aes_handler_gmac);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GMAC, &app_aes_handler_gmac);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GMAC, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -426,7 +426,7 @@ static int enable_tdes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable 3DES-ECB */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_ECB, &app_des_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_ECB, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -434,7 +434,7 @@ static int enable_tdes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable 3DES-CBC */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBC, &app_des_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CBC, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -450,42 +450,42 @@ static int enable_hash(ACVP_CTX *ctx) {
     int i = 0;
 
     /* Enable SHA-1 and SHA-2 */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA384, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA384, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -494,7 +494,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -503,7 +503,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_384, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_384, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -512,7 +512,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_512, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_512, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -521,7 +521,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_128, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHAKE_128, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -532,7 +532,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_OUT_LENGTH, 16, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHAKE_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_256, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -564,7 +564,7 @@ static int enable_cmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable CMAC */
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &app_cmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &app_cmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_AES, ACVP_CMAC_MSGLEN, 0, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -592,7 +592,7 @@ static int enable_kmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable KMAC */
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_128, &app_kmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_128, &app_kmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_128, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -606,7 +606,7 @@ static int enable_kmac(ACVP_CTX *ctx) {
     rv = acvp_cap_kmac_set_parm(ctx, ACVP_KMAC_128, ACVP_KMAC_HEX_CUSTOM_SUPPORT, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_256, &app_kmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_256, &app_kmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_256, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -626,7 +626,7 @@ end:
 static int enable_hmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -635,7 +635,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA1, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -644,7 +644,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -653,7 +653,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -662,7 +662,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_384, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -671,7 +671,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_224, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -680,7 +680,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_256, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -689,7 +689,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_224, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -698,7 +698,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_256, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -707,7 +707,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_384, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -716,7 +716,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_384, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_512, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -733,7 +733,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     int flags = 0;
 
-    rv = acvp_cap_kdf_tls12_enable(ctx, &app_kdf_tls12_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS12, &app_kdf_tls12_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -746,7 +746,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf_tls12_set_parm(ctx, ACVP_KDF_TLS12_HASH_ALG, ACVP_SHA512);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &app_kdf135_ssh_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &app_kdf135_ssh_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -768,7 +768,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf135_ssh_set_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_256_CBC, flags);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf135_x942_enable(ctx, &app_kdf135_x942_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X942, &app_kdf135_x942_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X942, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -811,7 +811,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_OID, ACVP_KDF_X942_OID_AES256KW);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf135_x963_enable(ctx, &app_kdf135_x963_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &app_kdf135_x963_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -837,7 +837,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* KDF108 Counter Mode */
-    rv = acvp_cap_kdf108_enable(ctx, &app_kdf108_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &app_kdf108_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -916,7 +916,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* PBKDF */
-    rv = acvp_cap_pbkdf_enable(ctx, &app_pbkdf_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_PBKDF, &app_pbkdf_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_PBKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -944,7 +944,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_pbkdf_set_domain(ctx, ACVP_PBKDF_SALT_LEN, 128, 4096, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf_tls13_enable(ctx, &app_kdf_tls13_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS13, &app_kdf_tls13_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS13, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -968,7 +968,7 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable KAS-ECC.... */
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -999,7 +999,7 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_SSC, &app_kas_ecc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_SSC, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_PREREQ_ECDSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1054,7 +1054,7 @@ static int enable_kas_ifc(ACVP_CTX *ctx) {
     expo_str = BN_bn2hex(expo);
     BN_free(expo);
 
-    rv = acvp_cap_kas_ifc_enable(ctx, ACVP_KAS_IFC_SSC, &app_kas_ifc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_IFC_SSC, &app_kas_ifc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_RSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1115,7 +1115,7 @@ static int enable_kts_ifc(ACVP_CTX *ctx) {
     expo_str = BN_bn2hex(expo);
     BN_free(expo);
 
-    rv = acvp_cap_kts_ifc_enable(ctx, ACVP_KTS_IFC, &app_kts_ifc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KTS_IFC, &app_kts_ifc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KTS_IFC, ACVP_PREREQ_RSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1195,7 +1195,7 @@ end:
 static int enable_kas_ffc(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_SSC, &app_kas_ffc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_SSC, &app_kas_ffc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_SAFE_PRIMES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1233,7 +1233,7 @@ end:
 static int enable_kda(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_HKDF, &app_kda_hkdf_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_HKDF, &app_kda_hkdf_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_HKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1280,7 +1280,7 @@ static int enable_kda(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     // kdf onestep
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1314,7 +1314,7 @@ static int enable_kda(ACVP_CTX *ctx) {
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_L, 2048, NULL);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_TWOSTEP, &app_kda_twostep_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_TWOSTEP, &app_kda_twostep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_TWOSTEP, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1380,7 +1380,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
         /* Enable DSA.... */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGGEN, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGGEN, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1421,7 +1421,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGGEN, ACVP_DSA_MODE_PQGGEN, ACVP_DSA_LN3072_256, ACVP_SHA512_256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGVER, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1477,7 +1477,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN3072_256, ACVP_SHA512_256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_KEYGEN, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_KEYGEN, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1490,7 +1490,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_KEYGEN, ACVP_DSA_MODE_KEYGEN, ACVP_DSA_LN3072_256, ACVP_NO_SHA);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGGEN, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGGEN, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1533,7 +1533,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGGEN, ACVP_DSA_MODE_SIGGEN, ACVP_DSA_LN3072_256, ACVP_SHA512_256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGVER, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGVER, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1615,7 +1615,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     BN_free(expo);
 
     /* Enable RSA keygen... */
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1640,7 +1640,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable siggen */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1736,7 +1736,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable sigver */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGVER, &app_rsa_sig_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGVER, &app_rsa_sig_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1890,7 +1890,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable Signature Primitive */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGPRIM, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1916,7 +1916,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable ECDSA keyGen... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1952,7 +1952,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA keyVer... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYVER, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1992,7 +1992,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA sigGen... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGGEN, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGGEN, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2040,7 +2040,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA sigVer... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGVER, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGVER, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2102,7 +2102,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Hash DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_set_prereq(ctx, ACVP_HASHDRBG, ACVP_PREREQ_SHA, value);
@@ -2191,7 +2191,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* HMAC DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMACDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2281,7 +2281,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* CTR DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_CTRDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_CTRDRBG, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2382,7 +2382,7 @@ static int enable_safe_primes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Register Safe Prime Key Generation testing */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYGEN, &app_safe_primes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYGEN, &app_safe_primes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2400,7 +2400,7 @@ static int enable_safe_primes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Register Safe Prime Key Verify testing */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYVER, &app_safe_primes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYVER, &app_safe_primes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);

--- a/app/implementations/openssl/3/registrations/fp_312.c
+++ b/app/implementations/openssl/3/registrations/fp_312.c
@@ -64,7 +64,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable AES_GCM */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &app_aes_handler_aead);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &app_aes_handler_aead);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -107,7 +107,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-ECB 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_ECB, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_ECB, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -125,7 +125,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CBC 128 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -143,7 +143,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CBC-CS1, CS2, and CS3 */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS1, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS1, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -156,7 +156,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -169,7 +169,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -183,7 +183,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB1 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB1, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -201,7 +201,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB8 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB8, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB8, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -219,7 +219,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB128 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB128, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB128, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -237,7 +237,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-OFB 128, 192, 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_OFB, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_OFB, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -255,7 +255,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Register AES CCM capabilities */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CCM, &app_aes_handler_aead);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CCM, &app_aes_handler_aead);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -295,7 +295,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* AES-KW */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KW, &app_aes_keywrap_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KW, &app_aes_keywrap_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -316,7 +316,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -334,7 +334,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-XTS 128 and 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XTS, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XTS, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -349,7 +349,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CTR 128, 192, 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CTR, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CTR, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -373,7 +373,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     //GMAC
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GMAC, &app_aes_handler_gmac);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GMAC, &app_aes_handler_gmac);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GMAC, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -425,44 +425,44 @@ static int enable_hash(ACVP_CTX *ctx) {
     int i = 0;
 
     /* Enable SHA-1 and SHA-2 */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA384, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA384, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
     /* SHA2-512/224 and SHA2-512/256 */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
     /* SHA3 and SHAKE */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -471,7 +471,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -480,7 +480,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_384, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_384, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -489,7 +489,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_512, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_512, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -498,7 +498,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_128, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHAKE_128, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -510,7 +510,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHAKE_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_256, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -554,7 +554,7 @@ static int enable_cmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable CMAC */
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &app_cmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &app_cmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_AES, ACVP_CMAC_MSGLEN, 0, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -582,7 +582,7 @@ static int enable_kmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable KMAC */
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_128, &app_kmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_128, &app_kmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_128, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -596,7 +596,7 @@ static int enable_kmac(ACVP_CTX *ctx) {
     rv = acvp_cap_kmac_set_parm(ctx, ACVP_KMAC_128, ACVP_KMAC_HEX_CUSTOM_SUPPORT, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_256, &app_kmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_256, &app_kmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_256, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -616,7 +616,7 @@ end:
 static int enable_hmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -625,7 +625,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA1, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -634,7 +634,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -643,7 +643,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -652,7 +652,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_384, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -661,7 +661,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_224, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -670,7 +670,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_256, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -679,7 +679,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_224, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -688,7 +688,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_256, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -697,7 +697,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_384, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -706,7 +706,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_384, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_512, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -723,7 +723,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     int flags = 0;
 
-    rv = acvp_cap_kdf_tls12_enable(ctx, &app_kdf_tls12_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS12, &app_kdf_tls12_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -737,7 +737,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
 
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &app_kdf135_ssh_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &app_kdf135_ssh_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -761,7 +761,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
 
 
 
-    rv = acvp_cap_kdf135_x942_enable(ctx, &app_kdf135_x942_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X942, &app_kdf135_x942_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X942, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -804,7 +804,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_OID, ACVP_KDF_X942_OID_AES256KW);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf135_x963_enable(ctx, &app_kdf135_x963_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &app_kdf135_x963_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -830,7 +830,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* KDF108 Counter Mode */
-    rv = acvp_cap_kdf108_enable(ctx, &app_kdf108_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &app_kdf108_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -947,7 +947,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* PBKDF */
-    rv = acvp_cap_pbkdf_enable(ctx, &app_pbkdf_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_PBKDF, &app_pbkdf_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_PBKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -983,7 +983,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_pbkdf_set_domain(ctx, ACVP_PBKDF_SALT_LEN, 128, 4096, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf_tls13_enable(ctx, &app_kdf_tls13_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS13, &app_kdf_tls13_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS13, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1007,7 +1007,7 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable KAS-ECC.... */
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1038,7 +1038,7 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_SSC, &app_kas_ecc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_SSC, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_PREREQ_ECDSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1094,7 +1094,7 @@ static int enable_kas_ifc(ACVP_CTX *ctx) {
     expo_str = BN_bn2hex(expo);
     BN_free(expo);
 
-    rv = acvp_cap_kas_ifc_enable(ctx, ACVP_KAS_IFC_SSC, &app_kas_ifc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_IFC_SSC, &app_kas_ifc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_RSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1156,7 +1156,7 @@ static int enable_kts_ifc(ACVP_CTX *ctx) {
     expo_str = BN_bn2hex(expo);
     BN_free(expo);
 
-    rv = acvp_cap_kts_ifc_enable(ctx, ACVP_KTS_IFC, &app_kts_ifc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KTS_IFC, &app_kts_ifc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KTS_IFC, ACVP_PREREQ_RSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1236,7 +1236,7 @@ end:
 static int enable_kas_ffc(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_SSC, &app_kas_ffc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_SSC, &app_kas_ffc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_SAFE_PRIMES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1284,7 +1284,7 @@ end:
 static int enable_kda(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_HKDF, &app_kda_hkdf_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_HKDF, &app_kda_hkdf_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_HKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1332,7 +1332,7 @@ static int enable_kda(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     // kdf onestep
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1407,7 +1407,7 @@ static int enable_kda(ACVP_CTX *ctx) {
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_L, 2048, NULL);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_TWOSTEP, &app_kda_twostep_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_TWOSTEP, &app_kda_twostep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_TWOSTEP, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1474,7 +1474,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable DSA.... */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGGEN, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGGEN, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1515,7 +1515,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGGEN, ACVP_DSA_MODE_PQGGEN, ACVP_DSA_LN3072_256, ACVP_SHA512_256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGVER, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1571,7 +1571,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN3072_256, ACVP_SHA512_256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_KEYGEN, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_KEYGEN, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1584,7 +1584,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_KEYGEN, ACVP_DSA_MODE_KEYGEN, ACVP_DSA_LN3072_256, ACVP_NO_SHA);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGGEN, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGGEN, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1627,7 +1627,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGGEN, ACVP_DSA_MODE_SIGGEN, ACVP_DSA_LN3072_256, ACVP_SHA512_256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGVER, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGVER, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1708,7 +1708,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     BN_free(expo);
 
     /* Enable RSA keygen... */
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1741,7 +1741,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable siggen */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1849,7 +1849,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable sigver */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGVER, &app_rsa_sig_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGVER, &app_rsa_sig_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2020,7 +2020,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable Signature Primitive */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGPRIM, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2047,7 +2047,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable ECDSA keyGen... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2083,7 +2083,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA keyVer... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYVER, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2123,7 +2123,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA sigGen... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGGEN, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGGEN, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2180,7 +2180,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA sigVer... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGVER, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGVER, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2250,7 +2250,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Hash DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_set_prereq(ctx, ACVP_HASHDRBG, ACVP_PREREQ_SHA, value);
@@ -2284,7 +2284,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
 
 
     /* HMAC DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMACDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2318,7 +2318,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* CTR DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_CTRDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_CTRDRBG, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2419,7 +2419,7 @@ static int enable_safe_primes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Register Safe Prime Key Generation testing */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYGEN, &app_safe_primes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYGEN, &app_safe_primes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2447,7 +2447,7 @@ static int enable_safe_primes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Register Safe Prime Key Verify testing */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYVER, &app_safe_primes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYVER, &app_safe_primes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);

--- a/app/implementations/openssl/3/registrations/fp_340.c
+++ b/app/implementations/openssl/3/registrations/fp_340.c
@@ -66,7 +66,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable AES_GCM */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &app_aes_handler_aead);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &app_aes_handler_aead);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -109,7 +109,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-ECB 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_ECB, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_ECB, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -127,7 +127,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CBC 128 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -145,7 +145,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CBC-CS1, CS2, and CS3 */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS1, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS1, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -158,7 +158,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
     CHECK_ENABLE_CAP_RV(rv);
     
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -171,7 +171,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -185,7 +185,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB1 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB1, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -203,7 +203,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB8 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB8, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB8, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -221,7 +221,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB128 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB128, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB128, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -239,7 +239,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-OFB 128, 192, 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_OFB, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_OFB, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -257,7 +257,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Register AES CCM capabilities */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CCM, &app_aes_handler_aead);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CCM, &app_aes_handler_aead);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -297,7 +297,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* AES-KW */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KW, &app_aes_keywrap_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KW, &app_aes_keywrap_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -318,7 +318,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -336,7 +336,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-XTS 128 and 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XTS, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XTS, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -351,7 +351,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CTR 128, 192, 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CTR, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CTR, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -375,7 +375,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     //GMAC
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GMAC, &app_aes_handler_gmac);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GMAC, &app_aes_handler_gmac);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GMAC, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -427,44 +427,44 @@ static int enable_hash(ACVP_CTX *ctx) {
     int i = 0;
 
     /* Enable SHA-1 and SHA-2 */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA384, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA384, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
     /* SHA2-512/224 and SHA2-512/256 */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
     /* SHA3 and SHAKE */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -473,7 +473,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -482,7 +482,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_384, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_384, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -491,7 +491,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_512, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_512, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -500,7 +500,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_128, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHAKE_128, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -512,7 +512,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHAKE_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_256, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -556,7 +556,7 @@ static int enable_cmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable CMAC */
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &app_cmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &app_cmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_AES, ACVP_CMAC_MSGLEN, 0, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -584,7 +584,7 @@ static int enable_kmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable KMAC */
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_128, &app_kmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_128, &app_kmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_128, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -598,7 +598,7 @@ static int enable_kmac(ACVP_CTX *ctx) {
     rv = acvp_cap_kmac_set_parm(ctx, ACVP_KMAC_128, ACVP_KMAC_HEX_CUSTOM_SUPPORT, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_256, &app_kmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_256, &app_kmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_256, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -618,7 +618,7 @@ end:
 static int enable_hmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -627,7 +627,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA1, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -636,7 +636,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -645,7 +645,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -654,7 +654,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_384, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -663,7 +663,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_224, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -672,7 +672,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_256, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -681,7 +681,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
     
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_224, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -690,7 +690,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
     
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_256, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -699,7 +699,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
     
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_384, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -708,7 +708,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_384, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
     
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_512, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -725,7 +725,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     int flags = 0;
 
-    rv = acvp_cap_kdf_tls12_enable(ctx, &app_kdf_tls12_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS12, &app_kdf_tls12_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -739,7 +739,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
 
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &app_kdf135_ssh_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &app_kdf135_ssh_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -759,7 +759,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
 
 
 
-    rv = acvp_cap_kdf135_x942_enable(ctx, &app_kdf135_x942_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X942, &app_kdf135_x942_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X942, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -802,7 +802,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_OID, ACVP_KDF_X942_OID_AES256KW);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf135_x963_enable(ctx, &app_kdf135_x963_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &app_kdf135_x963_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -828,7 +828,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* KDF108 Counter Mode */
-    rv = acvp_cap_kdf108_enable(ctx, &app_kdf108_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &app_kdf108_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -945,7 +945,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* PBKDF */
-    rv = acvp_cap_pbkdf_enable(ctx, &app_pbkdf_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_PBKDF, &app_pbkdf_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_PBKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -981,7 +981,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_pbkdf_set_domain(ctx, ACVP_PBKDF_SALT_LEN, 128, 4096, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf_tls13_enable(ctx, &app_kdf_tls13_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS13, &app_kdf_tls13_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS13, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1005,7 +1005,7 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable KAS-ECC.... */
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1036,7 +1036,7 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_SSC, &app_kas_ecc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_SSC, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_PREREQ_ECDSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1092,7 +1092,7 @@ static int enable_kas_ifc(ACVP_CTX *ctx) {
     expo_str = BN_bn2hex(expo);
     BN_free(expo);
 
-    rv = acvp_cap_kas_ifc_enable(ctx, ACVP_KAS_IFC_SSC, &app_kas_ifc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_IFC_SSC, &app_kas_ifc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_RSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1154,7 +1154,7 @@ static int enable_kts_ifc(ACVP_CTX *ctx) {
     expo_str = BN_bn2hex(expo);
     BN_free(expo);
 
-    rv = acvp_cap_kts_ifc_enable(ctx, ACVP_KTS_IFC, &app_kts_ifc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KTS_IFC, &app_kts_ifc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KTS_IFC, ACVP_PREREQ_RSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1234,7 +1234,7 @@ end:
 static int enable_kas_ffc(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_SSC, &app_kas_ffc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_SSC, &app_kas_ffc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_SAFE_PRIMES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1282,7 +1282,7 @@ end:
 static int enable_kda(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_HKDF, &app_kda_hkdf_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_HKDF, &app_kda_hkdf_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_HKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1330,7 +1330,7 @@ static int enable_kda(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     // kdf onestep
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1405,7 +1405,7 @@ static int enable_kda(ACVP_CTX *ctx) {
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_L, 2048, NULL);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_TWOSTEP, &app_kda_twostep_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_TWOSTEP, &app_kda_twostep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_TWOSTEP, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1471,7 +1471,7 @@ end:
 static int enable_dsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGVER, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1527,7 +1527,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN3072_256, ACVP_SHA512_256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGVER, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGVER, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1608,7 +1608,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     BN_free(expo);
 
     /* Enable RSA keygen... */
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1633,7 +1633,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable siggen */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1725,7 +1725,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable sigver */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGVER, &app_rsa_sig_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGVER, &app_rsa_sig_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1824,7 +1824,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable Signature Primitive */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGPRIM, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1846,7 +1846,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable Decryption Primitive */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_DECPRIM, &app_rsa_decprim_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_DECPRIM, &app_rsa_decprim_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_DECPRIM, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1877,7 +1877,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable ECDSA keyGen... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1911,7 +1911,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA keyVer... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYVER, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1943,7 +1943,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA sigGen... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGGEN, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGGEN, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1998,7 +1998,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA sigVer... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGVER, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGVER, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2057,21 +2057,21 @@ end:
 static int enable_eddsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_KEYGEN, &app_eddsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_EDDSA_KEYGEN, &app_eddsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_KEYVER, &app_eddsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_EDDSA_KEYVER, &app_eddsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_SIGGEN, &app_eddsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_EDDSA_SIGGEN, &app_eddsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2084,7 +2084,7 @@ static int enable_eddsa(ACVP_CTX *ctx) {
     rv = acvp_cap_eddsa_set_domain(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_CONTEXT_LEN, 0, 255, 1);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_SIGVER, &app_eddsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_EDDSA_SIGVER, &app_eddsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2102,7 +2102,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Hash DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_set_prereq(ctx, ACVP_HASHDRBG, ACVP_PREREQ_SHA, value);
@@ -2170,7 +2170,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
 
 
     /* HMAC DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMACDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2239,7 +2239,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* CTR DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_CTRDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_CTRDRBG, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2340,7 +2340,7 @@ static int enable_safe_primes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Register Safe Prime Key Generation testing */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYGEN, &app_safe_primes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYGEN, &app_safe_primes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2368,7 +2368,7 @@ static int enable_safe_primes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Register Safe Prime Key Verify testing */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYVER, &app_safe_primes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYVER, &app_safe_primes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);

--- a/app/implementations/openssl/3/registrations/fp_350.c
+++ b/app/implementations/openssl/3/registrations/fp_350.c
@@ -71,7 +71,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable AES_GCM */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &app_aes_handler_aead);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &app_aes_handler_aead);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -114,7 +114,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-ECB 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_ECB, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_ECB, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -132,7 +132,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CBC 128 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -150,7 +150,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CBC-CS1, CS2, and CS3 */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS1, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS1, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -163,7 +163,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -176,7 +176,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -190,7 +190,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB1 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB1, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -208,7 +208,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB8 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB8, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB8, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -226,7 +226,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB128 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB128, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB128, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -244,7 +244,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-OFB 128, 192, 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_OFB, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_OFB, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -262,7 +262,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Register AES CCM capabilities */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CCM, &app_aes_handler_aead);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CCM, &app_aes_handler_aead);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -302,7 +302,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* AES-KW */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KW, &app_aes_keywrap_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KW, &app_aes_keywrap_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -323,7 +323,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -341,7 +341,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-XTS 128 and 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XTS, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XTS, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -356,7 +356,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CTR 128, 192, 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CTR, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CTR, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -380,7 +380,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     //GMAC
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GMAC, &app_aes_handler_gmac);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GMAC, &app_aes_handler_gmac);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GMAC, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -428,44 +428,44 @@ static int enable_hash(ACVP_CTX *ctx) {
     int i = 0;
 
     /* Enable SHA-1 and SHA-2 */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA384, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA384, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
     /* SHA2-512/224 and SHA2-512/256 */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
     /* SHA3 and SHAKE */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -474,7 +474,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -483,7 +483,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_384, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_384, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -492,7 +492,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_512, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_512, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -501,7 +501,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_128, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHAKE_128, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -512,7 +512,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_OUT_LENGTH, 16, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHAKE_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_256, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -556,7 +556,7 @@ static int enable_cmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable CMAC */
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &app_cmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &app_cmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_AES, ACVP_CMAC_MSGLEN, 0, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -584,7 +584,7 @@ static int enable_kmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable KMAC */
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_128, &app_kmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_128, &app_kmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_128, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -598,7 +598,7 @@ static int enable_kmac(ACVP_CTX *ctx) {
     rv = acvp_cap_kmac_set_parm(ctx, ACVP_KMAC_128, ACVP_KMAC_HEX_CUSTOM_SUPPORT, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_256, &app_kmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_256, &app_kmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_256, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -618,7 +618,7 @@ end:
 static int enable_hmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -627,7 +627,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA1, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -636,7 +636,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -645,7 +645,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -654,7 +654,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_384, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -663,7 +663,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_224, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -672,7 +672,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_256, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -681,7 +681,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_224, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -690,7 +690,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_256, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -699,7 +699,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_384, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -708,7 +708,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_384, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_512, ACVP_HMAC_KEYLEN, 112, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -725,7 +725,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     int flags = 0;
 
-    rv = acvp_cap_kdf_tls12_enable(ctx, &app_kdf_tls12_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS12, &app_kdf_tls12_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -739,7 +739,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
 
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &app_kdf135_ssh_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &app_kdf135_ssh_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -759,7 +759,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
 
 
 
-    rv = acvp_cap_kdf135_x942_enable(ctx, &app_kdf135_x942_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X942, &app_kdf135_x942_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X942, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -802,7 +802,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_OID, ACVP_KDF_X942_OID_AES256KW);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf135_x963_enable(ctx, &app_kdf135_x963_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &app_kdf135_x963_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -828,7 +828,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* KDF108 Counter Mode */
-    rv = acvp_cap_kdf108_enable(ctx, &app_kdf108_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &app_kdf108_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -945,7 +945,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* PBKDF */
-    rv = acvp_cap_pbkdf_enable(ctx, &app_pbkdf_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_PBKDF, &app_pbkdf_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_PBKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -981,7 +981,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_pbkdf_set_domain(ctx, ACVP_PBKDF_SALT_LEN, 128, 4096, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf_tls13_enable(ctx, &app_kdf_tls13_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS13, &app_kdf_tls13_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS13, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1005,7 +1005,7 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable KAS-ECC.... */
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1036,7 +1036,7 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_SSC, &app_kas_ecc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_SSC, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_PREREQ_ECDSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1092,7 +1092,7 @@ static int enable_kas_ifc(ACVP_CTX *ctx) {
     expo_str = BN_bn2hex(expo);
     BN_free(expo);
 
-    rv = acvp_cap_kas_ifc_enable(ctx, ACVP_KAS_IFC_SSC, &app_kas_ifc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_IFC_SSC, &app_kas_ifc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_RSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1154,7 +1154,7 @@ static int enable_kts_ifc(ACVP_CTX *ctx) {
     expo_str = BN_bn2hex(expo);
     BN_free(expo);
 
-    rv = acvp_cap_kts_ifc_enable(ctx, ACVP_KTS_IFC, &app_kts_ifc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KTS_IFC, &app_kts_ifc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KTS_IFC, ACVP_PREREQ_RSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1234,7 +1234,7 @@ end:
 static int enable_kas_ffc(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_SSC, &app_kas_ffc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_SSC, &app_kas_ffc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_SAFE_PRIMES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1282,7 +1282,7 @@ end:
 static int enable_kda(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_HKDF, &app_kda_hkdf_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_HKDF, &app_kda_hkdf_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_HKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1330,7 +1330,7 @@ static int enable_kda(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     // kdf onestep
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1405,7 +1405,7 @@ static int enable_kda(ACVP_CTX *ctx) {
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_L, 2048, NULL);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_TWOSTEP, &app_kda_twostep_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_TWOSTEP, &app_kda_twostep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_TWOSTEP, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1471,7 +1471,7 @@ end:
 static int enable_dsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGVER, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1527,7 +1527,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN3072_256, ACVP_SHA512_256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGVER, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGVER, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1608,7 +1608,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     BN_free(expo);
 
     /* Enable RSA keygen... */
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1633,7 +1633,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable siggen */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1725,7 +1725,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable sigver */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGVER, &app_rsa_sig_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGVER, &app_rsa_sig_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1824,7 +1824,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable Signature Primitive */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGPRIM, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1846,7 +1846,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable Decryption Primitive */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_DECPRIM, &app_rsa_decprim_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_DECPRIM, &app_rsa_decprim_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_DECPRIM, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1877,7 +1877,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable ECDSA keyGen... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1911,7 +1911,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA keyVer... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYVER, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1943,7 +1943,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA sigGen... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGGEN, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGGEN, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1998,7 +1998,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA sigVer... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGVER, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGVER, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2057,21 +2057,21 @@ end:
 static int enable_eddsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_KEYGEN, &app_eddsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_EDDSA_KEYGEN, &app_eddsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_KEYVER, &app_eddsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_EDDSA_KEYVER, &app_eddsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_SIGGEN, &app_eddsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_EDDSA_SIGGEN, &app_eddsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2084,7 +2084,7 @@ static int enable_eddsa(ACVP_CTX *ctx) {
     rv = acvp_cap_eddsa_set_domain(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_CONTEXT_LEN, 0, 255, 1);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_SIGVER, &app_eddsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_EDDSA_SIGVER, &app_eddsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2102,7 +2102,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Hash DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_set_prereq(ctx, ACVP_HASHDRBG, ACVP_PREREQ_SHA, value);
@@ -2170,7 +2170,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
 
 
     /* HMAC DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMACDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2239,7 +2239,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* CTR DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_CTRDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_CTRDRBG, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2340,7 +2340,7 @@ static int enable_safe_primes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Register Safe Prime Key Generation testing */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYGEN, &app_safe_primes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYGEN, &app_safe_primes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2368,7 +2368,7 @@ static int enable_safe_primes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Register Safe Prime Key Verify testing */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYVER, &app_safe_primes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYVER, &app_safe_primes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2402,7 +2402,7 @@ end:
 static int enable_ml_kem(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_ml_kem_enable(ctx, ACVP_ML_KEM_KEYGEN, &app_ml_kem_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ML_KEM_KEYGEN, &app_ml_kem_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_KEYGEN, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_512);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2411,7 +2411,7 @@ static int enable_ml_kem(ACVP_CTX *ctx) {
     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_KEYGEN, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_1024);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_ml_kem_enable(ctx, ACVP_ML_KEM_XCAP, &app_ml_kem_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ML_KEM_XCAP, &app_ml_kem_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_512);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2431,7 +2431,7 @@ end:
 static int enable_ml_dsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_KEYGEN, &app_ml_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ML_DSA_KEYGEN, &app_ml_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_KEYGEN, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_44);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2440,7 +2440,7 @@ static int enable_ml_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_KEYGEN, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_87);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_SIGGEN, &app_ml_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ML_DSA_SIGGEN, &app_ml_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_DETERMINISTIC_MODE, ACVP_DETERMINISTIC_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2461,7 +2461,7 @@ static int enable_ml_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_ml_dsa_set_domain(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_CONTEXT_LEN, 0, 2040, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_SIGVER, &app_ml_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ML_DSA_SIGVER, &app_ml_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_SIG_INTERFACE, ACVP_SIG_INTERFACE_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2487,7 +2487,7 @@ end:
 static int enable_slh_dsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_slh_dsa_enable(ctx, ACVP_SLH_DSA_KEYGEN, &app_slh_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SLH_DSA_KEYGEN, &app_slh_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_128S);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2514,7 +2514,7 @@ static int enable_slh_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_256F);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_slh_dsa_enable(ctx, ACVP_SLH_DSA_SIGGEN, &app_slh_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SLH_DSA_SIGGEN, &app_slh_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_DETERMINISTIC_MODE, ACVP_DETERMINISTIC_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2551,7 +2551,7 @@ static int enable_slh_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_slh_dsa_set_domain(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_CONTEXT_LEN, 0, 2040, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_slh_dsa_enable(ctx, ACVP_SLH_DSA_SIGVER, &app_slh_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SLH_DSA_SIGVER, &app_slh_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_SIG_INTERFACE, ACVP_SIG_INTERFACE_BOTH);
     CHECK_ENABLE_CAP_RV(rv);

--- a/app/implementations/openssl/3/registrations/non_fips.c
+++ b/app/implementations/openssl/3/registrations/non_fips.c
@@ -72,7 +72,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable AES_GCM */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &app_aes_handler_aead);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &app_aes_handler_aead);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -115,7 +115,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-ECB 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_ECB, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_ECB, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -133,7 +133,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CBC 128 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -151,7 +151,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CBC-CS1, CS2, and CS3 */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS1, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS1, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -164,7 +164,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -177,7 +177,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -191,7 +191,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB1 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB1, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -209,7 +209,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB8 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB8, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB8, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -227,7 +227,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CFB128 128,192,256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB128, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB128, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -245,7 +245,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-OFB 128, 192, 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_OFB, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_OFB, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -263,7 +263,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Register AES CCM capabilities */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CCM, &app_aes_handler_aead);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CCM, &app_aes_handler_aead);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -303,7 +303,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* AES-KW */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KW, &app_aes_keywrap_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KW, &app_aes_keywrap_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -325,7 +325,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -343,7 +343,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-XTS 128 and 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XTS, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XTS, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -358,7 +358,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable AES-CTR 128, 192, 256 bit key */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CTR, &app_aes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CTR, &app_aes_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -382,7 +382,7 @@ static int enable_aes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     //GMAC
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GMAC, &app_aes_handler_gmac);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GMAC, &app_aes_handler_gmac);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GMAC, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -430,7 +430,7 @@ static int enable_tdes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable 3DES-ECB */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_ECB, &app_des_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_ECB, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -438,7 +438,7 @@ static int enable_tdes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable 3DES-CBC */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBC, &app_des_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CBC, &app_des_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
@@ -454,44 +454,44 @@ static int enable_hash(ACVP_CTX *ctx) {
     int i = 0;
 
     /* Enable SHA-1 and SHA-2 */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA384, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA384, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
     /* SHA2-512/224 and SHA2-512/256 */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
     /* SHA3 and SHAKE */
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -500,7 +500,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -509,7 +509,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_384, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_384, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -518,7 +518,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_512, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA3_512, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -527,7 +527,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_128, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHAKE_128, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -538,7 +538,7 @@ static int enable_hash(ACVP_CTX *ctx) {
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_OUT_LENGTH, 16, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_256, &app_sha_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHAKE_256, &app_sha_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_256, ACVP_HASH_IN_BIT, 0);
     CHECK_ENABLE_CAP_RV(rv);
@@ -570,7 +570,7 @@ static int enable_cmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable CMAC */
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &app_cmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &app_cmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_AES, ACVP_CMAC_MSGLEN, 0, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -598,7 +598,7 @@ static int enable_kmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable KMAC */
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_128, &app_kmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_128, &app_kmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_128, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -612,7 +612,7 @@ static int enable_kmac(ACVP_CTX *ctx) {
     rv = acvp_cap_kmac_set_parm(ctx, ACVP_KMAC_128, ACVP_KMAC_HEX_CUSTOM_SUPPORT, 0);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_256, &app_kmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_256, &app_kmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_256, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -632,7 +632,7 @@ end:
 static int enable_hmac(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -641,7 +641,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA1, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -650,7 +650,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -659,7 +659,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -668,7 +668,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_384, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -677,7 +677,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_224, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -686,7 +686,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_256, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -695,7 +695,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_224, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -704,7 +704,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_224, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_256, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -713,7 +713,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_256, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_384, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -722,7 +722,7 @@ static int enable_hmac(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_384, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_512, ACVP_HMAC_KEYLEN, 8, 524288, 8);
     CHECK_ENABLE_CAP_RV(rv);
@@ -739,7 +739,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
     int flags = 0;
 
-    rv = acvp_cap_kdf_tls12_enable(ctx, &app_kdf_tls12_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS12, &app_kdf_tls12_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -752,7 +752,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf_tls12_set_parm(ctx, ACVP_KDF_TLS12_HASH_ALG, ACVP_SHA512);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &app_kdf135_ssh_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &app_kdf135_ssh_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -774,7 +774,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf135_ssh_set_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_256_CBC, flags);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf135_x942_enable(ctx, &app_kdf135_x942_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X942, &app_kdf135_x942_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X942, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -817,7 +817,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_OID, ACVP_KDF_X942_OID_AES256KW);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf135_x963_enable(ctx, &app_kdf135_x963_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &app_kdf135_x963_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -843,7 +843,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* KDF108 Counter Mode */
-    rv = acvp_cap_kdf108_enable(ctx, &app_kdf108_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &app_kdf108_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -924,7 +924,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     /* KDF108 KMAC Mode */
 
     /* PBKDF */
-    rv = acvp_cap_pbkdf_enable(ctx, &app_pbkdf_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_PBKDF, &app_pbkdf_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_PBKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -952,7 +952,7 @@ static int enable_kdf(ACVP_CTX *ctx) {
     rv = acvp_cap_pbkdf_set_domain(ctx, ACVP_PBKDF_SALT_LEN, 128, 4096, 8);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kdf_tls13_enable(ctx, &app_kdf_tls13_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS13, &app_kdf_tls13_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS13, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -976,7 +976,7 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable KAS-ECC.... */
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1007,7 +1007,7 @@ static int enable_kas_ecc(ACVP_CTX *ctx) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_SSC, &app_kas_ecc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_SSC, &app_kas_ecc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_PREREQ_ECDSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1062,7 +1062,7 @@ static int enable_kas_ifc(ACVP_CTX *ctx) {
     expo_str = BN_bn2hex(expo);
     BN_free(expo);
 
-    rv = acvp_cap_kas_ifc_enable(ctx, ACVP_KAS_IFC_SSC, &app_kas_ifc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_IFC_SSC, &app_kas_ifc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_RSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1125,7 +1125,7 @@ static int enable_kts_ifc(ACVP_CTX *ctx) {
     expo_str = BN_bn2hex(expo);
     BN_free(expo);
 
-    rv = acvp_cap_kts_ifc_enable(ctx, ACVP_KTS_IFC, &app_kts_ifc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KTS_IFC, &app_kts_ifc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KTS_IFC, ACVP_PREREQ_RSA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1205,7 +1205,7 @@ end:
 static int enable_kas_ffc(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_SSC, &app_kas_ffc_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_SSC, &app_kas_ffc_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_SAFE_PRIMES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1243,7 +1243,7 @@ end:
 static int enable_kda(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_HKDF, &app_kda_hkdf_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_HKDF, &app_kda_hkdf_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_HKDF, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1290,7 +1290,7 @@ static int enable_kda(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     // kdf onestep
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1324,7 +1324,7 @@ static int enable_kda(ACVP_CTX *ctx) {
     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_L, 2048, NULL);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_TWOSTEP, &app_kda_twostep_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_TWOSTEP, &app_kda_twostep_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_TWOSTEP, ACVP_PREREQ_HMAC, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1389,7 +1389,7 @@ end:
 static int enable_dsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGVER, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1445,7 +1445,7 @@ static int enable_dsa(ACVP_CTX *ctx) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN3072_256, ACVP_SHA512_256);
     CHECK_ENABLE_CAP_RV(rv);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGVER, &app_dsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGVER, &app_dsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1527,7 +1527,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     BN_free(expo);
 
     /* Enable RSA keygen... */
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1540,7 +1540,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable siggen */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1613,7 +1613,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable sigver */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGVER, &app_rsa_sig_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGVER, &app_rsa_sig_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1695,7 +1695,7 @@ static int enable_rsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable Signature Primitive */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGPRIM, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1723,7 +1723,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Enable ECDSA keyGen... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1742,7 +1742,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA keyVer... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYVER, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1759,7 +1759,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA sigGen... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGGEN, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGGEN, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1790,7 +1790,7 @@ static int enable_ecdsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Enable ECDSA sigVer... */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGVER, &app_ecdsa_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGVER, &app_ecdsa_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -1827,7 +1827,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Hash DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
 
     rv = acvp_cap_set_prereq(ctx, ACVP_HASHDRBG, ACVP_PREREQ_SHA, value);
@@ -1916,7 +1916,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* HMAC DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMACDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, ACVP_PREREQ_SHA, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2006,7 +2006,7 @@ static int enable_drbg(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* CTR DRBG */
-    rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &app_drbg_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_CTRDRBG, &app_drbg_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_CTRDRBG, ACVP_PREREQ_AES, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2107,7 +2107,7 @@ static int enable_safe_primes(ACVP_CTX *ctx) {
     ACVP_RESULT rv = ACVP_SUCCESS;
 
     /* Register Safe Prime Key Generation testing */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYGEN, &app_safe_primes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYGEN, &app_safe_primes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2125,7 +2125,7 @@ static int enable_safe_primes(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
 
     /* Register Safe Prime Key Verify testing */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYVER, &app_safe_primes_handler);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYVER, &app_safe_primes_handler);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_PREREQ_DRBG, value);
     CHECK_ENABLE_CAP_RV(rv);

--- a/ms/resources/Source.def
+++ b/ms/resources/Source.def
@@ -1,32 +1,22 @@
 LIBRARY libacvp
 EXPORTS
-  acvp_cap_sym_cipher_enable
+  acvp_enable_algorithm
   acvp_cap_sym_cipher_set_parm
   acvp_cap_sym_cipher_set_domain
   acvp_cap_sym_cipher_set_parm_string
   acvp_cap_sym_cipher_set_iv_modes
-  acvp_cap_hash_enable
   acvp_cap_hash_set_parm
   acvp_cap_hash_set_domain
-  acvp_cap_drbg_enable
   acvp_cap_drbg_set_parm
   acvp_cap_drbg_set_length
-  acvp_cap_dsa_enable
   acvp_cap_dsa_set_parm
-  acvp_cap_safe_primes_enable
   acvp_cap_safe_primes_set_parm
-  acvp_cap_kas_ecc_enable
   acvp_cap_kas_ecc_set_prereq
   acvp_cap_kas_ecc_set_parm
   acvp_cap_kas_ecc_set_scheme
-  acvp_cap_kas_ffc_enable
   acvp_cap_kas_ffc_set_prereq
   acvp_cap_kas_ffc_set_parm
   acvp_cap_kas_ffc_set_scheme
-  acvp_cap_rsa_keygen_enable
-  acvp_cap_rsa_sig_enable
-  acvp_cap_ecdsa_enable
-  acvp_cap_eddsa_enable
   acvp_cap_eddsa_set_parm
   acvp_cap_eddsa_set_domain
   acvp_cap_rsa_keygen_set_parm
@@ -41,29 +31,17 @@ EXPORTS
   acvp_cap_rsa_keygen_set_exponent
   acvp_cap_rsa_sigver_set_exponent
   acvp_cap_rsa_keygen_set_primes
-  acvp_cap_rsa_prim_enable
   acvp_cap_rsa_prim_set_parm
   acvp_cap_rsa_prim_set_exponent
   acvp_cap_rsa_siggen_set_parm
   acvp_cap_rsa_siggen_set_mod_mask
   acvp_cap_rsa_sigver_set_mod_mask
-  acvp_cap_hmac_enable
   acvp_cap_hmac_set_parm
   acvp_cap_hmac_set_domain
-  acvp_cap_cmac_enable
   acvp_cap_cmac_set_parm
   acvp_cap_cmac_set_domain
-  acvp_cap_kmac_enable
   acvp_cap_kmac_set_parm
   acvp_cap_kmac_set_domain
-  acvp_cap_kdf135_snmp_enable
-  acvp_cap_kdf135_ssh_enable
-  acvp_cap_kdf135_srtp_enable
-  acvp_cap_kdf135_ikev2_enable
-  acvp_cap_kdf135_ikev1_enable
-  acvp_cap_kdf135_x942_enable
-  acvp_cap_kdf135_x963_enable
-  acvp_cap_kdf108_enable
   acvp_cap_kdf135_ssh_set_parm
   acvp_cap_kdf135_srtp_set_parm
   acvp_cap_kdf108_set_parm
@@ -78,22 +56,15 @@ EXPORTS
   acvp_cap_kdf135_ikev1_set_domain
   acvp_cap_kdf108_set_domain
   acvp_cap_kdf135_x942_set_domain
-  acvp_cap_pbkdf_enable
   acvp_cap_pbkdf_set_domain
   acvp_cap_pbkdf_set_parm
-  acvp_cap_kdf_tls12_enable
   acvp_cap_kdf_tls12_set_parm
-  acvp_cap_kdf_tls13_enable
   acvp_cap_kdf_tls13_set_parm
-  acvp_cap_lms_enable
   acvp_cap_lms_set_parm
   acvp_cap_lms_set_mode_compatability_pair
-  acvp_cap_ml_dsa_enable
   acvp_cap_ml_dsa_set_parm
   acvp_cap_ml_dsa_set_domain
-  acvp_cap_ml_kem_enable
   acvp_cap_ml_kem_set_parm
-  acvp_cap_slh_dsa_enable
   acvp_cap_slh_dsa_set_parm
   acvp_cap_slh_dsa_set_domain
   acvp_cap_set_prereq
@@ -136,15 +107,12 @@ EXPORTS
   acvp_mark_as_delete_only
   acvp_cancel_test_session
   acvp_get_vector_set_count
-  acvp_cap_kda_enable
   acvp_cap_kda_set_parm
   acvp_cap_kda_twostep_set_parm
   acvp_cap_kda_twostep_set_domain
   acvp_cap_kda_set_domain
-  acvp_cap_kas_ifc_enable
   acvp_cap_kas_ifc_set_parm
   acvp_cap_kas_ifc_set_exponent
-  acvp_cap_kts_ifc_enable
   acvp_cap_kts_ifc_set_parm
   acvp_cap_kts_ifc_set_scheme_parm
   acvp_cap_kts_ifc_set_param_string

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -3091,7 +3091,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
      */
     cap = acvp_locate_cap_entry(ctx, cipher);
     if (!cap) {
-        ACVP_LOG_ERR("Cap entry not found, use acvp_cap_sym_cipher_enable() first.");
+        ACVP_LOG_ERR("Cap entry not found, use acvp_enable_algorithm() first.");
         return ACVP_NO_CAP;
     }
 
@@ -3448,7 +3448,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm_string(ACVP_CTX *ctx,
      */
     cap = acvp_locate_cap_entry(ctx, cipher);
     if (!cap) {
-        ACVP_LOG_ERR("Cap entry not found, use acvp_cap_sym_cipher_enable() first.");
+        ACVP_LOG_ERR("Cap entry not found, use acvp_enable_algorithm() first.");
         return ACVP_NO_CAP;
     }
 
@@ -3641,7 +3641,7 @@ ACVP_RESULT acvp_cap_sym_cipher_set_iv_modes(ACVP_CTX *ctx,
      */
     cap = acvp_locate_cap_entry(ctx, cipher);
     if (!cap) {
-        ACVP_LOG_ERR("Cap entry not found, use acvp_cap_sym_cipher_enable() first.");
+        ACVP_LOG_ERR("Cap entry not found, use acvp_enable_algorithm() first.");
         return ACVP_NO_CAP;
     }
 
@@ -3667,23 +3667,9 @@ ACVP_RESULT acvp_cap_sym_cipher_set_iv_modes(ACVP_CTX *ctx,
     return ACVP_SUCCESS;
 }
 
-/*
- * This function is called by the application to register a crypto
- * capability for symmetric ciphers, along with a handler that the
- * application implements when that particular crypto operation is
- * needed by libacvp.
- *
- * This function should be called one or more times for each crypto
- * capability supported by the crypto module being validated.  This
- * needs to be called after acvp_create_test_session() and prior to
- * calling acvp_register().
- *
- */
-ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
-                                       ACVP_CIPHER cipher,
-                                       int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
+ACVP_RESULT acvp_enable_algorithm(ACVP_CTX *ctx, ACVP_CIPHER cipher, int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
+    ACVP_RESULT result = ACVP_UNSUPPORTED_OP;
+    ACVP_CAP_TYPE type = 0;
     if (!ctx) {
         return ACVP_NO_CTX;
     }
@@ -3726,8 +3712,8 @@ ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
     case ACVP_TDES_CFBP64:
     case ACVP_TDES_CTR:
     case ACVP_TDES_KW:
+        type = ACVP_SYM_TYPE;
         break;
-    case ACVP_CIPHER_START:
     case ACVP_HASH_SHA1:
     case ACVP_HASH_SHA224:
     case ACVP_HASH_SHA256:
@@ -3741,9 +3727,13 @@ ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
     case ACVP_HASH_SHA3_512:
     case ACVP_HASH_SHAKE_128:
     case ACVP_HASH_SHAKE_256:
+        type = ACVP_HASH_TYPE;
+        break;
     case ACVP_HASHDRBG:
     case ACVP_HMACDRBG:
     case ACVP_CTRDRBG:
+        type = ACVP_DRBG_TYPE;
+        break;
     case ACVP_HMAC_SHA1:
     case ACVP_HMAC_SHA2_224:
     case ACVP_HMAC_SHA2_256:
@@ -3755,122 +3745,178 @@ ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
     case ACVP_HMAC_SHA3_256:
     case ACVP_HMAC_SHA3_384:
     case ACVP_HMAC_SHA3_512:
+        type = ACVP_HMAC_TYPE;
+        break;
     case ACVP_CMAC_AES:
     case ACVP_CMAC_TDES:
+        type = ACVP_CMAC_TYPE;
+        break;
     case ACVP_KMAC_128:
     case ACVP_KMAC_256:
+        type = ACVP_KMAC_TYPE;
+        break;
     case ACVP_DSA_KEYGEN:
     case ACVP_DSA_PQGGEN:
     case ACVP_DSA_PQGVER:
     case ACVP_DSA_SIGGEN:
     case ACVP_DSA_SIGVER:
+        type = ACVP_DSA_TYPE;
+        break;
     case ACVP_RSA_KEYGEN:
+        type = ACVP_RSA_KEYGEN_TYPE;
+        break;
     case ACVP_RSA_SIGGEN:
+        type = ACVP_RSA_SIGGEN_TYPE;
+        break;
     case ACVP_RSA_SIGVER:
+        type = ACVP_RSA_SIGVER_TYPE;
+        break;
     case ACVP_RSA_SIGPRIM:
     case ACVP_RSA_DECPRIM:
+        type = ACVP_RSA_PRIM_TYPE;
+        break;
     case ACVP_ECDSA_KEYGEN:
+        type = ACVP_ECDSA_KEYGEN_TYPE;
+        break;
     case ACVP_ECDSA_KEYVER:
+        type = ACVP_ECDSA_KEYVER_TYPE;
+        break;
     case ACVP_ECDSA_SIGGEN:
+        type = ACVP_ECDSA_SIGGEN_TYPE;
+        break;
     case ACVP_ECDSA_SIGVER:
+        type = ACVP_ECDSA_SIGVER_TYPE;
+        break;
     case ACVP_DET_ECDSA_SIGGEN:
+        type = ACVP_DET_ECDSA_SIGGEN_TYPE;
+        break;
     case ACVP_EDDSA_KEYGEN:
+        type = ACVP_EDDSA_KEYGEN_TYPE;
+        break;
     case ACVP_EDDSA_KEYVER:
+        type = ACVP_EDDSA_KEYVER_TYPE;
+        break;
     case ACVP_EDDSA_SIGGEN:
+        type = ACVP_EDDSA_SIGGEN_TYPE;
+        break;
     case ACVP_EDDSA_SIGVER:
+        type = ACVP_EDDSA_SIGVER_TYPE;
+        break;
     case ACVP_KDF135_SNMP:
+        type = ACVP_KDF135_SNMP_TYPE;
+        break;
     case ACVP_KDF135_SSH:
+        type = ACVP_KDF135_SSH_TYPE;
+        break;
     case ACVP_KDF135_SRTP:
+        type = ACVP_KDF135_SRTP_TYPE;
+        break;
     case ACVP_KDF135_IKEV2:
+        type = ACVP_KDF135_IKEV2_TYPE;
+        break;
     case ACVP_KDF135_IKEV1:
+        type = ACVP_KDF135_IKEV1_TYPE;
+        break;
     case ACVP_KDF135_X942:
+        type = ACVP_KDF135_X942_TYPE;
+        break;
     case ACVP_KDF135_X963:
+        type = ACVP_KDF135_X963_TYPE;
+        break;
     case ACVP_KDF108:
+        type = ACVP_KDF108_TYPE;
+        break;
     case ACVP_PBKDF:
+        type = ACVP_PBKDF_TYPE;
+        break;
     case ACVP_KDF_TLS12:
+        type = ACVP_KDF_TLS12_TYPE;
+        break;
     case ACVP_KDF_TLS13:
+        type = ACVP_KDF_TLS13_TYPE;
+        break;
     case ACVP_KAS_ECC_CDH:
+        type = ACVP_KAS_ECC_CDH_TYPE;
+        break;
     case ACVP_KAS_ECC_COMP:
+        type = ACVP_KAS_ECC_COMP_TYPE;
+        break;
     case ACVP_KAS_ECC_NOCOMP:
+        type = ACVP_KAS_ECC_NOCOMP_TYPE;
+        break;
     case ACVP_KAS_ECC_SSC:
+        type = ACVP_KAS_ECC_SSC_TYPE;
+        break;
     case ACVP_KAS_FFC_COMP:
-    case ACVP_KAS_FFC_NOCOMP:
-    case ACVP_KDA_ONESTEP:
-    case ACVP_KDA_TWOSTEP:
-    case ACVP_KDA_HKDF:
+        type = ACVP_KAS_FFC_COMP_TYPE;
+        break;
     case ACVP_KAS_FFC_SSC:
+        type = ACVP_KAS_FFC_SSC_TYPE;
+        break;
+    case ACVP_KAS_FFC_NOCOMP:
+        type = ACVP_KAS_FFC_NOCOMP_TYPE;
+        break;
     case ACVP_KAS_IFC_SSC:
+        type = ACVP_KAS_IFC_TYPE;
+        break;
+    case ACVP_KDA_ONESTEP:
+        type = ACVP_KDA_ONESTEP_TYPE;
+        break;
+    case ACVP_KDA_TWOSTEP:
+        type = ACVP_KDA_TWOSTEP_TYPE;
+        break;
+    case ACVP_KDA_HKDF:
+        type = ACVP_KDA_HKDF_TYPE;
+        break;
     case ACVP_KTS_IFC:
+        type = ACVP_KTS_IFC_TYPE;
+        break;
     case ACVP_SAFE_PRIMES_KEYGEN:
+        type = ACVP_SAFE_PRIMES_KEYGEN_TYPE;
+        break;
     case ACVP_SAFE_PRIMES_KEYVER:
-    case ACVP_LMS_SIGGEN:
-    case ACVP_LMS_SIGVER:
+        type = ACVP_SAFE_PRIMES_KEYVER_TYPE;
+        break;
     case ACVP_LMS_KEYGEN:
+        type = ACVP_LMS_KEYGEN_TYPE;
+        break;
+    case ACVP_LMS_SIGGEN:
+        type = ACVP_LMS_SIGGEN_TYPE;
+        break;
+    case ACVP_LMS_SIGVER:
+        type = ACVP_LMS_SIGVER_TYPE;
+        break;
     case ACVP_ML_DSA_KEYGEN:
+        type = ACVP_ML_DSA_KEYGEN_TYPE;
+        break;
     case ACVP_ML_DSA_SIGGEN:
+        type = ACVP_ML_DSA_SIGGEN_TYPE;
+        break;
     case ACVP_ML_DSA_SIGVER:
+        type = ACVP_ML_DSA_SIGVER_TYPE;
+        break;
     case ACVP_ML_KEM_KEYGEN:
+        type = ACVP_ML_KEM_KEYGEN_TYPE;
+        break;
     case ACVP_ML_KEM_XCAP:
+        type = ACVP_ML_KEM_XCAP_TYPE;
+        break;
     case ACVP_SLH_DSA_KEYGEN:
+        type = ACVP_SLH_DSA_KEYGEN_TYPE;
+        break;
     case ACVP_SLH_DSA_SIGGEN:
+        type = ACVP_SLH_DSA_SIGGEN_TYPE;
+        break;
     case ACVP_SLH_DSA_SIGVER:
+        type = ACVP_SLH_DSA_SIGVER_TYPE;
+        break;
+    case ACVP_CIPHER_START:
     case ACVP_CIPHER_END:
     default:
         return ACVP_INVALID_ARG;
     }
 
-    result = acvp_cap_list_append(ctx, ACVP_SYM_TYPE, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
-ACVP_RESULT acvp_cap_hash_enable(ACVP_CTX *ctx,
-                                 ACVP_CIPHER cipher,
-                                 int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-    ACVP_SUB_HASH alg;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_hash_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-
-    switch (alg) {
-    case ACVP_SUB_HASH_SHA1:
-    case ACVP_SUB_HASH_SHA2_224:
-    case ACVP_SUB_HASH_SHA2_256:
-    case ACVP_SUB_HASH_SHA2_384:
-    case ACVP_SUB_HASH_SHA2_512:
-    case ACVP_SUB_HASH_SHA2_512_224:
-    case ACVP_SUB_HASH_SHA2_512_256:
-    case ACVP_SUB_HASH_SHA3_224:
-    case ACVP_SUB_HASH_SHA3_256:
-    case ACVP_SUB_HASH_SHA3_384:
-    case ACVP_SUB_HASH_SHA3_512:
-    case ACVP_SUB_HASH_SHAKE_128:
-    case ACVP_SUB_HASH_SHAKE_256:
-        break;
-    default:
-        ACVP_LOG_ERR("Invalid parameter 'cipher'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_HASH_TYPE, cipher, crypto_handler);
+    result = acvp_cap_list_append(ctx, type, cipher, crypto_handler);
 
     if (result == ACVP_DUP_CIPHER) {
         ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
@@ -4180,54 +4226,6 @@ static ACVP_RESULT acvp_validate_hmac_parm_value(ACVP_CIPHER cipher,
     return retval;
 }
 
-ACVP_RESULT acvp_cap_hmac_enable(ACVP_CTX *ctx,
-                                 ACVP_CIPHER cipher,
-                                 int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-    ACVP_SUB_HMAC alg;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_hmac_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_HMAC_SHA1:
-    case ACVP_SUB_HMAC_SHA2_224:
-    case ACVP_SUB_HMAC_SHA2_256:
-    case ACVP_SUB_HMAC_SHA2_384:
-    case ACVP_SUB_HMAC_SHA2_512:
-    case ACVP_SUB_HMAC_SHA2_512_224:
-    case ACVP_SUB_HMAC_SHA2_512_256:
-    case ACVP_SUB_HMAC_SHA3_224:
-    case ACVP_SUB_HMAC_SHA3_256:
-    case ACVP_SUB_HMAC_SHA3_384:
-    case ACVP_SUB_HMAC_SHA3_512:
-        break;
-    default:
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_HMAC_TYPE, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
 ACVP_RESULT acvp_cap_hmac_set_domain(ACVP_CTX *ctx,
                                      ACVP_CIPHER cipher,
                                      ACVP_HMAC_PARM parm,
@@ -4367,44 +4365,6 @@ static ACVP_RESULT acvp_validate_cmac_parm_value(ACVP_CMAC_PARM parm, int value)
     return retval;
 }
 
-ACVP_RESULT acvp_cap_cmac_enable(ACVP_CTX *ctx,
-                                 ACVP_CIPHER cipher,
-                                 int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-    ACVP_SUB_CMAC alg;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_cmac_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_CMAC_AES:
-    case ACVP_SUB_CMAC_TDES:
-        break;
-    default:
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_CMAC_TYPE, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
 ACVP_RESULT acvp_cap_cmac_set_domain(ACVP_CTX *ctx,
                                      ACVP_CIPHER cipher,
                                      ACVP_CMAC_PARM parm,
@@ -4517,44 +4477,6 @@ ACVP_RESULT acvp_cap_cmac_set_parm(ACVP_CTX *ctx,
     }
 
     return ACVP_SUCCESS;
-}
-
-ACVP_RESULT acvp_cap_kmac_enable(ACVP_CTX *ctx,
-                                 ACVP_CIPHER cipher,
-                                 int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-    ACVP_SUB_KMAC alg;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_kmac_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_KMAC_128:
-    case ACVP_SUB_KMAC_256:
-        break;
-    default:
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_KMAC_TYPE, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
 }
 
 ACVP_RESULT acvp_cap_kmac_set_parm(ACVP_CTX *ctx,
@@ -4968,30 +4890,6 @@ ACVP_RESULT acvp_cap_drbg_set_parm(ACVP_CTX *ctx,
     return ACVP_SUCCESS;
 }
 
-ACVP_RESULT acvp_cap_drbg_enable(ACVP_CTX *ctx,
-                                 ACVP_CIPHER cipher,
-                                 int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_DRBG_TYPE, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
 /*
  * The user should call this after invoking acvp_enable_rsa_keygen_cap().
  */
@@ -5088,36 +4986,6 @@ ACVP_RESULT acvp_cap_rsa_keygen_set_parm(ACVP_CTX *ctx,
         break;
     }
     return rv;
-}
-
-ACVP_RESULT acvp_cap_rsa_keygen_enable(ACVP_CTX *ctx,
-                                       ACVP_CIPHER cipher,
-                                       int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    if (cipher != ACVP_RSA_KEYGEN) {
-        ACVP_LOG_ERR("Invalid parameter 'cipher'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_RSA_KEYGEN_TYPE, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
 }
 
 /*
@@ -5921,125 +5789,6 @@ ACVP_RESULT acvp_cap_rsa_siggen_set_mod_parm(ACVP_CTX *ctx,
     return ACVP_SUCCESS;
 }
 
-static ACVP_RESULT internal_cap_rsa_sig_enable(ACVP_CTX *ctx,
-                                               ACVP_CIPHER cipher,
-                                               int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_CAP_TYPE type = 0;
-    ACVP_RESULT result = ACVP_SUCCESS;
-    ACVP_SUB_RSA alg;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_rsa_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_RSA_SIGGEN:
-        type = ACVP_RSA_SIGGEN_TYPE;
-        break;
-    case ACVP_SUB_RSA_SIGVER:
-        type = ACVP_RSA_SIGVER_TYPE;
-        break;
-    case ACVP_SUB_RSA_SIGPRIM:
-    case ACVP_SUB_RSA_DECPRIM:
-        type = ACVP_RSA_PRIM_TYPE;
-        break;
-    case ACVP_SUB_RSA_KEYGEN:
-    default:
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, type, cipher, crypto_handler);
-
-    return result;
-}
-
-ACVP_RESULT acvp_cap_rsa_sig_enable(ACVP_CTX *ctx,
-                                    ACVP_CIPHER cipher,
-                                    int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-    const char *cap_message_str = NULL;
-    ACVP_SUB_RSA alg;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_rsa_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_RSA_SIGGEN:
-        cap_message_str = "ACVP_RSA_SIGGEN";
-        break;
-    case ACVP_SUB_RSA_SIGVER:
-        cap_message_str = "ACVP_RSA_SIGVER";
-        break;
-    case ACVP_SUB_RSA_KEYGEN:
-    case ACVP_SUB_RSA_DECPRIM:
-    case ACVP_SUB_RSA_SIGPRIM:
-    default:
-        ACVP_LOG_ERR("Invalid parameter 'cipher'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = internal_cap_rsa_sig_enable(ctx, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability (%s) previously enabled. Duplicate not allowed.",
-                     cap_message_str);
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate (%s) capability object",
-                     cap_message_str);
-    }
-
-    return result;
-}
-ACVP_RESULT acvp_cap_rsa_prim_enable(ACVP_CTX *ctx,
-                                     ACVP_CIPHER cipher,
-                                     int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    if ((cipher != ACVP_RSA_SIGPRIM) && (cipher != ACVP_RSA_DECPRIM)) {
-        ACVP_LOG_ERR("Invalid parameter 'cipher'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_RSA_PRIM_TYPE, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
 /*
  * The user should call this after invoking acvp_enable_rsa_prim_cap().
  */
@@ -6367,59 +6116,6 @@ ACVP_RESULT acvp_cap_ecdsa_set_curve_hash_alg(ACVP_CTX *ctx, ACVP_CIPHER cipher,
     return ACVP_UNSUPPORTED_OP;
 }
 
-ACVP_RESULT acvp_cap_ecdsa_enable(ACVP_CTX *ctx,
-                                  ACVP_CIPHER cipher,
-                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_CAP_TYPE type = 0;
-    ACVP_RESULT result = ACVP_SUCCESS;
-    ACVP_SUB_ECDSA alg;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_ecdsa_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_ECDSA_KEYGEN:
-        type = ACVP_ECDSA_KEYGEN_TYPE;
-        break;
-    case ACVP_SUB_ECDSA_KEYVER:
-        type = ACVP_ECDSA_KEYVER_TYPE;
-        break;
-    case ACVP_SUB_ECDSA_SIGGEN:
-        type = ACVP_ECDSA_SIGGEN_TYPE;
-        break;
-    case ACVP_SUB_ECDSA_SIGVER:
-        type = ACVP_ECDSA_SIGVER_TYPE;
-        break;
-    case ACVP_SUB_DET_ECDSA_SIGGEN:
-        type = ACVP_DET_ECDSA_SIGGEN_TYPE;
-        break;
-    default:
-        ACVP_LOG_ERR("Invalid parameter 'cipher'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, type, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
 /*
  * The user should call this after invoking acvp_enable_eddsa_cap().
  */
@@ -6576,57 +6272,6 @@ ACVP_RESULT acvp_cap_eddsa_set_domain(ACVP_CTX *ctx,
     return result;
 }
 
-ACVP_RESULT acvp_cap_eddsa_enable(ACVP_CTX *ctx,
-                                  ACVP_CIPHER cipher,
-                                  int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_CAP_TYPE type = 0;
-    ACVP_RESULT result = ACVP_SUCCESS;
-    ACVP_SUB_EDDSA alg;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_eddsa_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-
-    switch (alg) {
-    case ACVP_SUB_EDDSA_KEYGEN:
-        type = ACVP_EDDSA_KEYGEN_TYPE;
-        break;
-    case ACVP_SUB_EDDSA_KEYVER:
-        type = ACVP_EDDSA_KEYVER_TYPE;
-        break;
-    case ACVP_SUB_EDDSA_SIGGEN:
-        type = ACVP_EDDSA_SIGGEN_TYPE;
-        break;
-    case ACVP_SUB_EDDSA_SIGVER:
-        type = ACVP_EDDSA_SIGVER_TYPE;
-        break;
-    default:
-        ACVP_LOG_ERR("Invalid parameter 'cipher'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, type, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
 /*
  * The user should call this after invoking acvp_enable_dsa_cap().
  */
@@ -6766,218 +6411,6 @@ ACVP_RESULT acvp_cap_kdf135_snmp_set_engid(ACVP_CTX *ctx,
     }
 
     result = acvp_append_name_list(&kdf135_snmp_cap->eng_ids, engid);
-
-    return result;
-}
-
-ACVP_RESULT acvp_cap_kdf135_srtp_enable(ACVP_CTX *ctx,
-                                        int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_KDF135_SRTP_TYPE, ACVP_KDF135_SRTP, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
-ACVP_RESULT acvp_cap_kdf135_ikev2_enable(ACVP_CTX *ctx,
-                                         int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_KDF135_IKEV2_TYPE, ACVP_KDF135_IKEV2, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
-
-ACVP_RESULT acvp_cap_kdf135_x942_enable(ACVP_CTX *ctx,
-                                        int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_KDF135_X942_TYPE, ACVP_KDF135_X942, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
-
-ACVP_RESULT acvp_cap_kdf135_x963_enable(ACVP_CTX *ctx,
-                                        int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_KDF135_X963_TYPE, ACVP_KDF135_X963, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
-ACVP_RESULT acvp_cap_kdf135_ikev1_enable(ACVP_CTX *ctx,
-                                         int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_KDF135_IKEV1_TYPE, ACVP_KDF135_IKEV1, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
-ACVP_RESULT acvp_cap_kdf108_enable(ACVP_CTX *ctx,
-                                   int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_KDF108_TYPE, ACVP_KDF108, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
-ACVP_RESULT acvp_cap_kdf135_snmp_enable(ACVP_CTX *ctx,
-                                        int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_KDF135_SNMP_TYPE, ACVP_KDF135_SNMP, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
-ACVP_RESULT acvp_cap_kdf135_ssh_enable(ACVP_CTX *ctx,
-                                       int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_KDF135_SSH_TYPE, ACVP_KDF135_SSH, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
-ACVP_RESULT acvp_cap_pbkdf_enable(ACVP_CTX *ctx,
-                                  int (*crypto_handler) (ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_PBKDF_TYPE, ACVP_PBKDF, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
 
     return result;
 }
@@ -7402,30 +6835,6 @@ ACVP_RESULT acvp_cap_kdf135_srtp_set_parm(ACVP_CTX *ctx,
     }
 
     return ACVP_SUCCESS;
-}
-
-ACVP_RESULT acvp_cap_dsa_enable(ACVP_CTX *ctx,
-                                ACVP_CIPHER cipher,
-                                int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_DSA_TYPE, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
 }
 
 ACVP_RESULT acvp_cap_kdf135_ikev2_set_parm(ACVP_CTX *ctx,
@@ -7994,32 +7403,8 @@ ACVP_RESULT acvp_cap_kdf108_set_domain(ACVP_CTX *ctx,
     return ACVP_SUCCESS;
 }
 
-ACVP_RESULT acvp_cap_kdf_tls12_enable(ACVP_CTX *ctx,
-                                       int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        return ACVP_INVALID_ARG;
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_KDF_TLS12_TYPE, ACVP_KDF_TLS12, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
 /*
- * The user should call this after invoking acvp_cap_kdf_tls12_enable()
+ * The user should call this after invoking acvp_enable_algorithm
  * to specify the kdf parameters.
  */
 ACVP_RESULT acvp_cap_kdf_tls12_set_parm(ACVP_CTX *ctx,
@@ -8062,32 +7447,6 @@ ACVP_RESULT acvp_cap_kdf_tls12_set_parm(ACVP_CTX *ctx,
     case ACVP_KDF_TLS12_PARAM_MIN:
     default:
         return ACVP_INVALID_ARG;
-    }
-
-    return result;
-}
-
-
-
-ACVP_RESULT acvp_cap_kdf_tls13_enable(ACVP_CTX *ctx,
-                                      int (*crypto_handler) (ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, ACVP_KDF_TLS13_TYPE, ACVP_KDF_TLS13, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
     }
 
     return result;
@@ -8223,65 +7582,6 @@ ACVP_RESULT acvp_cap_kas_ecc_set_prereq(ACVP_CTX *ctx,
      * Add the value to the cap
      */
     return acvp_add_kas_ecc_prereq_val(kas_ecc_mode, pre_req, value);
-}
-
-ACVP_RESULT acvp_cap_kas_ecc_enable(ACVP_CTX *ctx,
-                                    ACVP_CIPHER cipher,
-                                    int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_CAP_TYPE type = 0;
-    ACVP_RESULT result = ACVP_SUCCESS;
-    ACVP_SUB_KAS alg;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_kas_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_KAS_ECC_CDH:
-        type = ACVP_KAS_ECC_CDH_TYPE;
-        break;
-    case ACVP_SUB_KAS_ECC_COMP:
-        type = ACVP_KAS_ECC_COMP_TYPE;
-        break;
-    case ACVP_SUB_KAS_ECC_NOCOMP:
-        type = ACVP_KAS_ECC_NOCOMP_TYPE;
-        break;
-    case ACVP_SUB_KAS_ECC_SSC:
-        type = ACVP_KAS_ECC_SSC_TYPE;
-        break;
-    case ACVP_SUB_KAS_FFC_COMP:
-    case ACVP_SUB_KAS_FFC_NOCOMP:
-    case ACVP_SUB_KAS_FFC_SSC: 
-    case ACVP_SUB_KAS_IFC_SSC: 
-    case ACVP_SUB_KTS_IFC: 
-    case ACVP_SUB_KDA_ONESTEP:
-    case ACVP_SUB_KDA_TWOSTEP:
-    case ACVP_SUB_KDA_HKDF:
-    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
-    case ACVP_SUB_SAFE_PRIMES_KEYVER:
-    default:
-        ACVP_LOG_ERR("Invalid parameter 'cipher'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, type, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
 }
 
 ACVP_RESULT acvp_cap_kas_ecc_set_parm(ACVP_CTX *ctx,
@@ -8660,63 +7960,6 @@ ACVP_RESULT acvp_cap_kas_ffc_set_prereq(ACVP_CTX *ctx,
     return acvp_add_kas_ffc_prereq_val(kas_ffc_mode, pre_req, value);
 }
 
-ACVP_RESULT acvp_cap_kas_ffc_enable(ACVP_CTX *ctx,
-                                    ACVP_CIPHER cipher,
-                                    int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_CAP_TYPE type = 0;
-    ACVP_RESULT result = ACVP_SUCCESS;
-    ACVP_SUB_KAS alg;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_kas_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_KAS_FFC_SSC:
-        type = ACVP_KAS_FFC_SSC_TYPE;
-        break;
-    case ACVP_SUB_KAS_FFC_COMP:
-        type = ACVP_KAS_FFC_COMP_TYPE;
-        break;
-    case ACVP_SUB_KAS_FFC_NOCOMP:
-        type = ACVP_KAS_FFC_NOCOMP_TYPE;
-        break;
-    case ACVP_SUB_KAS_ECC_CDH:
-    case ACVP_SUB_KAS_ECC_COMP:
-    case ACVP_SUB_KAS_ECC_NOCOMP:
-    case ACVP_SUB_KAS_ECC_SSC:
-    case ACVP_SUB_KAS_IFC_SSC: 
-    case ACVP_SUB_KTS_IFC: 
-    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
-    case ACVP_SUB_SAFE_PRIMES_KEYVER:
-    case ACVP_SUB_KDA_ONESTEP:
-    case ACVP_SUB_KDA_TWOSTEP:
-    case ACVP_SUB_KDA_HKDF:
-    default:
-        ACVP_LOG_ERR("Invalid parameter 'cipher'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, type, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
 ACVP_RESULT acvp_cap_kas_ffc_set_parm(ACVP_CTX *ctx,
                                       ACVP_CIPHER cipher,
                                       ACVP_KAS_FFC_MODE mode,
@@ -8966,31 +8209,6 @@ ACVP_RESULT acvp_cap_kas_ffc_set_scheme(ACVP_CTX *ctx,
     return result;
 }
 
-ACVP_RESULT acvp_cap_kas_ifc_enable(ACVP_CTX *ctx,
-                                    ACVP_CIPHER cipher,
-                                    int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_CAP_TYPE type = 0;
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-    type = ACVP_KAS_IFC_TYPE;
-    result = acvp_cap_list_append(ctx, type, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
 ACVP_RESULT acvp_cap_kas_ifc_set_parm(ACVP_CTX *ctx,
                                       ACVP_CIPHER cipher,
                                       ACVP_KAS_IFC_PARAM param,
@@ -9079,63 +8297,6 @@ ACVP_RESULT acvp_cap_kas_ifc_set_exponent(ACVP_CTX *ctx,
     kas_ifc_cap->fixed_pub_exp = calloc(len + 1, sizeof(char));
     strcpy_s(kas_ifc_cap->fixed_pub_exp, len + 1, value);
     return ACVP_SUCCESS;
-}
-
-ACVP_RESULT acvp_cap_kda_enable(ACVP_CTX *ctx,
-                                    ACVP_CIPHER cipher,
-                                    int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_CAP_TYPE type = 0;
-    ACVP_RESULT result = ACVP_SUCCESS;
-    ACVP_SUB_KAS alg;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_kas_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_KDA_ONESTEP:
-        type = ACVP_KDA_ONESTEP_TYPE;
-        break;
-    case ACVP_SUB_KDA_TWOSTEP:
-        type = ACVP_KDA_TWOSTEP_TYPE;
-        break;
-    case ACVP_SUB_KDA_HKDF:
-        type = ACVP_KDA_HKDF_TYPE;
-        break;
-    case ACVP_SUB_KAS_ECC_CDH:
-    case ACVP_SUB_KAS_ECC_COMP:
-    case ACVP_SUB_KAS_ECC_NOCOMP:
-    case ACVP_SUB_KAS_ECC_SSC:
-    case ACVP_SUB_KAS_FFC_COMP:
-    case ACVP_SUB_KAS_FFC_NOCOMP:
-    case ACVP_SUB_KAS_FFC_SSC:
-    case ACVP_SUB_KAS_IFC_SSC:
-    case ACVP_SUB_KTS_IFC:
-    case ACVP_SUB_SAFE_PRIMES_KEYGEN:
-    case ACVP_SUB_SAFE_PRIMES_KEYVER:
-    default:
-        ACVP_LOG_ERR("Invalid parameter 'cipher'");
-        return ACVP_INVALID_ARG;
-    }
-
-    result = acvp_cap_list_append(ctx, type, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
 }
 
 ACVP_RESULT acvp_cap_kda_set_parm(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KDA_PARM param,
@@ -9910,33 +9071,6 @@ ACVP_RESULT acvp_cap_kda_set_domain(ACVP_CTX *ctx, ACVP_CIPHER cipher, ACVP_KDA_
     return result;
 }
 
-ACVP_RESULT acvp_cap_kts_ifc_enable(ACVP_CTX *ctx,
-                                    ACVP_CIPHER cipher,
-                                    int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_CAP_TYPE type = 0;
-    ACVP_RESULT result = ACVP_SUCCESS;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    type = ACVP_KTS_IFC_TYPE;
-
-    result = acvp_cap_list_append(ctx, type, cipher, crypto_handler);
-
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    }
-
-    return result;
-}
-
 ACVP_RESULT acvp_cap_kts_ifc_set_parm(ACVP_CTX *ctx,
                                       ACVP_CIPHER cipher,
                                       ACVP_KTS_IFC_PARAM param,
@@ -10184,36 +9318,6 @@ ACVP_RESULT acvp_cap_kts_ifc_set_scheme_string(ACVP_CTX *ctx,
     return ACVP_SUCCESS;
 }
 
-ACVP_RESULT acvp_cap_safe_primes_enable(ACVP_CTX *ctx,
-                                        ACVP_CIPHER cipher,
-                                        int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_NO_CAP;
-
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    if (cipher == ACVP_SAFE_PRIMES_KEYGEN) {
-        result = acvp_cap_list_append(ctx, ACVP_SAFE_PRIMES_KEYGEN_TYPE, cipher, crypto_handler);
-    } else if (cipher == ACVP_SAFE_PRIMES_KEYVER) {
-        result = acvp_cap_list_append(ctx, ACVP_SAFE_PRIMES_KEYVER_TYPE, cipher, crypto_handler);
-    } 
-    if (result == ACVP_DUP_CIPHER) {
-        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
-    } else if (result == ACVP_MALLOC_FAIL) {
-        ACVP_LOG_ERR("Failed to allocate capability object");
-    } else if (result == ACVP_NO_CAP) {
-        ACVP_LOG_ERR("Invalid capability");
-        return ACVP_NO_CAP;
-    }
-
-    return result;
-}
-
 ACVP_RESULT acvp_cap_safe_primes_set_parm(ACVP_CTX *ctx,
                                           ACVP_CIPHER cipher,
                                           ACVP_SAFE_PRIMES_PARAM param,
@@ -10293,46 +9397,6 @@ ACVP_RESULT acvp_cap_safe_primes_set_parm(ACVP_CTX *ctx,
     default:
         break;
     }
-    return result;
-}
-
-ACVP_RESULT acvp_cap_lms_enable(ACVP_CTX *ctx,
-                                ACVP_CIPHER cipher,
-                                int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_NO_CAP;
-    ACVP_SUB_LMS alg;
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_lms_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_LMS_KEYGEN:
-        result = acvp_cap_list_append(ctx, ACVP_LMS_KEYGEN_TYPE, cipher, crypto_handler);
-        break;
-    case ACVP_SUB_LMS_SIGGEN:
-        result = acvp_cap_list_append(ctx, ACVP_LMS_SIGGEN_TYPE, cipher, crypto_handler);
-        break;
-    case ACVP_SUB_LMS_SIGVER:
-        result = acvp_cap_list_append(ctx, ACVP_LMS_SIGVER_TYPE, cipher, crypto_handler);
-        break;
-    default:
-        ACVP_LOG_ERR("Invalid cipher provided to acvp_cap_lms_enable()");
-        break;
-    }
-
-    if (result != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Error occured while enabling LMS algorithm. rv: %d", result);
-    }
-
     return result;
 }
 
@@ -10453,46 +9517,6 @@ ACVP_RESULT acvp_cap_lms_set_mode_compatability_pair(ACVP_CTX *ctx,
     }
 
     return ACVP_SUCCESS;
-}
-
-ACVP_RESULT acvp_cap_ml_dsa_enable(ACVP_CTX *ctx,
-                                ACVP_CIPHER cipher,
-                                int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_NO_CAP;
-    ACVP_SUB_ML_DSA alg;
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_ml_dsa_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_ML_DSA_KEYGEN:
-        result = acvp_cap_list_append(ctx, ACVP_ML_DSA_KEYGEN_TYPE, cipher, crypto_handler);
-        break;
-    case ACVP_SUB_ML_DSA_SIGGEN:
-        result = acvp_cap_list_append(ctx, ACVP_ML_DSA_SIGGEN_TYPE, cipher, crypto_handler);
-        break;
-    case ACVP_SUB_ML_DSA_SIGVER:
-        result = acvp_cap_list_append(ctx, ACVP_ML_DSA_SIGVER_TYPE, cipher, crypto_handler);
-        break;
-    default:
-        ACVP_LOG_ERR("Invalid cipher provided to acvp_cap_ml_dsa_enable()");
-        break;
-    }
-
-    if (result != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Error occured while enabling ML-DSA algorithm. rv: %d", result);
-    }
-
-    return result;
 }
 
 ACVP_RESULT acvp_cap_ml_dsa_set_parm(ACVP_CTX *ctx,
@@ -10774,43 +9798,6 @@ ACVP_RESULT acvp_cap_ml_dsa_set_domain(ACVP_CTX *ctx,
     return ACVP_SUCCESS;
 }
 
-ACVP_RESULT acvp_cap_ml_kem_enable(ACVP_CTX *ctx,
-                                ACVP_CIPHER cipher,
-                                int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_NO_CAP;
-    ACVP_SUB_ML_KEM alg;
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_ml_kem_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_ML_KEM_KEYGEN:
-        result = acvp_cap_list_append(ctx, ACVP_ML_KEM_KEYGEN_TYPE, cipher, crypto_handler);
-        break;
-    case ACVP_SUB_ML_KEM_XCAP:
-        result = acvp_cap_list_append(ctx, ACVP_ML_KEM_XCAP_TYPE, cipher, crypto_handler);
-        break;
-    default:
-        ACVP_LOG_ERR("Invalid cipher provided to acvp_cap_ml_kem_enable()");
-        break;
-    }
-
-    if (result != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Error occured while enabling ML-KEM algorithm. rv: %d", result);
-    }
-
-    return result;
-}
-
 ACVP_RESULT acvp_cap_ml_kem_set_parm(ACVP_CTX *ctx,
                                   ACVP_CIPHER cipher,
                                   ACVP_ML_KEM_PARAM param, int value) {
@@ -10862,46 +9849,6 @@ ACVP_RESULT acvp_cap_ml_kem_set_parm(ACVP_CTX *ctx,
     }
 
     return ACVP_SUCCESS;
-}
-
-ACVP_RESULT acvp_cap_slh_dsa_enable(ACVP_CTX *ctx,
-                                ACVP_CIPHER cipher,
-                                int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
-    ACVP_RESULT result = ACVP_NO_CAP;
-    ACVP_SUB_SLH_DSA alg;
-    if (!ctx) {
-        return ACVP_NO_CTX;
-    }
-    if (!crypto_handler) {
-        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
-        return ACVP_INVALID_ARG;
-    }
-
-    alg = acvp_get_slh_dsa_alg(cipher);
-    if (alg == 0) {
-        ACVP_LOG_ERR("Invalid cipher value");
-        return ACVP_INVALID_ARG;
-    }
-    switch (alg) {
-    case ACVP_SUB_SLH_DSA_KEYGEN:
-        result = acvp_cap_list_append(ctx, ACVP_SLH_DSA_KEYGEN_TYPE, cipher, crypto_handler);
-        break;
-    case ACVP_SUB_SLH_DSA_SIGGEN:
-        result = acvp_cap_list_append(ctx, ACVP_SLH_DSA_SIGGEN_TYPE, cipher, crypto_handler);
-        break;
-    case ACVP_SUB_SLH_DSA_SIGVER:
-        result = acvp_cap_list_append(ctx, ACVP_SLH_DSA_SIGVER_TYPE, cipher, crypto_handler);
-        break;
-    default:
-        ACVP_LOG_ERR("Invalid cipher provided to acvp_cap_slh_dsa_enable()");
-        break;
-    }
-
-    if (result != ACVP_SUCCESS) {
-        ACVP_LOG_ERR("Error occurred while enabling SLH-DSA algorithm. rv: %d", result);
-    }
-
-    return result;
 }
 
 ACVP_RESULT acvp_cap_slh_dsa_set_parm(ACVP_CTX *ctx,

--- a/test/test_acvp.c
+++ b/test/test_acvp.c
@@ -28,7 +28,7 @@ static void setup(void) {
 static void setup_full_ctx(void) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -47,7 +47,7 @@ static void setup_full_ctx(void) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PTLEN, 1536);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -72,9 +72,9 @@ static void setup_full_ctx(void) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_AADLEN, 0);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_cmac_set_parm(ctx, ACVP_CMAC_AES, ACVP_CMAC_MACLEN, 128);
     cr_assert(rv == ACVP_SUCCESS);
@@ -82,10 +82,10 @@ static void setup_full_ctx(void) {
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_cmac_set_parm(ctx, ACVP_CMAC_AES, ACVP_CMAC_DIRECTION_GEN, 1);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -94,7 +94,7 @@ static void setup_full_ctx(void) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_P224);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_COMP, ACVP_KAS_FFC_MODE_COMPONENT, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -109,7 +109,7 @@ static void setup_full_ctx(void) {
     rv = acvp_cap_kas_ffc_set_scheme(ctx, ACVP_KAS_FFC_COMP, ACVP_KAS_FFC_MODE_COMPONENT, ACVP_KAS_FFC_DH_EPHEMERAL, ACVP_KAS_FFC_FB, ACVP_SHA224);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -120,7 +120,7 @@ static void setup_full_ctx(void) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGGEN, ACVP_DSA_MODE_PQGGEN, ACVP_DSA_GENG, ACVP_DSA_CANONICAL);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_siggen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -129,7 +129,7 @@ static void setup_full_ctx(void) {
     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_X931, 2048, ACVP_SHA256, 0);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -140,7 +140,7 @@ static void setup_full_ctx(void) {
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_SECRET_GEN, ACVP_ECDSA_SECRET_GEN_TEST_CAND);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_DER_FUNC_ENABLED, 0);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_aes.c
+++ b/test/test_acvp_aes.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -69,7 +69,7 @@ static void setup(void) {
     /*
      * Enable AES-ECB 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_ECB, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_ECB, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -91,7 +91,7 @@ static void setup(void) {
     /*
      * Enable AES-CBC 128 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -113,7 +113,7 @@ static void setup(void) {
     /*
      * Enable AES-CBC-CS1, CS2, and CS3
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -126,7 +126,7 @@ static void setup(void) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS2, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -139,7 +139,7 @@ static void setup(void) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS3, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -155,7 +155,7 @@ static void setup(void) {
     /*
      * Enable AES-CFB1 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -177,7 +177,7 @@ static void setup(void) {
     /*
      * Enable AES-CFB8 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB8, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB8, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -199,7 +199,7 @@ static void setup(void) {
     /*
      * Enable AES-CFB128 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB128, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB128, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -221,7 +221,7 @@ static void setup(void) {
     /*
      * Enable AES-OFB 128, 192, 256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_OFB, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_OFB, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -243,7 +243,7 @@ static void setup(void) {
     /*
      * Register AES CCM capabilities
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -283,7 +283,7 @@ static void setup(void) {
      * Note: this is with padding disabled, minimum PT length is 128 bits and must be
      *       a multiple of 64 bits. openssl does not support INVERSE mode.
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KW, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KW, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -313,7 +313,7 @@ static void setup(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
 #ifdef OPENSSL_KWP
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KWP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KWP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -346,7 +346,7 @@ static void setup(void) {
     /*
      * Enable AES-XTS 128 and 256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XTS, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XTS, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -368,7 +368,7 @@ static void setup(void) {
     /*
      * Enable AES-CTR 128, 192, 256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CTR, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CTR, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -396,7 +396,7 @@ static void setup(void) {
 static void setup_fail(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -444,7 +444,7 @@ static void setup_fail(void) {
     /*
      * Enable AES-ECB 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_ECB, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_ECB, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -466,7 +466,7 @@ static void setup_fail(void) {
     /*
      * Enable AES-CBC 128 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -488,7 +488,7 @@ static void setup_fail(void) {
     /*
      * Enable AES-CFB1 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB1, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -510,7 +510,7 @@ static void setup_fail(void) {
     /*
      * Enable AES-CFB8 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB8, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB8, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -532,7 +532,7 @@ static void setup_fail(void) {
     /*
      * Enable AES-CFB128 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB128, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB128, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -554,7 +554,7 @@ static void setup_fail(void) {
     /*
      * Enable AES-OFB 128, 192, 256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_OFB, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_OFB, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -576,7 +576,7 @@ static void setup_fail(void) {
     /*
      * Register AES CCM capabilities
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CCM, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CCM, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -616,7 +616,7 @@ static void setup_fail(void) {
      * Note: this is with padding disabled, minimum PT length is 128 bits and must be
      *       a multiple of 64 bits. openssl does not support INVERSE mode.
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KW, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KW, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -646,7 +646,7 @@ static void setup_fail(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
 #ifdef OPENSSL_KWP
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KWP, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KWP, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -679,7 +679,7 @@ static void setup_fail(void) {
     /*
      * Enable AES-XTS 128 and 256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XTS, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XTS, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -701,7 +701,7 @@ static void setup_fail(void) {
     /*
      * Enable AES-CTR 128, 192, 256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CTR, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CTR, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -724,7 +724,7 @@ static void setup_fail(void) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PTLEN, 128);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XPN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XPN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_XPN, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -761,7 +761,7 @@ static void teardown(void) {
 Test(AES_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -809,7 +809,7 @@ Test(AES_CAPABILITY, good) {
     /*
      * Enable AES-ECB 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_ECB, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_ECB, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -831,7 +831,7 @@ Test(AES_CAPABILITY, good) {
     /*
      * Enable AES-CBC 128 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -853,7 +853,7 @@ Test(AES_CAPABILITY, good) {
     /*
      * Enable AES-CBC-CS1, CS2, and CS3
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -866,7 +866,7 @@ Test(AES_CAPABILITY, good) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS2, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -879,7 +879,7 @@ Test(AES_CAPABILITY, good) {
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS3, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -895,7 +895,7 @@ Test(AES_CAPABILITY, good) {
     /*
      * Enable AES-CFB1 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -917,7 +917,7 @@ Test(AES_CAPABILITY, good) {
     /*
      * Enable AES-CFB8 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB8, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB8, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -939,7 +939,7 @@ Test(AES_CAPABILITY, good) {
     /*
      * Enable AES-CFB128 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB128, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB128, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -961,7 +961,7 @@ Test(AES_CAPABILITY, good) {
     /*
      * Enable AES-OFB 128, 192, 256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_OFB, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_OFB, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -983,7 +983,7 @@ Test(AES_CAPABILITY, good) {
     /*
      * Register AES CCM capabilities
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1023,7 +1023,7 @@ Test(AES_CAPABILITY, good) {
      * Note: this is with padding disabled, minimum PT length is 128 bits and must be
      *       a multiple of 64 bits. openssl does not support INVERSE mode.
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KW, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KW, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -1053,7 +1053,7 @@ Test(AES_CAPABILITY, good) {
     cr_assert(rv == ACVP_SUCCESS);
 
 #ifdef OPENSSL_KWP
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KWP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KWP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -1086,7 +1086,7 @@ Test(AES_CAPABILITY, good) {
     /*
      * Enable AES-XTS 128 and 256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XTS, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XTS, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -1108,7 +1108,7 @@ Test(AES_CAPABILITY, good) {
     /*
      * Enable AES-CTR 128, 192, 256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CTR, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CTR, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -1131,7 +1131,7 @@ Test(AES_CAPABILITY, good) {
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PTLEN, 128);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XPN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XPN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_XPN, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_build_register.c
+++ b/test/test_acvp_build_register.c
@@ -34,7 +34,7 @@ static void add_des_details_good(void) {
     /*
      * Enable 3DES-ECB
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_ECB, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_ECB, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -44,7 +44,7 @@ static void add_des_details_good(void) {
     /*
      * Enable 3DES-CBC
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CBC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -54,7 +54,7 @@ static void add_des_details_good(void) {
     /*
      * Enable 3DES-OFB
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_OFB, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_OFB, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -64,7 +64,7 @@ static void add_des_details_good(void) {
     /*
      * Enable 3DES-CFB64
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB64, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CFB64, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -74,7 +74,7 @@ static void add_des_details_good(void) {
     /*
      * Enable 3DES-CFB8
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB8, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CFB8, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -84,7 +84,7 @@ static void add_des_details_good(void) {
     /*
      * Enable 3DES-CFB1
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CFB1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -93,7 +93,7 @@ static void add_des_details_good(void) {
 }
 
 static void add_aes_details_good(void) {
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -141,7 +141,7 @@ static void add_aes_details_good(void) {
     /*
      * Enable AES-ECB 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_ECB, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_ECB, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -163,7 +163,7 @@ static void add_aes_details_good(void) {
     /*
      * Enable AES-CBC 128 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -185,7 +185,7 @@ static void add_aes_details_good(void) {
     /*
      * Enable AES-CFB1 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -207,7 +207,7 @@ static void add_aes_details_good(void) {
     /*
      * Enable AES-CFB8 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB8, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB8, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -229,7 +229,7 @@ static void add_aes_details_good(void) {
     /*
      * Enable AES-CFB128 128,192,256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB128, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB128, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -251,7 +251,7 @@ static void add_aes_details_good(void) {
     /*
      * Enable AES-OFB 128, 192, 256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_OFB, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_OFB, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -273,7 +273,7 @@ static void add_aes_details_good(void) {
     /*
      * Register AES CCM capabilities
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -313,7 +313,7 @@ static void add_aes_details_good(void) {
      * Note: this is with padding disabled, minimum PT length is 128 bits and must be
      *       a multiple of 64 bits. openssl does not support INVERSE mode.
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KW, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_KW, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -345,7 +345,7 @@ static void add_aes_details_good(void) {
     /*
      * Enable AES-XTS 128 and 256 bit key
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XTS, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XTS, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -366,34 +366,34 @@ static void add_aes_details_good(void) {
 }
 
 static void add_hash_details_good(void) {
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA224, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA224, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA224, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA256, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA256, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA256, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA384, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA384, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA384, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
 }
 
 static void add_drbg_details_good(void) {
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
                                    ACVP_DRBG_DER_FUNC_ENABLED, 0);
@@ -424,7 +424,7 @@ static void add_drbg_details_good(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     //ACVP_HMACDRBG
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMACDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, 
                                      ACVP_PREREQ_SHA, cvalue);
@@ -459,7 +459,7 @@ static void add_drbg_details_good(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     // ACVP_CTRDRBG
-    rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CTRDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_CTRDRBG, 
                                      ACVP_PREREQ_AES, cvalue);
@@ -491,7 +491,7 @@ static void add_drbg_details_good(void) {
 }
 
 static void add_cmac_details_good(void) {
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_AES, ACVP_CMAC_MSGLEN, 0, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -510,7 +510,7 @@ static void add_cmac_details_good(void) {
     rv = acvp_cap_set_prereq(ctx, ACVP_CMAC_AES, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_TDES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_TDES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_TDES, ACVP_CMAC_MSGLEN, 0, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -527,7 +527,7 @@ static void add_cmac_details_good(void) {
 }
 
 static void add_hmac_details_good(void) {
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -536,7 +536,7 @@ static void add_hmac_details_good(void) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA1, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_224, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_224, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -545,7 +545,7 @@ static void add_hmac_details_good(void) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_224, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_256, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_256, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -554,7 +554,7 @@ static void add_hmac_details_good(void) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_256, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_384, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_384, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -563,7 +563,7 @@ static void add_hmac_details_good(void) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_384, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -574,7 +574,7 @@ static void add_hmac_details_good(void) {
 }
 
 static void add_dsa_details_good(void) {
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -605,7 +605,7 @@ static void add_dsa_details_good(void) {
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGGEN, ACVP_DSA_MODE_PQGGEN, ACVP_DSA_LN3072_256, ACVP_SHA512);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -637,7 +637,7 @@ static void add_dsa_details_good(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_KEYGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -669,7 +669,7 @@ static void add_dsa_details_good(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -701,7 +701,7 @@ static void add_dsa_details_good(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -737,7 +737,7 @@ static void add_rsa_details_good(void) {
     char *expo_str = calloc(7, sizeof(char));
     strncpy(expo_str, "010001", 7);
 
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -771,7 +771,7 @@ static void add_rsa_details_good(void) {
     /*
      * Enable siggen
      */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_siggen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -842,7 +842,7 @@ static void add_rsa_details_good(void) {
     /*
      * Enable sigver
      */
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_sigver_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -923,7 +923,7 @@ static void add_rsa_details_good(void) {
 }
 
 static void add_ecdsa_details_good(void) {
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -959,7 +959,7 @@ static void add_ecdsa_details_good(void) {
     /*
      * Enable ECDSA keyVer...
      */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -994,7 +994,7 @@ static void add_ecdsa_details_good(void) {
     /*
      * Enable ECDSA sigGen...
      */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1060,7 +1060,7 @@ static void add_ecdsa_details_good(void) {
     /*
      * Enable ECDSA sigVer...
      */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1130,7 +1130,7 @@ static void add_kdf_details_good(void) {
     /*
      * Enable KDF-135
      */
-    rv = acvp_cap_kdf135_snmp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SNMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1141,7 +1141,7 @@ static void add_kdf_details_good(void) {
     rv = acvp_cap_kdf135_snmp_set_engid(ctx, ACVP_KDF135_SNMP, "testengidtestengid");
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1163,7 +1163,7 @@ static void add_kdf_details_good(void) {
     rv = acvp_cap_kdf135_ssh_set_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_256_CBC, flags);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_kdf135_srtp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SRTP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SRTP, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1180,7 +1180,7 @@ static void add_kdf_details_good(void) {
     rv = acvp_cap_kdf135_srtp_set_parm(ctx, ACVP_KDF135_SRTP, ACVP_SRTP_AES_KEYLEN, 256);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_kdf135_ikev2_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV2, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_IKEV2, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1207,7 +1207,7 @@ static void add_kdf_details_good(void) {
     /*
      * KDF108 Counter Mode
      */
-    rv = acvp_cap_kdf108_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1239,7 +1239,7 @@ static void add_kdf_details_good(void) {
 }
 
 static void add_kas_ecc_details_good(void) {
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1270,7 +1270,7 @@ static void add_kas_ecc_details_good(void) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1303,7 +1303,7 @@ static void add_kas_ecc_details_good(void) {
 }
 
 static void add_kas_ffc_details_good(void) {
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_COMP, ACVP_KAS_FFC_MODE_COMPONENT, ACVP_PREREQ_DSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1550,7 +1550,7 @@ Test(BUILD_TEST_SESSION, good_aes_output, .fini = teardown) {
  */
 Test(BUILD_TEST_SESSION, missing_required_keylen_aes, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);;
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_DRBG, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1581,7 +1581,7 @@ Test(BUILD_TEST_SESSION, missing_required_keylen_aes, .fini = teardown) {
  */
 Test(BUILD_TEST_SESSION, missing_required_direction_aes, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1664,7 +1664,7 @@ Test(BUILD_TEST_SESSION, good_drbg, .fini = teardown) {
  */
 Test(BUILD_TEST_SESSION, drbg_missing_cap_parms, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_build_registration_json(ctx, &generated_value);
@@ -1707,7 +1707,7 @@ Test(BUILD_TEST_SESSION, good_cmac_output, .fini = teardown) {
  */
 Test(BUILD_TEST_SESSION, cmac_missing_direction, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_AES, ACVP_CMAC_MSGLEN, 0, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1726,7 +1726,7 @@ Test(BUILD_TEST_SESSION, cmac_missing_direction, .fini = teardown) {
  */
 Test(BUILD_TEST_SESSION, cmac_missing_tdes_ko, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_TDES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_TDES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_TDES, ACVP_CMAC_MSGLEN, 0, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1807,14 +1807,14 @@ Test(BUILD_TEST_SESSION, good_dsa, .fini = teardown) {
  */
 Test(BUILD_TEST_SESSION, dsa_missing_pqgen, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGGEN, ACVP_DSA_MODE_PQGGEN, ACVP_DSA_GENG, ACVP_DSA_CANONICAL);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_build_registration_json(ctx, &generated_value);
     cr_assert(rv == ACVP_MISSING_ARG);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_GENG, ACVP_DSA_CANONICAL);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1827,14 +1827,14 @@ Test(BUILD_TEST_SESSION, dsa_missing_pqgen, .fini = teardown) {
  */
 Test(BUILD_TEST_SESSION, dsa_missing_ggen, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGGEN, ACVP_DSA_MODE_PQGGEN, ACVP_DSA_GENPQ, ACVP_DSA_PROBABLE);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_build_registration_json(ctx, &generated_value);
     cr_assert(rv == ACVP_MISSING_ARG);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_GENPQ, ACVP_DSA_PROBABLE);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1847,7 +1847,7 @@ Test(BUILD_TEST_SESSION, dsa_missing_ggen, .fini = teardown) {
  */
 Test(BUILD_TEST_SESSION, dsa_missing_hashalgs, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGGEN, ACVP_DSA_MODE_PQGGEN, ACVP_DSA_GENPQ, ACVP_DSA_PROBABLE);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1856,7 +1856,7 @@ Test(BUILD_TEST_SESSION, dsa_missing_hashalgs, .fini = teardown) {
     rv = acvp_build_registration_json(ctx, &generated_value);
     cr_assert(rv == ACVP_MISSING_ARG);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_GENPQ, ACVP_DSA_PROBABLE);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1865,17 +1865,17 @@ Test(BUILD_TEST_SESSION, dsa_missing_hashalgs, .fini = teardown) {
     rv = acvp_build_registration_json(ctx, &generated_value);
     cr_assert(rv == ACVP_MISSING_ARG);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_build_registration_json(ctx, &generated_value);
     cr_assert(rv == ACVP_MISSING_ARG);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_build_registration_json(ctx, &generated_value);
     cr_assert(rv == ACVP_MISSING_ARG);
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_build_registration_json(ctx, &generated_value);
     cr_assert(rv == ACVP_MISSING_ARG);
@@ -1949,7 +1949,7 @@ Test(BUILD_TEST_SESSION, good_rsa, .fini = teardown) {
 Test(BUILD_TEST_SESSION, rsa_no_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_build_registration_json(ctx, &generated_value);
@@ -1992,7 +1992,7 @@ Test(BUILD_TEST_SESSION, good_ecdsa, .fini = teardown) {
 Test(BUILD_TEST_SESSION, ecdsa_no_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_build_registration_json(ctx, &generated_value);
@@ -2034,9 +2034,8 @@ Test(BUILD_TEST_SESSION, good_kdf, .fini = teardown) {
  */
 Test(BUILD_TEST_SESSION, kdf_more_modes, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_kdf108_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-
     rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 8, 384, 8);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA1);
@@ -2063,7 +2062,7 @@ Test(BUILD_TEST_SESSION, kdf_more_modes, .fini = teardown) {
     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_DPI, ACVP_KDF108_SUPPORTS_EMPTY_IV, 0);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_HASH_ALG, ACVP_SHA224);
     cr_assert(rv == ACVP_SUCCESS);
@@ -2080,7 +2079,7 @@ Test(BUILD_TEST_SESSION, kdf_more_modes, .fini = teardown) {
     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_SHARED_INFO_LEN, 256);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_kdf135_ikev1_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_IKEV1, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -2151,7 +2150,7 @@ Test(BUILD_TEST_SESSION, good_kas_ecc, .fini = teardown) {
 Test(BUILD_TEST_SESSION, kas_ecc_no_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_build_registration_json(ctx, &generated_value);
@@ -2194,7 +2193,7 @@ Test(BUILD_TEST_SESSION, good_kas_ffc, .fini = teardown) {
 Test(BUILD_TEST_SESSION, kas_ffc_no_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_build_registration_json(ctx, &generated_value);

--- a/test/test_acvp_capabilities.c
+++ b/test/test_acvp_capabilities.c
@@ -22,7 +22,7 @@ static void teardown(void) {
 Test(EnableCapHash, properly, .fini = teardown) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN,
@@ -50,7 +50,7 @@ Test(EnableCapHash, properly, .fini = teardown) {
 Test(EnableCapHash, param_alg_mismatch, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA256, ACVP_HASH_MESSAGE_LEN,
@@ -64,7 +64,7 @@ Test(EnableCapHash, param_alg_mismatch, .fini = teardown) {
 Test(EnableCapHash, null_handler, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, NULL);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, NULL);
     cr_assert(rv == ACVP_INVALID_ARG);
 }
 
@@ -74,7 +74,7 @@ Test(EnableCapHash, null_handler, .fini = teardown) {
 Test(EnableCapHash, invalid_args, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN,
@@ -96,7 +96,7 @@ Test(EnableCapHash, invalid_args, .fini = teardown) {
 Test(EnableCapKDF108, good, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf108_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -146,7 +146,7 @@ Test(EnableCapKDF108, good, .fini = teardown) {
 Test(EnableCapKDF108, alg_mismatch, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf108_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf108_set_domain(ctx, 0, ACVP_KDF108_SUPPORTED_LEN, 8, 384, 8);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -160,7 +160,7 @@ Test(EnableCapKDF108, alg_mismatch, .fini = teardown) {
 Test(EnableCapKDF108, invalid_domain, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf108_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 0, 384, 8);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -174,7 +174,7 @@ Test(EnableCapKDF108, invalid_domain, .fini = teardown) {
 Test(EnableCapKDF108, invalid_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf108_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, 0);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -202,7 +202,7 @@ Test(EnableCapKDFx963, properly, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -232,7 +232,7 @@ Test(EnableCapKDFx963, properly, .fini = teardown) {
  * tries to enable kdf x963 with empty ctx, expect fail
  */
 Test(EnableCapKDFx963, null_ctx, .fini = teardown) {
-    rv = acvp_cap_kdf135_x963_enable(NULL, &dummy_handler_success);
+    rv = acvp_enable_algorithm(NULL, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_NO_CTX);
 }
 
@@ -245,7 +245,7 @@ Test(EnableCapKDFx963, invalid_params, .fini = teardown) {
     // shouldn't be called before enable_cap
     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_HASH_ALG, ACVP_SHA256);
     cr_assert(rv == ACVP_NO_CAP);
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_HASH_ALG, ACVP_SHA256);
     cr_assert(rv == ACVP_SUCCESS);
@@ -270,7 +270,7 @@ Test(EnableCapKDFx963, invalid_params, .fini = teardown) {
 Test(EnableCapKDFSNMP, properly, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_snmp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SNMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -290,7 +290,7 @@ Test(EnableCapKDFSNMP, properly, .fini = teardown) {
 Test(EnableCapKDFSNMP, param_alg_mismatch, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_snmp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SNMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_NO_CAP);
@@ -302,7 +302,7 @@ Test(EnableCapKDFSNMP, param_alg_mismatch, .fini = teardown) {
 Test(EnableCapKDFSNMP, invalid_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_snmp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SNMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf135_snmp_set_parm(ctx, ACVP_KDF135_SNMP, ACVP_KDF135_SNMP_PASS_LEN, 0);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -320,7 +320,7 @@ Test(EnableCapKDFSRTP, good, .fini = teardown) {
     
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_srtp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SRTP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SRTP, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -342,7 +342,7 @@ Test(EnableCapKDFSRTP, good, .fini = teardown) {
  * enable srtp with null ctx
  */
 Test(EnableCapKDFSRTP, null_ctx, .fini = teardown) {
-    rv = acvp_cap_kdf135_srtp_enable(NULL, &dummy_handler_success);
+    rv = acvp_enable_algorithm(NULL, ACVP_KDF135_SRTP, &dummy_handler_success);
     cr_assert(rv == ACVP_NO_CTX);
 }
 
@@ -352,7 +352,7 @@ Test(EnableCapKDFSRTP, null_ctx, .fini = teardown) {
 Test(EnableCapKDFSRTP, invalid_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_srtp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SRTP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf135_srtp_set_parm(ctx, ACVP_KDF135_SRTP, ACVP_SRTP_SUPPORT_ZERO_KDR, 3);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -368,7 +368,7 @@ Test(EnableCapKDFSRTP, invalid_params, .fini = teardown) {
 Test(EnableCapKDFSSH, properly, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -390,7 +390,7 @@ Test(EnableCapKDFSSH, properly, .fini = teardown) {
  * tries to enable kdf ssh with null_ctx, expect failure
  */
 Test(EnableCapKDFSSH, null_ctx, .fini = teardown) {
-    rv = acvp_cap_kdf135_ssh_enable(NULL, &dummy_handler_success);
+    rv = acvp_enable_algorithm(NULL, ACVP_KDF135_SSH, &dummy_handler_success);
     cr_assert(rv == ACVP_NO_CTX);
 }
 
@@ -400,7 +400,7 @@ Test(EnableCapKDFSSH, null_ctx, .fini = teardown) {
 Test(EnableCapKDFSSH, invalid_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf135_ssh_set_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_TDES_CBC, 0);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -414,7 +414,7 @@ Test(EnableCapKDFSSH, invalid_params, .fini = teardown) {
 Test(EnableCapKDFSSH, param_alg_mismatch, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf135_ssh_set_parm(ctx, ACVP_KDF135_SNMP, ACVP_SSH_METH_TDES_CBC, ACVP_SHA256 | ACVP_SHA384 | ACVP_SHA512);
     cr_assert(rv == ACVP_NO_CAP);
@@ -425,7 +425,7 @@ Test(EnableCapKDFSSH, param_alg_mismatch, .fini = teardown) {
 Test(EnableCapCMAC, properly, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_CMAC_AES, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -449,7 +449,7 @@ Test(EnableCapCMAC, properly, .fini = teardown) {
 Test(EnableCapCMAC, param_alg_mismatch, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_TDES, ACVP_CMAC_MSGLEN, 0, 65536, 8);
@@ -462,16 +462,16 @@ Test(EnableCapCMAC, param_alg_mismatch, .fini = teardown) {
 Test(EnableCapCMAC, null_handler, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, NULL);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, NULL);
     cr_assert(rv == ACVP_INVALID_ARG);
 }
 
 Test(EnableCapCMAC, invalid_args, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_TDES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_TDES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     
     rv = acvp_cap_set_prereq(ctx, ACVP_CMAC_AES, ACVP_PREREQ_AES, NULL);
@@ -526,7 +526,7 @@ Test(EnableCapCMAC, invalid_args, .fini = teardown) {
 Test(EnableCapHMAC, properly, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_224, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_224, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_224, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -539,11 +539,8 @@ Test(EnableCapHMAC, properly, .fini = teardown) {
 Test(EnableCapHMAC, param_alg_mismatch, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_256, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_256, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-    
-    rv = acvp_cap_hmac_enable(ctx, ACVP_CMAC_AES, &dummy_handler_success);
-    cr_assert(rv == ACVP_INVALID_ARG);
 
     rv = acvp_cap_hmac_set_parm(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_KEYLEN, 32 * 8);
     cr_assert(rv == ACVP_NO_CAP);
@@ -555,14 +552,14 @@ Test(EnableCapHMAC, param_alg_mismatch, .fini = teardown) {
 Test(EnableCapHMAC, null_handler, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_384, NULL);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_384, NULL);
     cr_assert(rv == ACVP_INVALID_ARG);
 }
 
 Test(EnableCapHMAC, invalid_args, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512, ACVP_PREREQ_SHA, NULL);
@@ -594,7 +591,7 @@ Test(EnableCapHMAC, invalid_args, .fini = teardown) {
 
 Test(EnableCapRSAkeyGen, proper_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -610,7 +607,7 @@ Test(EnableCapRSAkeyGen, proper_params, .fini = teardown) {
 
 Test(EnableCapRSAkeyGen, proper_modes, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -629,7 +626,7 @@ Test(EnableCapRSAkeyGen, proper_modes, .fini = teardown) {
 
 Test(EnableCapRSAkeyGen, proper_modes_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -649,26 +646,18 @@ Test(EnableCapRSAkeyGen, proper_modes_params, .fini = teardown) {
     cr_assert(rv == ACVP_SUCCESS);
 }
 
-Test(EnableCapRSAkeyGen, alg_mismatch, .fini = teardown) {
-    setup_empty_ctx(&ctx);
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
-    cr_assert(rv == ACVP_INVALID_ARG);
-    rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_SHA, cvalue);
-    cr_assert(rv == ACVP_NO_CAP);
-}
-
 /*
  * Most of these params are members of enums, so the app
  * won't even build if it has an invalid value
  */
 Test(EnableCapRSAkeyGen, invalid_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, NULL);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, NULL);
     cr_assert(rv == ACVP_INVALID_ARG);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_NO_CAP);
     
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_SHA, "");
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -684,7 +673,7 @@ Test(EnableCapRSAkeyGen, invalid_params, .fini = teardown) {
 
 Test(EnableCapRSAkeyGen, invalid_modes_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -706,7 +695,7 @@ Test(EnableCapRSAkeyGen, invalid_modes_params, .fini = teardown) {
  */
 Test(EnableCapRSAkeyGen, cipher_param_mismatch, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -730,7 +719,7 @@ Test(EnableCapRSAkeyGen, cipher_param_mismatch, .fini = teardown) {
 
 Test(EnableCapAES, properly, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -756,22 +745,14 @@ Test(EnableCapAES, properly, .fini = teardown) {
     cr_assert(rv == ACVP_SUCCESS);
 }
 
-Test(EnableCapAES, alg_mismatch, .fini = teardown) {
-    setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
-    cr_assert(rv == ACVP_INVALID_ARG);
-    rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, cvalue);
-    cr_assert(rv == ACVP_NO_CAP);
-}
-
 Test(EnableCapAES, bad_conformance, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CTR, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CTR, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_CONFORMANCE, ACVP_CONFORMANCE_DEFAULT);
     cr_assert(rv == ACVP_INVALID_ARG);
     
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_PARM_CONFORMANCE, ACVP_CONFORMANCE_RFC3686);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -783,7 +764,7 @@ Test(EnableCapAES, bad_conformance, .fini = teardown) {
  */
 Test(EnableCapAES, invalid_callback, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, NULL);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, NULL);
     cr_assert(rv == ACVP_INVALID_ARG);
     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_NO_CAP);
@@ -795,7 +776,7 @@ Test(EnableCapAES, invalid_callback, .fini = teardown) {
  */
 Test(EnableCapAES, invalid_dir, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_PARM_DIR, 0);
@@ -808,7 +789,7 @@ Test(EnableCapAES, invalid_dir, .fini = teardown) {
  */
 Test(EnableCapAES, cipher_param_mismatch, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_GCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 128);
@@ -821,7 +802,7 @@ Test(EnableCapAES, cipher_param_mismatch, .fini = teardown) {
  */
 Test(EnableCapAES, invalid_keylens, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_KEYLEN, 333);
@@ -838,12 +819,12 @@ Test(EnableCapAES, invalid_keylens, .fini = teardown) {
  */
 Test(EnableCapAES, invalid_param_lens, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CFB1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PTLEN, 999999);
     cr_assert(rv == ACVP_INVALID_ARG);
     
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CCM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CCM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 0);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -867,7 +848,7 @@ Test(EnableCapAES, invalid_param_lens, .fini = teardown) {
  */
 Test(EnableCapAES, cipher_invalid_parm_domain, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS2, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_KEYLEN, 0, 128, 8);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -878,7 +859,7 @@ Test(EnableCapAES, cipher_invalid_parm_domain, .fini = teardown) {
  */
 Test(EnableCapAES, cipher_domain_no_ctx, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XPN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_XPN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_domain(NULL, ACVP_AES_XPN, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 128, 8);
     cr_assert(rv == ACVP_NO_CTX);
@@ -889,7 +870,7 @@ Test(EnableCapAES, cipher_domain_no_ctx, .fini = teardown) {
  */
 Test(EnableCapAES, cipher_domain_bad_values, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS3, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_DOMAIN_PTLEN, -64, 128, 8);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -906,7 +887,7 @@ Test(EnableCapAES, cipher_domain_bad_values, .fini = teardown) {
  */
 Test(EnableCapAES, dup_payload_registration, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_AES_CBC_CS1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PTLEN, 33333);
     cr_assert(rv == ACVP_SUCCESS);
@@ -918,7 +899,7 @@ Test(EnableCapAES, dup_payload_registration, .fini = teardown) {
 
 Test(EnableCapTDES, properly, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CBC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -928,7 +909,7 @@ Test(EnableCapTDES, properly, .fini = teardown) {
 
 Test(EnableCapTDES, alg_param_mismatch, .fini = teardown) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CBC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_TAGLEN, 256);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -942,7 +923,7 @@ Test(EnableCapTDES, alg_param_mismatch, .fini = teardown) {
 Test(EnableCapKDF135IKEv1, good, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_ikev1_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_IKEV1, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -983,9 +964,9 @@ Test(EnableCapKDF135IKEv1, good, .fini = teardown) {
 Test(EnableCapKDF135IKEv1, null_vals, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_ikev1_enable(NULL, &dummy_handler_success);
+    rv = acvp_enable_algorithm(NULL, ACVP_KDF135_IKEV1, &dummy_handler_success);
     cr_assert(rv == ACVP_NO_CTX);
-    rv = acvp_cap_kdf135_ikev1_enable(ctx, NULL);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV1, NULL);
     cr_assert(rv == ACVP_INVALID_ARG);
 }
 
@@ -995,7 +976,7 @@ Test(EnableCapKDF135IKEv1, null_vals, .fini = teardown) {
 Test(EnableCapKDF135IKEv1, invalid_domain, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_ikev1_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf135_ikev1_set_domain(ctx, ACVP_KDF_IKEv1_INIT_NONCE_LEN, 0, 2048, 1);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -1024,7 +1005,7 @@ Test(EnableCapKDF135IKEv1, invalid_params, .fini = teardown) {
     
     rv = acvp_cap_kdf135_ikev1_set_parm(ctx, ACVP_KDF_IKEv1_HASH_ALG, 999);
     cr_assert(rv == ACVP_NO_CAP);
-    rv = acvp_cap_kdf135_ikev1_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf135_ikev1_set_parm(ctx, ACVP_KDF_IKEv1_HASH_ALG, 999);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -1039,7 +1020,7 @@ Test(EnableCapKDF135IKEv1, invalid_params, .fini = teardown) {
 Test(EnableCapKDF135IKEv2, good, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_ikev2_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV2, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_IKEV2, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1077,7 +1058,7 @@ Test(EnableCapKDF135IKEv2, good, .fini = teardown) {
 Test(EnableCapKDF135IKEv2, good_domain, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_ikev2_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV2, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf135_ikev2_set_domain(ctx, ACVP_RESPOND_NONCE_LEN, 64, 2048, 1);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1095,9 +1076,9 @@ Test(EnableCapKDF135IKEv2, good_domain, .fini = teardown) {
 Test(EnableCapKDF135IKEv2, null_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_ikev2_enable(NULL, &dummy_handler_success);
+    rv = acvp_enable_algorithm(NULL, ACVP_KDF135_IKEV2, &dummy_handler_success);
     cr_assert(rv == ACVP_NO_CTX);
-    rv = acvp_cap_kdf135_ikev2_enable(ctx, NULL);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV2, NULL);
     cr_assert(rv == ACVP_INVALID_ARG);
 }
 
@@ -1109,7 +1090,7 @@ Test(EnableCapKDF135IKEv2, invalid_len_params, .fini = teardown) {
 
     rv = acvp_cap_kdf135_ikev2_set_length(ctx, ACVP_INIT_NONCE_LEN, 9999);
     cr_assert(rv == ACVP_NO_CAP);
-    rv = acvp_cap_kdf135_ikev2_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV2, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf135_ikev2_set_length(ctx, ACVP_INIT_NONCE_LEN, 9999);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -1144,7 +1125,7 @@ Test(EnableCapKDF135IKEv2, invalid_len_params, .fini = teardown) {
 Test(EnableCapKDF135IKEv2, invalid_hash_alg, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf135_ikev2_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV2, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kdf135_ikev2_set_parm(ctx, ACVP_KDF_HASH_ALG, 999);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -1156,7 +1137,7 @@ Test(EnableCapKDF135IKEv2, invalid_hash_alg, .fini = teardown) {
 Test(EnableCapECDSA, good_keygen, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1196,7 +1177,7 @@ Test(EnableCapECDSA, good_keygen, .fini = teardown) {
 Test(EnableCapECDSA, mode_mismatch_kg, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_KDF135_SNMP, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B233);
     cr_assert(rv == ACVP_NO_CAP);
@@ -1208,7 +1189,7 @@ Test(EnableCapECDSA, mode_mismatch_kg, .fini = teardown) {
 Test(EnableCapECDSA, invalid_params_kg, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, 256);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -1226,7 +1207,7 @@ Test(EnableCapECDSA, invalid_params_kg, .fini = teardown) {
 Test(EnableCapECDSA, good_keyver, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1264,7 +1245,7 @@ Test(EnableCapECDSA, good_keyver, .fini = teardown) {
 Test(EnableCapECDSA, invalid_params_kv, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, 256);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -1277,7 +1258,7 @@ Test(EnableCapECDSA, invalid_params_kv, .fini = teardown) {
 Test(EnableCapECDSA, good_siggen, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1325,7 +1306,7 @@ Test(EnableCapECDSA, good_siggen, .fini = teardown) {
 Test(EnableCapECDSA, invalid_args_sg, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, 256);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -1345,7 +1326,7 @@ Test(EnableCapECDSA, invalid_args_sg, .fini = teardown) {
 Test(EnableCapECDSA, good_sigver, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1392,7 +1373,7 @@ Test(EnableCapECDSA, good_sigver, .fini = teardown) {
 Test(EnableCapECDSA, invalid_args_sv, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, 256);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -1412,7 +1393,7 @@ Test(EnableCapECDSA, invalid_args_sv, .fini = teardown) {
 Test(EnableCapDRBG, good_hash, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
                                    ACVP_DRBG_DER_FUNC_ENABLED, 0);
@@ -1449,7 +1430,7 @@ Test(EnableCapDRBG, good_hash, .fini = teardown) {
 Test(EnableCapDRBG, good_hmac, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMACDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, 
                                      ACVP_PREREQ_SHA, cvalue);
@@ -1490,7 +1471,7 @@ Test(EnableCapDRBG, good_hmac, .fini = teardown) {
 Test(EnableCapDRBG, good_ctr, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CTRDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_CTRDRBG, 
                                      ACVP_PREREQ_AES, cvalue);
@@ -1531,7 +1512,7 @@ Test(EnableCapDRBG, good_ctr, .fini = teardown) {
  * enable drbg with null ctx
  */
 Test(EnableCapDRBG, null_ctx, .fini = teardown) {
-    rv = acvp_cap_drbg_enable(NULL, ACVP_HASHDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(NULL, ACVP_HASHDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_NO_CTX);
 }
 
@@ -1541,7 +1522,7 @@ Test(EnableCapDRBG, null_ctx, .fini = teardown) {
 Test(EnableCapKASECC, good, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1572,7 +1553,7 @@ Test(EnableCapKASECC, good, .fini = teardown) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1609,7 +1590,7 @@ Test(EnableCapKASECC, good, .fini = teardown) {
  * enable kas ecc with valid params
  */
 Test(EnableCapKASECC, null_ctx, .fini = teardown) {
-    rv = acvp_cap_kas_ecc_enable(NULL, ACVP_KAS_ECC_CDH, &dummy_handler_success);
+    rv = acvp_enable_algorithm(NULL, ACVP_KAS_ECC_CDH, &dummy_handler_success);
     cr_assert(rv == ACVP_NO_CTX);
 }
 
@@ -1619,7 +1600,7 @@ Test(EnableCapKASECC, null_ctx, .fini = teardown) {
 Test(EnableCapKASECC, invalid_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_FUNCTION, 0);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -1634,7 +1615,7 @@ Test(EnableCapKASECC, invalid_params, .fini = teardown) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, 0);
     cr_assert(rv == ACVP_INVALID_ARG);
     
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_KAS_ECC_FUNCTION, 0);
     cr_assert(rv == ACVP_INVALID_ARG);
@@ -1662,7 +1643,7 @@ Test(EnableCapKASECC, invalid_params, .fini = teardown) {
 Test(EnableCapKASFFC, good, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_COMP, ACVP_KAS_FFC_MODE_COMPONENT, ACVP_PREREQ_DSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1698,7 +1679,7 @@ Test(EnableCapKASFFC, good, .fini = teardown) {
  * enable kas ffc with valid params
  */
 Test(EnableCapKASFFC, null_ctx, .fini = teardown) {
-    rv = acvp_cap_kas_ffc_enable(NULL, ACVP_KAS_FFC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(NULL, ACVP_KAS_FFC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_NO_CTX);
 }
 
@@ -1708,7 +1689,7 @@ Test(EnableCapKASFFC, null_ctx, .fini = teardown) {
 Test(EnableCapKASFFC, invalid_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     // invalid cipher
     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_KAS_FFC_MODE_COMPONENT, ACVP_KAS_FFC_FUNCTION, ACVP_KAS_FFC_FUNC_DPGEN);
@@ -1730,7 +1711,7 @@ Test(EnableCapKASFFC, invalid_params, .fini = teardown) {
 Test(EnableCapKASHKDF, invalid_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_HKDF, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_HKDF, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     // invalid cipher
     rv = acvp_cap_kda_set_parm(ctx, ACVP_HASH_SHA256, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_UPARTYINFO, NULL);
@@ -1771,7 +1752,7 @@ Test(EnableCapKASHKDF, invalid_params, .fini = teardown) {
 Test(EnableCapKASKDFONESTEP, invalid_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_ONESTEP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_ONESTEP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     // invalid cipher
     rv = acvp_cap_kda_set_parm(ctx, ACVP_HASH_SHA256, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_UPARTYINFO, NULL);
@@ -1811,7 +1792,7 @@ Test(EnableCapKASKDFONESTEP, invalid_params, .fini = teardown) {
 Test(EnableCapKDFTLS13, valid_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf_tls13_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS13, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS13, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1833,9 +1814,9 @@ Test(EnableCapKDFTLS13, valid_params, .fini = teardown) {
 Test(EnableCapKDFTLS13, invalid_params, .fini = teardown) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_kdf_tls13_enable(NULL, &dummy_handler_success);
+    rv = acvp_enable_algorithm(NULL, ACVP_KDF_TLS13, &dummy_handler_success);
     cr_assert(rv == ACVP_NO_CTX);
-    rv = acvp_cap_kdf_tls13_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS13, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS13, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_INVALID_ARG);

--- a/test/test_acvp_cmac.c
+++ b/test/test_acvp_cmac.c
@@ -21,12 +21,12 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_CMAC_AES, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_TDES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_TDES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_CMAC_TDES, ACVP_PREREQ_TDES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -36,12 +36,12 @@ static void setup(void) {
 static void setup_fail(void) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_CMAC_AES, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_TDES, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_TDES, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_CMAC_TDES, ACVP_PREREQ_TDES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -58,7 +58,7 @@ static void teardown(void) {
 Test(CMAC_AES_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_AES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_CMAC_AES, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -84,7 +84,7 @@ Test(CMAC_AES_CAPABILITY, good) {
 Test(CMAC_TDES_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
     
-    rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_TDES, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CMAC_TDES, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_CMAC_TDES, ACVP_PREREQ_TDES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_des.c
+++ b/test/test_acvp_des.c
@@ -23,7 +23,7 @@ static void setup(void) {
     /*
      * Enable 3DES-CBC
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CBC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -34,7 +34,7 @@ static void setup(void) {
     /*
      * Enable TDES-CTR
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CTR, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CTR, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -53,7 +53,7 @@ static void setup_fail(void) {
     /*
      * Enable 3DES-CBC
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBC, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CBC, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -65,7 +65,7 @@ static void setup_fail(void) {
     /*
      * Enable TDES-CTR
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CTR, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CTR, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -91,7 +91,7 @@ Test(DES_CAPABILITY, good) {
     /*
      * Enable 3DES-ECB
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_ECB, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_ECB, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -102,7 +102,7 @@ Test(DES_CAPABILITY, good) {
     /*
      * Enable 3DES-CBC
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CBC, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CBC, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -113,7 +113,7 @@ Test(DES_CAPABILITY, good) {
     /*
      * Enable 3DES-OFB
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_OFB, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_OFB, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -123,7 +123,7 @@ Test(DES_CAPABILITY, good) {
     /*
      * Enable 3DES-CFB64
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB64, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CFB64, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB64, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -133,7 +133,7 @@ Test(DES_CAPABILITY, good) {
     /*
      * Enable 3DES-CFB8
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB8, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CFB8, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
@@ -144,7 +144,7 @@ Test(DES_CAPABILITY, good) {
     /*
      * Enable 3DES-CFB1
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CFB1, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CFB1, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
     cr_assert(rv == ACVP_SUCCESS);
@@ -155,7 +155,7 @@ Test(DES_CAPABILITY, good) {
     /*
      * Enable TDES-CTR
      */
-    rv = acvp_cap_sym_cipher_enable(ctx, ACVP_TDES_CTR, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_TDES_CTR, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_TDES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);

--- a/test/test_acvp_drbg.c
+++ b/test/test_acvp_drbg.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
@@ -60,7 +60,7 @@ static void setup(void) {
             ACVP_DRBG_RET_BITS_LEN, 160);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMACDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, 
@@ -104,7 +104,7 @@ static void setup(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     // ACVP_CTRDRBG
-    rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CTRDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     //Add length range
@@ -144,7 +144,7 @@ static void setup(void) {
 static void setup_fail(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
@@ -183,7 +183,7 @@ static void setup_fail(void) {
             ACVP_DRBG_RET_BITS_LEN, 160);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMACDRBG, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, 
@@ -227,7 +227,7 @@ static void setup_fail(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     // ACVP_CTRDRBG
-    rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_CTRDRBG, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     //Add length range
@@ -274,7 +274,7 @@ static void teardown(void) {
 Test(DRBG_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASHDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0,
@@ -313,7 +313,7 @@ Test(DRBG_CAPABILITY, good) {
             ACVP_DRBG_RET_BITS_LEN, 160);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMACDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, 
@@ -357,7 +357,7 @@ Test(DRBG_CAPABILITY, good) {
     cr_assert(rv == ACVP_SUCCESS);
 
     // ACVP_CTRDRBG
-    rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_CTRDRBG, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
     //Add length range

--- a/test/test_acvp_dsa.c
+++ b/test/test_acvp_dsa.c
@@ -141,7 +141,7 @@ Test(DsaPqgGenApi, null_ctx) {
     cr_assert(rv == ACVP_UNSUPPORTED_OP);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     setup_pqggen();
 
@@ -168,7 +168,7 @@ Test(DsaPqgGenFunc, null_ctx) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     setup_pqggen();
 
@@ -382,7 +382,7 @@ Test(DsaKeyGenApi, null_ctx) {
     cr_assert(rv == ACVP_UNSUPPORTED_OP);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     setup_keygen();
 
@@ -408,7 +408,7 @@ Test(DsaKeyGenFunc, null_ctx) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     setup_keygen();
 
@@ -551,7 +551,7 @@ Test(DsaSigGenApi, null_ctx) {
     cr_assert(rv == ACVP_UNSUPPORTED_OP);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     setup_siggen();
 
@@ -578,7 +578,7 @@ Test(DsaSigGenFunc, null_ctx) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     setup_siggen();
 
@@ -756,7 +756,7 @@ Test(DsaSigVerApi, null_ctx) {
     cr_assert(rv == ACVP_UNSUPPORTED_OP);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -810,7 +810,7 @@ Test(DsaSigVerFunc, null_ctx) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1086,7 +1086,7 @@ Test(DsaPqgVerApi, null_ctx) {
     cr_assert(rv == ACVP_UNSUPPORTED_OP);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1140,7 +1140,7 @@ Test(DsaPqgVerFunc, null_ctx) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -1384,7 +1384,7 @@ Test(DsaPqgVer_HANDLER, cryptoFail1) {
 
     setup_empty_ctx(&ctx);
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGGEN, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGGEN, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     setup_pqggen();
@@ -1418,7 +1418,7 @@ Test(DsaPqgVer_HANDLER, cryptoFail2) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGGEN, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_PQGGEN, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     setup_pqggen();
@@ -1452,7 +1452,7 @@ Test(DsaKeyGen_HANDLER, cryptoFail1) {
     setup_empty_ctx(&ctx);
     /* Enable capabilites */
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_KEYGEN, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_KEYGEN, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     setup_keygen();
@@ -1486,7 +1486,7 @@ Test(DsaKeyGen_HANDLER, cryptoFail2) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_KEYGEN, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_KEYGEN, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     setup_keygen();
@@ -1520,7 +1520,7 @@ Test(SigGen_HANDLER, cryptoFail1) {
     setup_empty_ctx(&ctx);
     /* Enable capabilites */
 
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGGEN, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGGEN, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     setup_siggen();
@@ -1554,7 +1554,7 @@ Test(SigGen_HANDLER, cryptoFail2) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGGEN, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_DSA_SIGGEN, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
 
     setup_siggen();

--- a/test/test_acvp_ecdsa.c
+++ b/test/test_acvp_ecdsa.c
@@ -24,7 +24,7 @@ static void setup(void) {
     /*
      * Enable ECDSA keygen
      */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -40,7 +40,7 @@ static void setup(void) {
     /*
      * Enable ECDSA keyVer...
      */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -54,7 +54,7 @@ static void setup(void) {
     /*
      * Enable ECDSA sigGen...
      */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -70,7 +70,7 @@ static void setup(void) {
     /*
      * Enable ECDSA sigVer...
      */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -93,7 +93,7 @@ static void setup_fail(void) {
     /*
      * Enable ECDSA keygen
      */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -109,7 +109,7 @@ static void setup_fail(void) {
     /*
      * Enable ECDSA keyVer...
      */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYVER, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -123,7 +123,7 @@ static void setup_fail(void) {
     /*
      * Enable ECDSA sigGen...
      */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGGEN, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGGEN, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -139,7 +139,7 @@ static void setup_fail(void) {
     /*
      * Enable ECDSA sigVer...
      */
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGVER, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_SIGVER, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -166,7 +166,7 @@ static void teardown(void) {
 Test(ECDSA_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_ECDSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_hash.c
+++ b/test/test_acvp_hash.c
@@ -20,7 +20,7 @@ static JSON_Value *val = NULL;
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA256, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA256, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA256, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -29,7 +29,7 @@ static void setup(void) {
 static void fail_setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA256, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA256, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA256, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -45,27 +45,27 @@ static void teardown(void) {
 Test(HASH_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA224, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA224, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA224, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA256, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA256, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA256, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA384, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA384, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA384, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_hmac.c
+++ b/test/test_acvp_hmac.c
@@ -25,7 +25,7 @@ static void setup(ACVP_CTX *ctx) {
     ACVP_RESULT rv;
 
     /* Enable capabilites */
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -34,7 +34,7 @@ static void setup(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA1, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_224, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_224, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -43,7 +43,7 @@ static void setup(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_224, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_256, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_256, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -52,7 +52,7 @@ static void setup(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_256, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_384, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_384, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -61,7 +61,7 @@ static void setup(ACVP_CTX *ctx) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_384, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -77,7 +77,7 @@ static void setup_fail(void) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA1, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA1, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -86,7 +86,7 @@ static void setup_fail(void) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA1, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_224, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_224, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -95,7 +95,7 @@ static void setup_fail(void) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_224, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_256, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_256, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -104,7 +104,7 @@ static void setup_fail(void) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_256, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_384, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_384, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -113,7 +113,7 @@ static void setup_fail(void) {
     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_384, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_HMAC_SHA2_512, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_KEYLEN, 256, 448, 8);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kas_ecc.c
+++ b/test/test_acvp_kas_ecc.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -52,7 +52,7 @@ static void setup(void) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -83,7 +83,7 @@ static void setup(void) {
     rv = acvp_cap_kas_ecc_set_scheme(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_KAS_ECC_EPHEMERAL_UNIFIED, ACVP_KAS_ECC_EE, ACVP_EC_CURVE_P521, ACVP_SHA512);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_SSC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_SSC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -113,7 +113,7 @@ static void setup(void) {
 static void setup_fail(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -144,7 +144,7 @@ static void setup_fail(void) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -186,7 +186,7 @@ static void teardown(void) {
 Test(KAS_ECC_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_CDH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -217,7 +217,7 @@ Test(KAS_ECC_CAPABILITY, good) {
     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
     cr_assert(rv == ACVP_SUCCESS);
 
-    rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_ECC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_COMP, ACVP_KAS_ECC_MODE_COMPONENT, ACVP_PREREQ_ECDSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kas_ffc.c
+++ b/test/test_acvp_kas_ffc.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_COMP, ACVP_KAS_FFC_MODE_COMPONENT, ACVP_PREREQ_DSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -53,7 +53,7 @@ static void setup(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     /* Support is for FFC-SSC for hashZ only */
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_SSC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_SSC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_DSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -79,7 +79,7 @@ static void setup(void) {
 static void setup_fail(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_COMP, ACVP_KAS_FFC_MODE_COMPONENT, ACVP_PREREQ_DSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -111,7 +111,7 @@ static void setup_fail(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     /* Support is for FFC-SSC for hashZ only */
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_SSC, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_SSC, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_DSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -139,7 +139,7 @@ static void sp_setup(void) {
     setup_empty_ctx(&ctx);
 
     /* Support is for FFC-SSC for hashZ only */
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_SSC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_SSC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_DSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -197,7 +197,7 @@ static void teardown(void) {
 Test(KAS_FFC_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_FFC_COMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_COMP, ACVP_KAS_FFC_MODE_COMPONENT, ACVP_PREREQ_DSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kas_ifc.c
+++ b/test/test_acvp_kas_ifc.c
@@ -24,7 +24,7 @@ static void setup(void) {
     strncpy(expo_str, "010001", 7); // RSA_F4
 
     /* Support is for IFC-SSC for hashZ only */
-    rv = acvp_cap_kas_ifc_enable(ctx, ACVP_KAS_IFC_SSC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_IFC_SSC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_RSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -67,7 +67,7 @@ Test(KAS_IFC_CAPABILITY, good) {
 
     setup_empty_ctx(&ctx);
     /* Support is for IFC-SSC for hashZ only */
-    rv = acvp_cap_kas_ifc_enable(ctx, ACVP_KAS_IFC_SSC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KAS_IFC_SSC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_RSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kda.c
+++ b/test/test_acvp_kda.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_HKDF, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_HKDF, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_HKDF, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -59,7 +59,7 @@ static void setup(void) {
     cr_assert(rv == ACVP_SUCCESS);
 
     // kdf onestep
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_ONESTEP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_ONESTEP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -116,7 +116,7 @@ Test(KDA_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
 
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_HKDF, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_HKDF, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_HKDF, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -154,7 +154,7 @@ Test(KDA_CAPABILITY, good) {
     cr_assert(rv == ACVP_SUCCESS);
 
     // kdf onestep
-    rv = acvp_cap_kda_enable(ctx, ACVP_KDA_ONESTEP, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDA_ONESTEP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kdf108.c
+++ b/test/test_acvp_kdf108.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf108_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -48,7 +48,7 @@ static void setup(void) {
 static void fail_setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf108_enable(ctx, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -82,7 +82,7 @@ static void teardown(void) {
 Test(KDF108_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf108_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF108, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kdf135_ikev1.c
+++ b/test/test_acvp_kdf135_ikev1.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf135_ikev1_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_IKEV1, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -44,7 +44,7 @@ static void setup(void) {
 static void setup_fail(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf135_ikev1_enable(ctx, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV1, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_IKEV1, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -74,7 +74,7 @@ static void teardown(void) {
 Test(KDF135_IKEV1_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf135_ikev1_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_IKEV1, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kdf135_ikev2.c
+++ b/test/test_acvp_kdf135_ikev2.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf135_ikev2_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV2, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_IKEV2, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -48,7 +48,7 @@ static void setup(void) {
 static void setup_fail(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf135_ikev2_enable(ctx, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV2, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_IKEV2, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -82,7 +82,7 @@ static void teardown(void) {
 Test(KDF135_IKEV2_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf135_ikev2_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_IKEV2, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_IKEV2, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kdf135_snmp.c
+++ b/test/test_acvp_kdf135_snmp.c
@@ -38,7 +38,7 @@ Test(Kdf135SnmpApi, null_ctx) {
     cr_assert(rv == ACVP_UNSUPPORTED_OP);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_snmp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SNMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -71,7 +71,7 @@ Test(Kdf135SnmpFunc, null_ctx) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_snmp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SNMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -217,7 +217,7 @@ Test(Kdf135SnmpFail, cryptoFail1) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_snmp_enable(ctx, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SNMP, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -252,7 +252,7 @@ Test(Kdf135SnmpFail, cryptoFail2) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_snmp_enable(ctx, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SNMP, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -287,7 +287,7 @@ Test(Kdf135SnmpFail, tcidFail) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_snmp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SNMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -320,7 +320,7 @@ Test(Kdf135SnmpFail, tcFail) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_snmp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SNMP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SNMP, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kdf135_srtp.c
+++ b/test/test_acvp_kdf135_srtp.c
@@ -23,7 +23,7 @@ static void setup(void) {
 
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf135_srtp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SRTP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SRTP, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -46,7 +46,7 @@ static void setup_fail(void) {
 
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf135_srtp_enable(ctx, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SRTP, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SRTP, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -76,7 +76,7 @@ Test(KDF135_SRTP_CAPABILITY, good) {
 
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf135_srtp_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SRTP, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SRTP, ACVP_PREREQ_AES, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kdf135_ssh.c
+++ b/test/test_acvp_kdf135_ssh.c
@@ -39,7 +39,7 @@ Test(Kdf135SshApi, null_ctx) {
     cr_assert(rv == ACVP_UNSUPPORTED_OP);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -85,7 +85,7 @@ Test(Kdf135SshFunc, null_ctx) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -268,7 +268,7 @@ Test(Kdf135SshFail, cryptoFail1) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -317,7 +317,7 @@ Test(Kdf135SshFail, cryptoFail2) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -367,7 +367,7 @@ Test(Kdf135SshFail, tcidFail) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -414,7 +414,7 @@ Test(Kdf135SshFail, tcFail) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_ssh_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_SSH, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kdf135_x963.c
+++ b/test/test_acvp_kdf135_x963.c
@@ -59,7 +59,7 @@ Test(Kdf135x963Func1, null_ctx) {
     }
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -102,7 +102,7 @@ Test(Kdf135x963Func2, null_obj) {
     setup_empty_ctx(&ctx);
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -127,7 +127,7 @@ Test(Kdf135x963Func3, properly) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -159,7 +159,7 @@ Test(Kdf135x963Func4, missing) {
     setup_empty_ctx(&ctx);
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -192,7 +192,7 @@ Test(Kdf135x963Func5, missing) {
     setup_empty_ctx(&ctx);
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -224,7 +224,7 @@ Test(Kdf135x963Func6, missing) {
     setup_empty_ctx(&ctx);
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -256,7 +256,7 @@ Test(Kdf135x963Func7, invalid) {
     setup_empty_ctx(&ctx);
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -288,7 +288,7 @@ Test(Kdf135x963Func8, missing) {
     setup_empty_ctx(&ctx);
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -320,7 +320,7 @@ Test(Kdf135x963Func9, missing) {
     setup_empty_ctx(&ctx);
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -352,7 +352,7 @@ Test(Kdf135x963Func10, missing) {
     setup_empty_ctx(&ctx);
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -385,7 +385,7 @@ Test(Kdf135x963Func11, missing) {
     setup_empty_ctx(&ctx);
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -418,7 +418,7 @@ Test(Kdf135x963Func11, missing_tgid) {
     setup_empty_ctx(&ctx);
     
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -451,7 +451,7 @@ Test(Kdf135x963Fail, cryptoFail1) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -484,7 +484,7 @@ Test(Kdf135x963Fail, cryptoFail2) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -517,7 +517,7 @@ Test(Kdf135x963Fail, tgFail) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -548,7 +548,7 @@ Test(Kdf135x963Fail, tcFail) {
     setup_empty_ctx(&ctx);
 
     /* Enable capabilites */
-    rv = acvp_cap_kdf135_x963_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF135_X963, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kdf_tls12.c
+++ b/test/test_acvp_kdf_tls12.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf_tls12_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS12, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -38,7 +38,7 @@ static void setup(void) {
 static void setup_fail(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf_tls12_enable(ctx, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS12, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -62,7 +62,7 @@ static void teardown(void) {
 Test(KDF_TLS12_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf_tls12_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS12, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kdf_tls13.c
+++ b/test/test_acvp_kdf_tls13.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf_tls13_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS13, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS13, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -47,7 +47,7 @@ static void teardown(void) {
 Test(KDF_TLS13_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kdf_tls13_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KDF_TLS13, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS13, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kmac.c
+++ b/test/test_acvp_kmac.c
@@ -19,9 +19,9 @@ static JSON_Value *val = NULL;
 
 static void setup(void) {
     setup_empty_ctx(&ctx);
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_128, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_128, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_256, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_256, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
 
 }
@@ -36,7 +36,7 @@ static void teardown(void) {
 Test(KMAC_128_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_128, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_128, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_128, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);
@@ -58,7 +58,7 @@ Test(KMAC_128_CAPABILITY, good) {
 Test(KMAC_256_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_256, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KMAC_256, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_256, ACVP_KMAC_MSGLEN, 0, 65536, 8);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_kts_ifc.c
+++ b/test/test_acvp_kts_ifc.c
@@ -23,7 +23,7 @@ static void setup(void) {
     char *expo_str = calloc(7, sizeof(char));
     strncpy(expo_str, "010001", 7); // RSA_F4
 
-    rv = acvp_cap_kts_ifc_enable(ctx, ACVP_KTS_IFC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KTS_IFC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KTS_IFC, ACVP_PREREQ_RSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -80,7 +80,7 @@ Test(KTS_IFC_CAPABILITY, good) {
     char *expo_str = calloc(7, sizeof(char));
     strncpy(expo_str, "010001", 7); // RSA_F4
 
-    rv = acvp_cap_kts_ifc_enable(ctx, ACVP_KTS_IFC, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_KTS_IFC, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_KTS_IFC, ACVP_PREREQ_RSA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_pbkdf.c
+++ b/test/test_acvp_pbkdf.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_pbkdf_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_PBKDF, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_PBKDF, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -63,7 +63,7 @@ static void teardown(void) {
 Test(PBKDF_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_pbkdf_enable(ctx, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_PBKDF, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_PBKDF, ACVP_PREREQ_HMAC, cvalue);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_rsa_keygen.c
+++ b/test/test_acvp_rsa_keygen.c
@@ -24,7 +24,7 @@ static void setup(void) {
 
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -57,7 +57,7 @@ static void setup_fail(void) {
 
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -97,7 +97,7 @@ Test(RSA_KEYGEN_CAPABILITY, good) {
 
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_rsa_prim.c
+++ b/test/test_acvp_rsa_prim.c
@@ -27,7 +27,7 @@ static void setup(void) {
     /*
      * Enable Decryption Primitive
      */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_DECPRIM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_DECPRIM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_REVISION, ACVP_REVISION_1_0);
     cr_assert(rv == ACVP_SUCCESS);
@@ -39,7 +39,7 @@ static void setup(void) {
     /*
      * Enable Signature Primitive
      */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_SIGPRIM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGPRIM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_REVISION, ACVP_REVISION_1_0);
     cr_assert(rv == ACVP_SUCCESS);
@@ -72,7 +72,7 @@ Test(RSA_PRIM_CAPABILITY, good) {
     /*
      * Enable Decryption Primitive
      */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_DECPRIM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_DECPRIM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_REVISION, ACVP_REVISION_1_0);
     cr_assert(rv == ACVP_SUCCESS);
@@ -84,7 +84,7 @@ Test(RSA_PRIM_CAPABILITY, good) {
     /*
      * Enable Signature Primitive
      */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_SIGPRIM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGPRIM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_REVISION, ACVP_REVISION_1_0);
     cr_assert(rv == ACVP_SUCCESS);
@@ -207,7 +207,7 @@ Test(RSA_DECPRIM_API, error_paths) {
     /*
      * Enable Decryption Primitive
      */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_DECPRIM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_DECPRIM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_REVISION, ACVP_REVISION_1_0);
     cr_assert(rv == ACVP_SUCCESS);
@@ -323,7 +323,7 @@ Test(RSA_SIGPRIM_API, error_paths) {
     /*
      * Enable Signature Primitive
      */
-    rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_SIGPRIM, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGPRIM, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_REVISION, ACVP_REVISION_1_0);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_rsa_sig.c
+++ b/test/test_acvp_rsa_sig.c
@@ -21,7 +21,7 @@ static char cvalue[] = "same";
 static void setup_siggen(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_siggen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -52,7 +52,7 @@ static void setup_siggen(void) {
 static void setup_siggen_fail(void) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGGEN, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_siggen_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -86,7 +86,7 @@ static void setup_sigver(void) {
     char *expo_str = calloc(7, sizeof(char));
     strncpy(expo_str, "010001", 7); // RSA_F4
     
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_sigver_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -126,7 +126,7 @@ static void setup_sigver_fail(void) {
     char *expo_str = calloc(7, sizeof(char));
     strncpy(expo_str, "010001", 7); // RSA_F4
     
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGVER, &dummy_handler_failure);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGVER, &dummy_handler_failure);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_sigver_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);
@@ -171,7 +171,7 @@ static void teardown(void) {
 Test(RSA_SIGGEN_CAPABILITY, good) {
     setup_empty_ctx(&ctx);
 
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGGEN, ACVP_PREREQ_SHA, cvalue);
     cr_assert(rv == ACVP_SUCCESS);
@@ -449,7 +449,7 @@ Test(RSA_SIGVER_CAPABILITY, good) {
     char *expo_str = calloc(7, sizeof(char));
     strncpy(expo_str, "010001", 7); // RSA_F4
     
-    rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_RSA_SIGVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_rsa_sigver_set_parm(ctx, ACVP_RSA_PARM_REVISION, ACVP_REVISION_FIPS186_4);
     cr_assert(rv == ACVP_SUCCESS);

--- a/test/test_acvp_safe_primes.c
+++ b/test/test_acvp_safe_primes.c
@@ -24,7 +24,7 @@ static void setup(void) {
     /*
      * Register Safe Prime Key Generation testing
      */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYGEN, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYGEN, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYGEN,
                                   ACVP_PREREQ_DRBG, cvalue);
@@ -57,7 +57,7 @@ static void setup(void) {
     /*
      * Register Safe Prime Key Verify testing
      */
-    rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYVER, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_SAFE_PRIMES_KEYVER, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYVER,
                                   ACVP_PREREQ_DRBG, cvalue);

--- a/test/test_acvp_transport.c
+++ b/test/test_acvp_transport.c
@@ -85,12 +85,12 @@ static void test_setup_session_parameters(void)
 
 #ifdef TEST_TRANSPORT
 static void add_hash_details_good(void) {
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA1, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);
     
-    rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512, &dummy_handler_success);
+    rv = acvp_enable_algorithm(ctx, ACVP_HASH_SHA512, &dummy_handler_success);
     cr_assert(rv == ACVP_SUCCESS);
     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512, ACVP_HASH_MESSAGE_LEN, 0, 65528, 8);
     cr_assert(rv == ACVP_SUCCESS);


### PR DESCRIPTION
This is the first PR for the next major release of libacvp; this release has no definitive timeline.

Libacvp currently has about 3 dozen different APIs for enabling different algorithms or groups of algorithms. Each of these APIs is doing roughly the same thing - just creating a new capability object after doing the right checks.

This removes all of those APIs and creates one new one called acvp_enable_algorithm(). None of the underlying behavior has changed, it has all just been combined.

All function calls both in registration and in unit test code have been replaced.

Changes were tested and a full session of 3.5.0 algorithms passed with no issues. All unit tests also passed. 