### PR TITLE
Library support for cSHAKE, OpenSSL 4.X harness (2.3.0 branch)

### DIFF
--- a/app/Makefile.am
+++ b/app/Makefile.am
@@ -18,6 +18,7 @@ tmp_sources += implementations/openssl/3/iut.c \
                implementations/openssl/3/registrations/non_fips.c \
                implementations/openssl/3/registrations/fp_340.c \
                implementations/openssl/3/registrations/fp_350.c \
+               implementations/openssl/3/registrations/fp_4X.c \
                implementations/openssl/3/iut_aes.c \
                implementations/openssl/3/iut_cmac.c \
                implementations/openssl/3/iut_des.c \
@@ -30,6 +31,7 @@ tmp_sources += implementations/openssl/3/iut.c \
                implementations/openssl/3/iut_kdf.c \
                implementations/openssl/3/iut_kda.c \
                implementations/openssl/3/iut_kmac.c \
+               implementations/openssl/3/iut_cshake.c \
                implementations/openssl/3/iut_rsa.c \
                implementations/openssl/3/iut_hash.c \
                implementations/openssl/3/iut_ml_dsa.c \

--- a/app/Makefile.in
+++ b/app/Makefile.in
@@ -98,6 +98,7 @@ host_triplet = @host@
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/registrations/non_fips.c \
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/registrations/fp_340.c \
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/registrations/fp_350.c \
+@APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/registrations/fp_4X.c \
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/iut_aes.c \
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/iut_cmac.c \
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/iut_des.c \
@@ -110,6 +111,7 @@ host_triplet = @host@
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/iut_kdf.c \
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/iut_kda.c \
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/iut_kmac.c \
+@APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/iut_cshake.c \
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/iut_rsa.c \
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/iut_hash.c \
 @APP_IUT_OPENSSL_3_TRUE@               implementations/openssl/3/iut_ml_dsa.c \
@@ -185,6 +187,7 @@ am__libacvp_app_la_SOURCES_DIST = app_main.c app_cli.c app_utils.c \
 	implementations/openssl/3/registrations/non_fips.c \
 	implementations/openssl/3/registrations/fp_340.c \
 	implementations/openssl/3/registrations/fp_350.c \
+	implementations/openssl/3/registrations/fp_4X.c \
 	implementations/openssl/3/iut_aes.c \
 	implementations/openssl/3/iut_cmac.c \
 	implementations/openssl/3/iut_des.c \
@@ -197,6 +200,7 @@ am__libacvp_app_la_SOURCES_DIST = app_main.c app_cli.c app_utils.c \
 	implementations/openssl/3/iut_kdf.c \
 	implementations/openssl/3/iut_kda.c \
 	implementations/openssl/3/iut_kmac.c \
+	implementations/openssl/3/iut_cshake.c \
 	implementations/openssl/3/iut_rsa.c \
 	implementations/openssl/3/iut_hash.c \
 	implementations/openssl/3/iut_ml_dsa.c \
@@ -215,6 +219,7 @@ am__dirstamp = $(am__leading_dot)dirstamp
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/registrations/non_fips.lo \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/registrations/fp_340.lo \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/registrations/fp_350.lo \
+@APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/registrations/fp_4X.lo \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut_aes.lo \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut_cmac.lo \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut_des.lo \
@@ -227,6 +232,7 @@ am__dirstamp = $(am__leading_dot)dirstamp
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut_kdf.lo \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut_kda.lo \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut_kmac.lo \
+@APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut_cshake.lo \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut_rsa.lo \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut_hash.lo \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/iut_ml_dsa.lo \
@@ -258,6 +264,7 @@ am__acvp_app_SOURCES_DIST = app_main.c app_cli.c app_utils.c app_lcl.h \
 	implementations/openssl/3/registrations/non_fips.c \
 	implementations/openssl/3/registrations/fp_340.c \
 	implementations/openssl/3/registrations/fp_350.c \
+	implementations/openssl/3/registrations/fp_4X.c \
 	implementations/openssl/3/iut_aes.c \
 	implementations/openssl/3/iut_cmac.c \
 	implementations/openssl/3/iut_des.c \
@@ -270,6 +277,7 @@ am__acvp_app_SOURCES_DIST = app_main.c app_cli.c app_utils.c app_lcl.h \
 	implementations/openssl/3/iut_kdf.c \
 	implementations/openssl/3/iut_kda.c \
 	implementations/openssl/3/iut_kmac.c \
+	implementations/openssl/3/iut_cshake.c \
 	implementations/openssl/3/iut_rsa.c \
 	implementations/openssl/3/iut_hash.c \
 	implementations/openssl/3/iut_ml_dsa.c \
@@ -286,6 +294,7 @@ am__acvp_app_SOURCES_DIST = app_main.c app_cli.c app_utils.c app_lcl.h \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/registrations/acvp_app-non_fips.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/registrations/acvp_app-fp_340.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/registrations/acvp_app-fp_350.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/registrations/acvp_app-fp_4X.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_aes.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_cmac.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_des.$(OBJEXT) \
@@ -298,6 +307,7 @@ am__acvp_app_SOURCES_DIST = app_main.c app_cli.c app_utils.c app_lcl.h \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_kdf.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_kda.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_kmac.$(OBJEXT) \
+@APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_cshake.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_rsa.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_hash.$(OBJEXT) \
 @APP_IUT_OPENSSL_3_TRUE@	implementations/openssl/3/acvp_app-iut_ml_dsa.$(OBJEXT) \
@@ -349,6 +359,7 @@ am__depfiles_remade = ./$(DEPDIR)/acvp_app-app_cli.Po \
 	implementations/openssl/3/$(DEPDIR)/acvp_app-iut.Po \
 	implementations/openssl/3/$(DEPDIR)/acvp_app-iut_aes.Po \
 	implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cmac.Po \
+	implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cshake.Po \
 	implementations/openssl/3/$(DEPDIR)/acvp_app-iut_des.Po \
 	implementations/openssl/3/$(DEPDIR)/acvp_app-iut_drbg.Po \
 	implementations/openssl/3/$(DEPDIR)/acvp_app-iut_dsa.Po \
@@ -368,6 +379,7 @@ am__depfiles_remade = ./$(DEPDIR)/acvp_app-app_cli.Po \
 	implementations/openssl/3/$(DEPDIR)/iut.Plo \
 	implementations/openssl/3/$(DEPDIR)/iut_aes.Plo \
 	implementations/openssl/3/$(DEPDIR)/iut_cmac.Plo \
+	implementations/openssl/3/$(DEPDIR)/iut_cshake.Plo \
 	implementations/openssl/3/$(DEPDIR)/iut_des.Plo \
 	implementations/openssl/3/$(DEPDIR)/iut_drbg.Plo \
 	implementations/openssl/3/$(DEPDIR)/iut_dsa.Plo \
@@ -388,11 +400,13 @@ am__depfiles_remade = ./$(DEPDIR)/acvp_app-app_cli.Po \
 	implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_312.Po \
 	implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_340.Po \
 	implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_350.Po \
+	implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_4X.Po \
 	implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-non_fips.Po \
 	implementations/openssl/3/registrations/$(DEPDIR)/fp_30X.Plo \
 	implementations/openssl/3/registrations/$(DEPDIR)/fp_312.Plo \
 	implementations/openssl/3/registrations/$(DEPDIR)/fp_340.Plo \
 	implementations/openssl/3/registrations/$(DEPDIR)/fp_350.Plo \
+	implementations/openssl/3/registrations/$(DEPDIR)/fp_4X.Plo \
 	implementations/openssl/3/registrations/$(DEPDIR)/non_fips.Plo \
 	totp/$(DEPDIR)/acvp_app-hmac_sha256.Po \
 	totp/$(DEPDIR)/acvp_app-sha256.Po \
@@ -762,6 +776,9 @@ implementations/openssl/3/registrations/fp_340.lo:  \
 implementations/openssl/3/registrations/fp_350.lo:  \
 	implementations/openssl/3/registrations/$(am__dirstamp) \
 	implementations/openssl/3/registrations/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/registrations/fp_4X.lo:  \
+	implementations/openssl/3/registrations/$(am__dirstamp) \
+	implementations/openssl/3/registrations/$(DEPDIR)/$(am__dirstamp)
 implementations/openssl/3/iut_aes.lo:  \
 	implementations/openssl/3/$(am__dirstamp) \
 	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
@@ -796,6 +813,9 @@ implementations/openssl/3/iut_kda.lo:  \
 	implementations/openssl/3/$(am__dirstamp) \
 	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
 implementations/openssl/3/iut_kmac.lo:  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/iut_cshake.lo:  \
 	implementations/openssl/3/$(am__dirstamp) \
 	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
 implementations/openssl/3/iut_rsa.lo:  \
@@ -866,6 +886,9 @@ implementations/openssl/3/registrations/acvp_app-fp_340.$(OBJEXT):  \
 implementations/openssl/3/registrations/acvp_app-fp_350.$(OBJEXT):  \
 	implementations/openssl/3/registrations/$(am__dirstamp) \
 	implementations/openssl/3/registrations/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/registrations/acvp_app-fp_4X.$(OBJEXT):  \
+	implementations/openssl/3/registrations/$(am__dirstamp) \
+	implementations/openssl/3/registrations/$(DEPDIR)/$(am__dirstamp)
 implementations/openssl/3/acvp_app-iut_aes.$(OBJEXT):  \
 	implementations/openssl/3/$(am__dirstamp) \
 	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
@@ -900,6 +923,9 @@ implementations/openssl/3/acvp_app-iut_kda.$(OBJEXT):  \
 	implementations/openssl/3/$(am__dirstamp) \
 	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
 implementations/openssl/3/acvp_app-iut_kmac.$(OBJEXT):  \
+	implementations/openssl/3/$(am__dirstamp) \
+	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
+implementations/openssl/3/acvp_app-iut_cshake.$(OBJEXT):  \
 	implementations/openssl/3/$(am__dirstamp) \
 	implementations/openssl/3/$(DEPDIR)/$(am__dirstamp)
 implementations/openssl/3/acvp_app-iut_rsa.$(OBJEXT):  \
@@ -967,6 +993,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/acvp_app-iut.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/acvp_app-iut_aes.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cmac.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cshake.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/acvp_app-iut_des.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/acvp_app-iut_drbg.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/acvp_app-iut_dsa.Po@am__quote@ # am--include-marker
@@ -986,6 +1013,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/iut.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/iut_aes.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/iut_cmac.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/iut_cshake.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/iut_des.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/iut_drbg.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/$(DEPDIR)/iut_dsa.Plo@am__quote@ # am--include-marker
@@ -1006,11 +1034,13 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_312.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_340.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_350.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_4X.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-non_fips.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/registrations/$(DEPDIR)/fp_30X.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/registrations/$(DEPDIR)/fp_312.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/registrations/$(DEPDIR)/fp_340.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/registrations/$(DEPDIR)/fp_350.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/registrations/$(DEPDIR)/fp_4X.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@implementations/openssl/3/registrations/$(DEPDIR)/non_fips.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@totp/$(DEPDIR)/acvp_app-hmac_sha256.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@totp/$(DEPDIR)/acvp_app-sha256.Po@am__quote@ # am--include-marker
@@ -1231,6 +1261,20 @@ implementations/openssl/3/registrations/acvp_app-fp_350.obj: implementations/ope
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/registrations/acvp_app-fp_350.obj `if test -f 'implementations/openssl/3/registrations/fp_350.c'; then $(CYGPATH_W) 'implementations/openssl/3/registrations/fp_350.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/registrations/fp_350.c'; fi`
 
+implementations/openssl/3/registrations/acvp_app-fp_4X.o: implementations/openssl/3/registrations/fp_4X.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/registrations/acvp_app-fp_4X.o -MD -MP -MF implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_4X.Tpo -c -o implementations/openssl/3/registrations/acvp_app-fp_4X.o `test -f 'implementations/openssl/3/registrations/fp_4X.c' || echo '$(srcdir)/'`implementations/openssl/3/registrations/fp_4X.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_4X.Tpo implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_4X.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/registrations/fp_4X.c' object='implementations/openssl/3/registrations/acvp_app-fp_4X.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/registrations/acvp_app-fp_4X.o `test -f 'implementations/openssl/3/registrations/fp_4X.c' || echo '$(srcdir)/'`implementations/openssl/3/registrations/fp_4X.c
+
+implementations/openssl/3/registrations/acvp_app-fp_4X.obj: implementations/openssl/3/registrations/fp_4X.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/registrations/acvp_app-fp_4X.obj -MD -MP -MF implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_4X.Tpo -c -o implementations/openssl/3/registrations/acvp_app-fp_4X.obj `if test -f 'implementations/openssl/3/registrations/fp_4X.c'; then $(CYGPATH_W) 'implementations/openssl/3/registrations/fp_4X.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/registrations/fp_4X.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_4X.Tpo implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_4X.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/registrations/fp_4X.c' object='implementations/openssl/3/registrations/acvp_app-fp_4X.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/registrations/acvp_app-fp_4X.obj `if test -f 'implementations/openssl/3/registrations/fp_4X.c'; then $(CYGPATH_W) 'implementations/openssl/3/registrations/fp_4X.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/registrations/fp_4X.c'; fi`
+
 implementations/openssl/3/acvp_app-iut_aes.o: implementations/openssl/3/iut_aes.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/acvp_app-iut_aes.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/acvp_app-iut_aes.Tpo -c -o implementations/openssl/3/acvp_app-iut_aes.o `test -f 'implementations/openssl/3/iut_aes.c' || echo '$(srcdir)/'`implementations/openssl/3/iut_aes.c
 @am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/acvp_app-iut_aes.Tpo implementations/openssl/3/$(DEPDIR)/acvp_app-iut_aes.Po
@@ -1398,6 +1442,20 @@ implementations/openssl/3/acvp_app-iut_kmac.obj: implementations/openssl/3/iut_k
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/iut_kmac.c' object='implementations/openssl/3/acvp_app-iut_kmac.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/acvp_app-iut_kmac.obj `if test -f 'implementations/openssl/3/iut_kmac.c'; then $(CYGPATH_W) 'implementations/openssl/3/iut_kmac.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/iut_kmac.c'; fi`
+
+implementations/openssl/3/acvp_app-iut_cshake.o: implementations/openssl/3/iut_cshake.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/acvp_app-iut_cshake.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cshake.Tpo -c -o implementations/openssl/3/acvp_app-iut_cshake.o `test -f 'implementations/openssl/3/iut_cshake.c' || echo '$(srcdir)/'`implementations/openssl/3/iut_cshake.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cshake.Tpo implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cshake.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/iut_cshake.c' object='implementations/openssl/3/acvp_app-iut_cshake.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/acvp_app-iut_cshake.o `test -f 'implementations/openssl/3/iut_cshake.c' || echo '$(srcdir)/'`implementations/openssl/3/iut_cshake.c
+
+implementations/openssl/3/acvp_app-iut_cshake.obj: implementations/openssl/3/iut_cshake.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/acvp_app-iut_cshake.obj -MD -MP -MF implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cshake.Tpo -c -o implementations/openssl/3/acvp_app-iut_cshake.obj `if test -f 'implementations/openssl/3/iut_cshake.c'; then $(CYGPATH_W) 'implementations/openssl/3/iut_cshake.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/iut_cshake.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cshake.Tpo implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cshake.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='implementations/openssl/3/iut_cshake.c' object='implementations/openssl/3/acvp_app-iut_cshake.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -c -o implementations/openssl/3/acvp_app-iut_cshake.obj `if test -f 'implementations/openssl/3/iut_cshake.c'; then $(CYGPATH_W) 'implementations/openssl/3/iut_cshake.c'; else $(CYGPATH_W) '$(srcdir)/implementations/openssl/3/iut_cshake.c'; fi`
 
 implementations/openssl/3/acvp_app-iut_rsa.o: implementations/openssl/3/iut_rsa.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(acvp_app_CFLAGS) $(CFLAGS) -MT implementations/openssl/3/acvp_app-iut_rsa.o -MD -MP -MF implementations/openssl/3/$(DEPDIR)/acvp_app-iut_rsa.Tpo -c -o implementations/openssl/3/acvp_app-iut_rsa.o `test -f 'implementations/openssl/3/iut_rsa.c' || echo '$(srcdir)/'`implementations/openssl/3/iut_rsa.c
@@ -1714,6 +1772,7 @@ distclean: distclean-am
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_aes.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cmac.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cshake.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_des.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_drbg.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_dsa.Po
@@ -1733,6 +1792,7 @@ distclean: distclean-am
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut_aes.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut_cmac.Plo
+	-rm -f implementations/openssl/3/$(DEPDIR)/iut_cshake.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut_des.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut_drbg.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut_dsa.Plo
@@ -1753,11 +1813,13 @@ distclean: distclean-am
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_312.Po
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_340.Po
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_350.Po
+	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_4X.Po
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-non_fips.Po
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/fp_30X.Plo
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/fp_312.Plo
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/fp_340.Plo
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/fp_350.Plo
+	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/fp_4X.Plo
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/non_fips.Plo
 	-rm -f totp/$(DEPDIR)/acvp_app-hmac_sha256.Po
 	-rm -f totp/$(DEPDIR)/acvp_app-sha256.Po
@@ -1827,6 +1889,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_aes.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cmac.Po
+	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_cshake.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_des.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_drbg.Po
 	-rm -f implementations/openssl/3/$(DEPDIR)/acvp_app-iut_dsa.Po
@@ -1846,6 +1909,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut_aes.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut_cmac.Plo
+	-rm -f implementations/openssl/3/$(DEPDIR)/iut_cshake.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut_des.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut_drbg.Plo
 	-rm -f implementations/openssl/3/$(DEPDIR)/iut_dsa.Plo
@@ -1866,11 +1930,13 @@ maintainer-clean: maintainer-clean-am
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_312.Po
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_340.Po
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_350.Po
+	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-fp_4X.Po
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/acvp_app-non_fips.Po
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/fp_30X.Plo
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/fp_312.Plo
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/fp_340.Plo
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/fp_350.Plo
+	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/fp_4X.Plo
 	-rm -f implementations/openssl/3/registrations/$(DEPDIR)/non_fips.Plo
 	-rm -f totp/$(DEPDIR)/acvp_app-hmac_sha256.Po
 	-rm -f totp/$(DEPDIR)/acvp_app-sha256.Po

--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -79,6 +79,8 @@ static void print_usage(int code) {
     printf("      --ml_dsa\n");
     printf("      --ml_kem\n");
     printf("      --slh_dsa\n");
+    printf("      --kmac\n");
+    printf("      --cshake\n");
     printf("\n");
 
     printf("      If running hash, a maximum size for large data testing (LDT) may be required on specific\n");
@@ -221,6 +223,7 @@ static ko_longopt_t longopts[] = {
     { "ml_dsa", ko_no_argument, 329 },
     { "ml_kem", ko_no_argument, 330 },
     { "slh_dsa", ko_no_argument, 331 },
+    { "cshake", ko_no_argument, 332 },
     { "all_algs", ko_no_argument, 350 },
     { "manual_registration", ko_required_argument, 400 },
     { "fips_validation", ko_required_argument, 402 },
@@ -419,6 +422,10 @@ int ingest_cli(APP_CONFIG *cfg, int argc, char **argv) {
             break;
         case 331:
             cfg->slh_dsa = 1;
+            cfg->empty_alg = 0;
+            break;
+        case 332:
+            cfg->cshake = 1;
             cfg->empty_alg = 0;
             break;
         case 'a':

--- a/app/app_lcl.h
+++ b/app/app_lcl.h
@@ -90,7 +90,7 @@ typedef struct app_config {
      * 0 is off, 1 is on
      */
     int aes; int tdes;
-    int hash; int cmac; int hmac; int kmac;
+    int hash; int cmac; int hmac; int kmac; int cshake;
     int dsa; int rsa;
     int drbg; int ecdsa; int eddsa;
     int kas_ecc; int kas_ffc; int kas_ifc; int kda; int kts_ifc;

--- a/app/implementations/openssl/3/iut.c
+++ b/app/implementations/openssl/3/iut.c
@@ -121,8 +121,11 @@ ACVP_RESULT iut_register_capabilities(ACVP_CTX *ctx, APP_CONFIG *cfg) {
     } else if (fips_ver < OPENSSL_FIPS_350) { // for any versions of 3.4.0
         printf("Registering capabilities for FP 3.4.0 (not certified)...\n");
         return register_capabilities_fp_340(ctx, cfg);
-    } else {
+    } else if (fips_ver < OPENSSL_FIPS_360) { // for any versions of 3.5.0
         printf("Registering capabilities for FP 3.5.0...\n");
         return register_capabilities_fp_350(ctx, cfg);
+    } else {
+        printf("Registering capabilities for FP 4.X (unverified)...\n");
+        return register_capabilities_fp_4x(ctx, cfg);
     }
 }

--- a/app/implementations/openssl/3/iut.h
+++ b/app/implementations/openssl/3/iut.h
@@ -23,6 +23,7 @@
 #define OPENSSL_FIPS_312 3010002
 #define OPENSSL_FIPS_340 3040000
 #define OPENSSL_FIPS_350 3050000
+#define OPENSSL_FIPS_360 3060000
 
 #define ENGID1 "800002B805123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456"
 #define ENGID2 "000002b87766554433221100"
@@ -49,6 +50,7 @@ int app_aes_handler_aead(ACVP_TEST_CASE *test_case);
 int app_aes_keywrap_handler(ACVP_TEST_CASE *test_case);
 int app_des_handler(ACVP_TEST_CASE *test_case);
 int app_sha_handler(ACVP_TEST_CASE *test_case);
+int app_cshake_handler(ACVP_TEST_CASE *test_case);
 int app_hmac_handler(ACVP_TEST_CASE *test_case);
 int app_cmac_handler(ACVP_TEST_CASE *test_case);
 int app_kmac_handler(ACVP_TEST_CASE *test_case);
@@ -93,6 +95,7 @@ ACVP_RESULT register_capabilities_fp_312(ACVP_CTX *ctx, APP_CONFIG *cfg);
 ACVP_RESULT register_capabilities_non_fips(ACVP_CTX *ctx, APP_CONFIG *cfg);
 ACVP_RESULT register_capabilities_fp_340(ACVP_CTX *ctx, APP_CONFIG *cfg);
 ACVP_RESULT register_capabilities_fp_350(ACVP_CTX *ctx, APP_CONFIG *cfg);
+ACVP_RESULT register_capabilities_fp_4x(ACVP_CTX *ctx, APP_CONFIG *cfg);
 
 /**
  * Here, we conditionally add defines for core names added in new versions of OpenSSL

--- a/app/implementations/openssl/3/iut_cshake.c
+++ b/app/implementations/openssl/3/iut_cshake.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025, Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/cisco/libacvp/LICENSE
+ */
+
+#include "acvp/acvp.h"
+#include "app_lcl.h"
+#include "safe_lib.h"
+#include "implementations/openssl/3/iut.h"
+
+#include <openssl/evp.h>
+#include <openssl/core_names.h>
+#include <openssl/param_build.h>
+#include <openssl/err.h>
+
+int app_cshake_handler(ACVP_TEST_CASE *test_case) {
+    ACVP_CSHAKE_TC *tc = NULL;
+    EVP_MD *md = NULL;
+    EVP_MD_CTX *md_ctx = NULL;
+    OSSL_PARAM_BLD *pbld = NULL;
+    OSSL_PARAM *params = NULL;
+    const char *alg_name = NULL;
+    int rv = 1;
+    ACVP_SUB_CSHAKE alg = 0;
+
+    if (!test_case) {
+        printf("Missing CSHAKE test case from library\n");
+        return rv;
+    }
+
+    tc = test_case->tc.cshake;
+    if (!tc) {
+        printf("Missing CSHAKE test case from library\n");
+        return rv;
+    }
+
+    if ( !tc->msg) {
+        printf("Missing key/msg/md/maclen in CSHAKE test case\n");
+        return rv;
+    }
+
+    if (tc->custom_len && !(tc->custom || tc->custom_hex)) {
+        printf("Missing customization buffer in CSHAKE test case\n");
+        return rv;
+    }
+
+
+    alg = acvp_get_cshake_alg(tc->cipher);
+    if (alg == 0) {
+        printf("Invalid cipher value in CSHAKE");
+        return 1;
+    }
+
+    switch (alg) {
+    case ACVP_SUB_CSHAKE_128:
+        alg_name = "CSHAKE-128";
+        break;
+    case ACVP_SUB_CSHAKE_256:
+        alg_name = "CSHAKE-256";
+        break;
+    default:
+        printf("Error: Unsupported CSHAKE algorithm requested by ACVP server\n");
+        return rv;
+    }
+
+    md = EVP_MD_fetch(NULL, alg_name, NULL);
+    if (!md) {
+        printf("Error: unable to fetch CSHAKE");
+        goto end;
+    }
+    md_ctx = EVP_MD_CTX_create();
+    if (!md_ctx) {
+        printf("Error: unable to create CSHAKE CTX");
+        goto end;
+    }
+
+    pbld = OSSL_PARAM_BLD_new();
+    if (!pbld) {
+        printf("error creating param_bld in CSHAKE\n");
+        goto end;
+    }
+
+    OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_DIGEST_PARAM_N, tc->function_name, tc->function_name_len);
+    OSSL_PARAM_BLD_push_utf8_string(pbld, OSSL_DIGEST_PARAM_S, tc->custom, tc->custom_len);
+    params = OSSL_PARAM_BLD_to_param(pbld);
+    if (!params) {
+        printf("Error generating params for cSHAKE\n");
+        goto end;
+    }
+
+    if (!EVP_DigestInit_ex(md_ctx, md, NULL)) {
+        printf("Crypto module error, EVP_DigestInit_ex failed\n");
+        goto end;
+    }
+
+    if (EVP_MD_CTX_set_params(md_ctx, params) != 1) {
+        printf("Error setting cSHAKE params\n");
+        goto end;
+    }
+
+    if (!EVP_DigestUpdate(md_ctx, tc->msg, tc->msg_len)) {
+        printf("Crypto module error, EVP_DigestUpdate failed\n");
+        goto end;
+    }
+
+    if (!EVP_DigestFinalXOF(md_ctx, tc->md, tc->md_len)) {
+        printf("Crypto module error, EVP_DigestFinalXOF failed\n");
+        goto end;
+    }
+
+    rv = 0;
+
+end:
+    if (rv != 0) ERR_print_errors_fp(stderr);
+    if (md_ctx) EVP_MD_CTX_free(md_ctx);
+    if (md) EVP_MD_free(md);
+    if (pbld) OSSL_PARAM_BLD_free(pbld);
+    if (params) OSSL_PARAM_free(params);
+    return rv;
+}

--- a/app/implementations/openssl/3/registrations/fp_4X.c
+++ b/app/implementations/openssl/3/registrations/fp_4X.c
@@ -1,0 +1,2628 @@
+/*
+ * Copyright (c) 2025, Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/cisco/libacvp/LICENSE
+ */
+
+ /*
+  * NOTE: This is not an official OpenSSL algorithm registration; its not verified by OpenSSL or intended
+  * to indicate any future plans of OpenSSL. It is currently here for development and testing purposes only.
+  */
+
+ #include <stdio.h>
+
+ #include "app_lcl.h"
+ #include "implementations/openssl/3/iut.h"
+ #include "safe_mem_lib.h"
+ #include "safe_str_lib.h"
+
+ #include <openssl/rsa.h>
+ #include <openssl/bn.h>
+ #include <openssl/provider.h>
+ #include <openssl/evp.h>
+
+ static int enable_dsa(ACVP_CTX *ctx);
+ static int enable_kas_ffc(ACVP_CTX *ctx);
+ static int enable_safe_primes(ACVP_CTX *ctx);
+ static int enable_aes(ACVP_CTX *ctx);
+ static int enable_hash(ACVP_CTX *ctx);
+ static int enable_cmac(ACVP_CTX *ctx);
+ static int enable_hmac(ACVP_CTX *ctx);
+ static int enable_kmac(ACVP_CTX *ctx);
+ static int enable_cshake(ACVP_CTX *ctx);
+ static int enable_rsa(ACVP_CTX *ctx);
+ static int enable_ecdsa(ACVP_CTX *ctx);
+ static int enable_eddsa(ACVP_CTX *ctx);
+ static int enable_drbg(ACVP_CTX *ctx);
+ static int enable_kas_ecc(ACVP_CTX *ctx);
+ static int enable_kas_ifc(ACVP_CTX *ctx);
+ static int enable_kda(ACVP_CTX *ctx);
+ static int enable_kts_ifc(ACVP_CTX *ctx);
+ static int enable_kdf(ACVP_CTX *ctx);
+ static int enable_ml_kem(ACVP_CTX *ctx);
+ static int enable_ml_dsa(ACVP_CTX *ctx);
+ static int enable_slh_dsa(ACVP_CTX *ctx);
+
+ ACVP_RESULT register_capabilities_fp_4x(ACVP_CTX *ctx, APP_CONFIG *cfg) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     if (cfg->aes || cfg->testall) { if ((rv = enable_aes(ctx))) goto end; }
+     if (cfg->hash || cfg->testall) { if ((rv = enable_hash(ctx))) goto end; }
+     if (cfg->cmac || cfg->testall) { if ((rv = enable_cmac(ctx))) goto end; }
+     if (cfg->hmac || cfg->testall) { if ((rv = enable_hmac(ctx))) goto end; }
+     if (cfg->kmac || cfg->testall) { if ((rv = enable_kmac(ctx))) goto end; }
+     if (cfg->cshake || cfg->testall) { if ((rv = enable_cshake(ctx))) goto end; }
+     if (cfg->kdf || cfg->testall) { if ((rv = enable_kdf(ctx))) goto end; }
+     if (cfg->rsa || cfg->testall) { if ((rv = enable_rsa(ctx))) goto end; }
+     if (cfg->ecdsa || cfg->testall) { if ((rv = enable_ecdsa(ctx))) goto end; }
+     if (cfg->eddsa || cfg->testall) { if ((rv = enable_eddsa(ctx))) goto end; }
+     if (cfg->drbg || cfg->testall) { if ((rv = enable_drbg(ctx))) goto end; }
+     if (cfg->kas_ecc || cfg->testall) { if ((rv = enable_kas_ecc(ctx))) goto end; }
+     if (cfg->kas_ifc || cfg->testall) { if ((rv = enable_kas_ifc(ctx))) goto end; }
+     if (cfg->kts_ifc || cfg->testall) { if ((rv = enable_kts_ifc(ctx))) goto end; }
+     if (cfg->kda || cfg->testall) { if ((rv = enable_kda(ctx))) goto end; }
+     if (cfg->dsa || cfg->testall) { if ((rv = enable_dsa(ctx))) goto end; }
+     if (cfg->kas_ffc || cfg->testall) { if ((rv = enable_kas_ffc(ctx))) goto end; }
+     if (cfg->safe_primes || cfg->testall) { if ((rv = enable_safe_primes(ctx))) goto end; }
+     if (cfg->ml_kem || cfg->testall) { if ((rv = enable_ml_kem(ctx))) goto end; }
+     if (cfg->ml_dsa || cfg->testall) { if ((rv = enable_ml_dsa(ctx))) goto end; }
+     if (cfg->slh_dsa || cfg->testall) { if ((rv = enable_slh_dsa(ctx))) goto end; }
+ end:
+     return rv;
+ }
+
+ static int enable_aes(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     /* Enable AES_GCM */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GCM, &app_aes_handler_aead);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_AES, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GCM, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_EITHER);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_DOMAIN_IVLEN, 96, 1024, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_TAGLEN, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_TAGLEN, 64);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_TAGLEN, 96);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_TAGLEN, 104);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_TAGLEN, 112);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_TAGLEN, 120);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_DOMAIN_AADLEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_TAGLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GCM, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_821);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable AES-ECB 128,192,256 bit key */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_ECB, &app_aes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_ECB, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable AES-CBC 128 bit key */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC, &app_aes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable AES-CBC-CS1, CS2, and CS3 */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS1, &app_aes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS1, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS2, &app_aes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS2, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CBC_CS3, &app_aes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CBC_CS3, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 512, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable AES-CFB1 128,192,256 bit key */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB1, &app_aes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB1, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable AES-CFB8 128,192,256 bit key */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB8, &app_aes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB8, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable AES-CFB128 128,192,256 bit key */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CFB128, &app_aes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CFB128, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable AES-OFB 128, 192, 256 bit key */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_OFB, &app_aes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_OFB, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Register AES CCM capabilities */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CCM, &app_aes_handler_aead);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_AES_CCM, ACVP_PREREQ_AES, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_DOMAIN_PTLEN, 0, 256, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 48);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 64);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 80);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 96);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 112);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_TAGLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_DOMAIN_IVLEN, 56, 104, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CCM, ACVP_SYM_CIPH_DOMAIN_AADLEN, 0, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* AES-KW */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KW, &app_aes_keywrap_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_NA);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KW_MODE, ACVP_SYM_KW_CIPHER);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KW_MODE, ACVP_SYM_KW_INVERSE);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 524288, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KW, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_KWP, &app_aes_keywrap_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_KW_MODE, ACVP_SYM_KW_CIPHER);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_KW_MODE, ACVP_SYM_KW_INVERSE);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_KWP, ACVP_SYM_CIPH_DOMAIN_PTLEN, 8, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable AES-XTS 128 and 256 bit key */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_XTS, &app_aes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_TWEAK, ACVP_SYM_CIPH_TWEAK_HEX);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_XTS, ACVP_SYM_CIPH_DOMAIN_PTLEN, 128, 65536, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable AES-CTR 128, 192, 256 bit key */
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_CTR, &app_aes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     //CTR_INCR and CTR_OVRFLW are ignored by server if PERFORM_CTR is false - can remove those calls if so
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_PERFORM_CTR, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_CTR_INCR, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_PARM_CTR_OVRFLW, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_CTR, ACVP_SYM_CIPH_DOMAIN_PTLEN, 8, 128, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     //GMAC
+     rv = acvp_cap_sym_cipher_enable(ctx, ACVP_AES_GMAC, &app_aes_handler_gmac);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GMAC, ACVP_PREREQ_AES, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_AES_GMAC, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_PARM_DIR, ACVP_SYM_CIPH_DIR_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_PARM_IVGEN_SRC, ACVP_SYM_CIPH_IVGEN_SRC_EITHER);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_TAGLEN, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_TAGLEN, 64);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_TAGLEN, 96);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_TAGLEN, 104);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_TAGLEN, 112);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_TAGLEN, 120);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_DOMAIN_AADLEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_PARM_IVGEN_MODE, ACVP_SYM_CIPH_IVGEN_MODE_821);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_parm(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_TAGLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_sym_cipher_set_domain(ctx, ACVP_AES_GMAC, ACVP_SYM_CIPH_DOMAIN_IVLEN, 96, 1024, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+ end:
+
+     return rv;
+ }
+
+ static int enable_hash(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+     int i = 0;
+
+     /* Enable SHA-1 and SHA-2 */
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA1, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA1, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA224, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA256, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA384, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* SHA2-512/224 and SHA2-512/256 */
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_224, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA512_256, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA512_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* SHA3 and SHAKE */
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_224, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_IN_BIT, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_IN_EMPTY, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_256, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_IN_BIT, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_IN_EMPTY, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_384, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_IN_BIT, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_IN_EMPTY, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHA3_512, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_IN_BIT, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_IN_EMPTY, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_MESSAGE_LEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_128, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_IN_BIT, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_OUT_BIT, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_IN_EMPTY, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHAKE_128, ACVP_HASH_OUT_LENGTH, 16, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hash_enable(ctx, ACVP_HASH_SHAKE_256, &app_sha_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_256, ACVP_HASH_IN_BIT, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_256, ACVP_HASH_OUT_BIT, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHAKE_256, ACVP_HASH_IN_EMPTY, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hash_set_domain(ctx, ACVP_HASH_SHAKE_256, ACVP_HASH_OUT_LENGTH, 16, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     for (i = 1; i <= max_ldt_size; i *= 2) {
+         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA1, ACVP_HASH_LARGE_DATA, i);
+         CHECK_ENABLE_CAP_RV(rv);
+         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA224, ACVP_HASH_LARGE_DATA, i);
+         CHECK_ENABLE_CAP_RV(rv);
+         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA256, ACVP_HASH_LARGE_DATA, i);
+         CHECK_ENABLE_CAP_RV(rv);
+         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA384, ACVP_HASH_LARGE_DATA, i);
+         CHECK_ENABLE_CAP_RV(rv);
+         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA512, ACVP_HASH_LARGE_DATA, i);
+         CHECK_ENABLE_CAP_RV(rv);
+         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA512_224, ACVP_HASH_LARGE_DATA, i);
+         CHECK_ENABLE_CAP_RV(rv);
+         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA512_256, ACVP_HASH_LARGE_DATA, i);
+         CHECK_ENABLE_CAP_RV(rv);
+         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_224, ACVP_HASH_LARGE_DATA, i);
+         CHECK_ENABLE_CAP_RV(rv);
+         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_256, ACVP_HASH_LARGE_DATA, i);
+         CHECK_ENABLE_CAP_RV(rv);
+         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_384, ACVP_HASH_LARGE_DATA, i);
+         CHECK_ENABLE_CAP_RV(rv);
+         rv = acvp_cap_hash_set_parm(ctx, ACVP_HASH_SHA3_512, ACVP_HASH_LARGE_DATA, i);
+         CHECK_ENABLE_CAP_RV(rv);
+     }
+
+ end:
+     return rv;
+ }
+
+ static int enable_cmac(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     /* Enable CMAC */
+     rv = acvp_cap_cmac_enable(ctx, ACVP_CMAC_AES, &app_cmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_cmac_set_domain(ctx, ACVP_CMAC_AES, ACVP_CMAC_MSGLEN, 0, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_cmac_set_parm(ctx, ACVP_CMAC_AES, ACVP_CMAC_MACLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_CMAC_AES, ACVP_PREREQ_AES, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_cmac_set_parm(ctx, ACVP_CMAC_AES, ACVP_CMAC_DIRECTION_GEN, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_cmac_set_parm(ctx, ACVP_CMAC_AES, ACVP_CMAC_DIRECTION_VER, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_cmac_set_parm(ctx, ACVP_CMAC_AES, ACVP_CMAC_KEYLEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_cmac_set_parm(ctx, ACVP_CMAC_AES, ACVP_CMAC_KEYLEN, 192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_cmac_set_parm(ctx, ACVP_CMAC_AES, ACVP_CMAC_KEYLEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+ end:
+
+     return rv;
+ }
+
+ static int enable_kmac(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     /* Enable KMAC */
+     rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_128, &app_kmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_128, ACVP_KMAC_MSGLEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_128, ACVP_KMAC_MACLEN, 32, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_128, ACVP_KMAC_KEYLEN, 128, 1024, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kmac_set_parm(ctx, ACVP_KMAC_128, ACVP_KMAC_XOF_SUPPORT, ACVP_XOF_SUPPORT_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     /* OpenSSL 3.X supports hex customization strings, but they are not on the FIPS cert, so leaving disabled */
+     rv = acvp_cap_kmac_set_parm(ctx, ACVP_KMAC_128, ACVP_KMAC_HEX_CUSTOM_SUPPORT, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kmac_enable(ctx, ACVP_KMAC_256, &app_kmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_256, ACVP_KMAC_MSGLEN, 0, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_256, ACVP_KMAC_MACLEN, 32, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kmac_set_domain(ctx, ACVP_KMAC_256, ACVP_KMAC_KEYLEN, 128, 1024, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kmac_set_parm(ctx, ACVP_KMAC_256, ACVP_KMAC_XOF_SUPPORT, ACVP_XOF_SUPPORT_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     /* OpenSSL 3.X supports hex customization strings, but they are not on the FIPS cert, so leaving disabled */
+     rv = acvp_cap_kmac_set_parm(ctx, ACVP_KMAC_256, ACVP_KMAC_HEX_CUSTOM_SUPPORT, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+ end:
+    return rv;
+}
+
+static int enable_cshake(ACVP_CTX *ctx) {
+    ACVP_RESULT rv = ACVP_SUCCESS;
+
+    /* Enable cSHAKE-128 */
+    rv = acvp_cap_cshake_enable(ctx, ACVP_CSHAKE_128, &app_cshake_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_cshake_set_domain(ctx, ACVP_CSHAKE_128, ACVP_CSHAKE_MSGLEN, 0, 65536, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_cshake_set_domain(ctx, ACVP_CSHAKE_128, ACVP_CSHAKE_OUTLEN, 16, 65536, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_cshake_set_parm(ctx, ACVP_CSHAKE_128, ACVP_CSHAKE_HEX_CUSTOM_SUPPORT, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+
+    /* Enable cSHAKE-256 */
+    rv = acvp_cap_cshake_enable(ctx, ACVP_CSHAKE_256, &app_cshake_handler);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_cshake_set_domain(ctx, ACVP_CSHAKE_256, ACVP_CSHAKE_MSGLEN, 0, 65536, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_cshake_set_domain(ctx, ACVP_CSHAKE_256, ACVP_CSHAKE_OUTLEN, 16, 65536, 8);
+    CHECK_ENABLE_CAP_RV(rv);
+    rv = acvp_cap_cshake_set_parm(ctx, ACVP_CSHAKE_256, ACVP_CSHAKE_HEX_CUSTOM_SUPPORT, 0);
+    CHECK_ENABLE_CAP_RV(rv);
+end:
+    return rv;
+}
+
+static int enable_hmac(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA1, &app_hmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_KEYLEN, 112, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA1, ACVP_HMAC_MACLEN, 32, 160, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA1, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_224, &app_hmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_KEYLEN, 112, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_224, ACVP_HMAC_MACLEN, 32, 224, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_224, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_256, &app_hmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_KEYLEN, 112, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_256, ACVP_HMAC_MACLEN, 32, 256, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_256, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_384, &app_hmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_KEYLEN, 112, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_384, ACVP_HMAC_MACLEN, 32, 384, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_384, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512, &app_hmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_KEYLEN, 112, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512, ACVP_HMAC_MACLEN, 32, 512, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_224, &app_hmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_224, ACVP_HMAC_KEYLEN, 112, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_224, ACVP_HMAC_MACLEN, 32, 224, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_224, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA2_512_256, &app_hmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_256, ACVP_HMAC_KEYLEN, 112, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA2_512_256, ACVP_HMAC_MACLEN, 32, 256, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA2_512_256, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_224, &app_hmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_224, ACVP_HMAC_KEYLEN, 112, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_224, ACVP_HMAC_MACLEN, 32, 224, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_224, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_256, &app_hmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_256, ACVP_HMAC_KEYLEN, 112, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_256, ACVP_HMAC_MACLEN, 32, 256, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_256, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_384, &app_hmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_384, ACVP_HMAC_KEYLEN, 112, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_384, ACVP_HMAC_MACLEN, 32, 384, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_384, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_hmac_enable(ctx, ACVP_HMAC_SHA3_512, &app_hmac_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_512, ACVP_HMAC_KEYLEN, 112, 524288, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_hmac_set_domain(ctx, ACVP_HMAC_SHA3_512, ACVP_HMAC_MACLEN, 32, 512, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMAC_SHA3_512, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+ end:
+
+     return rv;
+ }
+
+ static int enable_kdf(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+     int flags = 0;
+
+     rv = acvp_cap_kdf_tls12_enable(ctx, &app_kdf_tls12_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS12, ACVP_PREREQ_HMAC, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf_tls12_set_parm(ctx, ACVP_KDF_TLS12_HASH_ALG, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf_tls12_set_parm(ctx, ACVP_KDF_TLS12_HASH_ALG, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf_tls12_set_parm(ctx, ACVP_KDF_TLS12_HASH_ALG, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+
+
+     rv = acvp_cap_kdf135_ssh_enable(ctx, &app_kdf135_ssh_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_SSH, ACVP_PREREQ_AES, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     //Bit flags for kdf135_ssh sha capabilities
+     flags = ACVP_SHA1 | ACVP_SHA224 | ACVP_SHA256
+             | ACVP_SHA384 | ACVP_SHA512;
+
+     rv = acvp_cap_kdf135_ssh_set_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_128_CBC, flags);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_ssh_set_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_192_CBC, flags);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_ssh_set_parm(ctx, ACVP_KDF135_SSH, ACVP_SSH_METH_AES_256_CBC, flags);
+     CHECK_ENABLE_CAP_RV(rv);
+
+
+
+     rv = acvp_cap_kdf135_x942_enable(ctx, &app_kdf135_x942_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X942, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_KDF_TYPE, ACVP_KDF_X942_KDF_TYPE_DER);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_HASH_ALG, ACVP_SHA1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_HASH_ALG, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_HASH_ALG, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_HASH_ALG, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_HASH_ALG, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_HASH_ALG, ACVP_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_HASH_ALG, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_HASH_ALG, ACVP_SHA3_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_HASH_ALG, ACVP_SHA3_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_HASH_ALG, ACVP_SHA3_384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_HASH_ALG, ACVP_SHA3_512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_domain(ctx, ACVP_KDF_X942_KEY_LEN, 8, 4096, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_domain(ctx, ACVP_KDF_X942_OTHER_INFO_LEN, 0, 4096, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_domain(ctx, ACVP_KDF_X942_ZZ_LEN, 112, 4096, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_domain(ctx, ACVP_KDF_X942_SUPP_INFO_LEN, 0, 120, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_OID, ACVP_KDF_X942_OID_AES128KW);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_OID, ACVP_KDF_X942_OID_AES192KW);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x942_set_parm(ctx, ACVP_KDF_X942_OID, ACVP_KDF_X942_OID_AES256KW);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kdf135_x963_enable(ctx, &app_kdf135_x963_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDF135_X963, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_HASH_ALG, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_HASH_ALG, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_HASH_ALG, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_HASH_ALG, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_KEY_DATA_LEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_KEY_DATA_LEN, 4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_FIELD_SIZE, 224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_FIELD_SIZE, 571);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_SHARED_INFO_LEN, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf135_x963_set_parm(ctx, ACVP_KDF_X963_SHARED_INFO_LEN, 1024);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* KDF108 Counter Mode */
+     rv = acvp_cap_kdf108_enable(ctx, &app_kdf108_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_HMAC, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_CMAC, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 72);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 776);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 3456);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_SUPPORTED_LEN, 4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_CMAC_AES128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_CMAC_AES192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_CMAC_AES256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_COUNTER_LEN, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_COUNTER, ACVP_KDF108_FIXED_DATA_ORDER, ACVP_KDF108_FIXED_DATA_ORDER_BEFORE);
+     CHECK_ENABLE_CAP_RV(rv);
+     /* KDF108 Feedback Mode */
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 72);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 776);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 3456);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTED_LEN, 4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_CMAC_AES128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_CMAC_AES192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_CMAC_AES256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_HMAC_SHA3_512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_SUPPORTS_EMPTY_IV, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_REQUIRES_EMPTY_IV, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_COUNTER_LEN, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_FEEDBACK, ACVP_KDF108_FIXED_DATA_ORDER, ACVP_KDF108_FIXED_DATA_ORDER_BEFORE);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* KDF108 KMAC Mode */
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDF108, ACVP_PREREQ_KMAC, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_KMAC_128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_parm(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_MAC_MODE, ACVP_KDF108_MAC_MODE_KMAC_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_DERIVATION_KEYLEN, 112, 4096, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_DERIVED_KEYLEN, 112, 4096, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_CONTEXT_LEN, 8, 4096, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf108_set_domain(ctx, ACVP_KDF108_MODE_KMAC, ACVP_KDF108_LABEL_LEN, 8, 4096, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* PBKDF */
+     rv = acvp_cap_pbkdf_enable(ctx, &app_pbkdf_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_PBKDF, ACVP_PREREQ_HMAC, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_parm(ctx, ACVP_PBKDF_HMAC_ALG, ACVP_SHA1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_parm(ctx, ACVP_PBKDF_HMAC_ALG, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_parm(ctx, ACVP_PBKDF_HMAC_ALG, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_parm(ctx, ACVP_PBKDF_HMAC_ALG, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_parm(ctx, ACVP_PBKDF_HMAC_ALG, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_parm(ctx, ACVP_PBKDF_HMAC_ALG, ACVP_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_parm(ctx, ACVP_PBKDF_HMAC_ALG, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_parm(ctx, ACVP_PBKDF_HMAC_ALG, ACVP_SHA3_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_parm(ctx, ACVP_PBKDF_HMAC_ALG, ACVP_SHA3_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_parm(ctx, ACVP_PBKDF_HMAC_ALG, ACVP_SHA3_384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_parm(ctx, ACVP_PBKDF_HMAC_ALG, ACVP_SHA3_512);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_pbkdf_set_domain(ctx, ACVP_PBKDF_ITERATION_COUNT, 1, 10000, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_domain(ctx, ACVP_PBKDF_KEY_LEN, 112, 4096, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_domain(ctx, ACVP_PBKDF_PASSWORD_LEN, 8, 128, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_pbkdf_set_domain(ctx, ACVP_PBKDF_SALT_LEN, 128, 4096, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kdf_tls13_enable(ctx, &app_kdf_tls13_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDF_TLS13, ACVP_PREREQ_HMAC, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf_tls13_set_parm(ctx, ACVP_KDF_TLS13_HMAC_ALG, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf_tls13_set_parm(ctx, ACVP_KDF_TLS13_HMAC_ALG, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf_tls13_set_parm(ctx, ACVP_KDF_TLS13_RUNNING_MODE, ACVP_KDF_TLS13_RUN_MODE_PSK);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf_tls13_set_parm(ctx, ACVP_KDF_TLS13_RUNNING_MODE, ACVP_KDF_TLS13_RUN_MODE_DHE);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kdf_tls13_set_parm(ctx, ACVP_KDF_TLS13_RUNNING_MODE, ACVP_KDF_TLS13_RUN_MODE_PSK_DHE);
+     CHECK_ENABLE_CAP_RV(rv);
+
+ end:
+
+     return rv;
+ }
+
+ static int enable_kas_ecc(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     /* Enable KAS-ECC.... */
+     rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_CDH, &app_kas_ecc_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_PREREQ_ECDSA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_REVISION, ACVP_REVISION_SP800_56AR3);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_P224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_P256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_P384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_P521);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_K233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_K283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_K409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_K571);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_CDH, ACVP_KAS_ECC_MODE_CDH, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kas_ecc_enable(ctx, ACVP_KAS_ECC_SSC, &app_kas_ecc_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_PREREQ_ECDSA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_prereq(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kas_ecc_set_scheme(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_EPHEMERAL_UNIFIED, ACVP_KAS_ECC_ROLE, 0, ACVP_KAS_ECC_ROLE_INITIATOR);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_scheme(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_EPHEMERAL_UNIFIED, ACVP_KAS_ECC_ROLE, 0, ACVP_KAS_ECC_ROLE_RESPONDER);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_P224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_P256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_P384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_P521);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_B571);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_K233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_K283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_K409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ecc_set_parm(ctx, ACVP_KAS_ECC_SSC, ACVP_KAS_ECC_MODE_NONE, ACVP_KAS_ECC_CURVE, ACVP_EC_CURVE_K571);
+     CHECK_ENABLE_CAP_RV(rv);
+
+ end:
+
+     return rv;
+ }
+
+ static int enable_kas_ifc(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+     BIGNUM *expo = NULL;
+     char *expo_str = NULL;
+
+     expo = BN_new();
+     if (!expo || !BN_set_word(expo, RSA_F4)) {
+         printf("oh no\n");
+         return 1;
+     }
+     expo_str = BN_bn2hex(expo);
+     BN_free(expo);
+
+     rv = acvp_cap_kas_ifc_enable(ctx, ACVP_KAS_IFC_SSC, &app_kas_ifc_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_RSA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KAS_IFC_SSC, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KAS1, ACVP_KAS_IFC_INITIATOR);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KAS1, ACVP_KAS_IFC_RESPONDER);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_MODULO, 2048);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_MODULO, 3072);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_MODULO, 4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_exponent(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_FIXEDPUBEXP, expo_str);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KAS2, ACVP_KAS_IFC_INITIATOR);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KAS2, ACVP_KAS_IFC_RESPONDER);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_MODULO, 6144);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_MODULO, 8192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KEYGEN_METHOD, ACVP_KAS_IFC_RSAKPG1_BASIC);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KEYGEN_METHOD, ACVP_KAS_IFC_RSAKPG2_BASIC);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KEYGEN_METHOD, ACVP_KAS_IFC_RSAKPG1_PRIME_FACTOR);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KEYGEN_METHOD, ACVP_KAS_IFC_RSAKPG2_PRIME_FACTOR);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KEYGEN_METHOD, ACVP_KAS_IFC_RSAKPG1_CRT);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ifc_set_parm(ctx, ACVP_KAS_IFC_SSC, ACVP_KAS_IFC_KEYGEN_METHOD, ACVP_KAS_IFC_RSAKPG2_CRT);
+     CHECK_ENABLE_CAP_RV(rv);
+
+ end:
+     if (expo_str) free(expo_str);
+     return rv;
+ }
+
+ static int enable_kts_ifc(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+     BIGNUM *expo = NULL;
+     char *expo_str = NULL;
+     char iut_id[] = "DEADDEAD";
+     char concatenation[] = "concatenation";
+
+     expo = BN_new();
+     if (!expo || !BN_set_word(expo, RSA_F4)) {
+         printf("oh no\n");
+         return 1;
+     }
+     expo_str = BN_bn2hex(expo);
+     BN_free(expo);
+
+     rv = acvp_cap_kts_ifc_enable(ctx, ACVP_KTS_IFC, &app_kts_ifc_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KTS_IFC, ACVP_PREREQ_RSA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_set_prereq(ctx, ACVP_KTS_IFC, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KTS_IFC, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_param_string(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_FIXEDPUBEXP, expo_str);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_param_string(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_IUT_ID, iut_id);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_FUNCTION, ACVP_KTS_IFC_KEYPAIR_GEN);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_FUNCTION, ACVP_KTS_IFC_PARTIAL_VAL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_MODULO, 2048);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_MODULO, 3072);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_MODULO, 4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_MODULO, 6144);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KEYGEN_METHOD, ACVP_KTS_IFC_RSAKPG1_BASIC);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KEYGEN_METHOD, ACVP_KTS_IFC_RSAKPG2_BASIC);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KEYGEN_METHOD, ACVP_KTS_IFC_RSAKPG1_PRIME_FACTOR);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KEYGEN_METHOD, ACVP_KTS_IFC_RSAKPG2_PRIME_FACTOR);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KEYGEN_METHOD, ACVP_KTS_IFC_RSAKPG1_CRT);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KEYGEN_METHOD, ACVP_KTS_IFC_RSAKPG2_CRT);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kts_ifc_set_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_SCHEME, ACVP_KTS_IFC_KAS1_BASIC);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_ROLE, ACVP_KTS_IFC_RESPONDER);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_ROLE, ACVP_KTS_IFC_INITIATOR);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_HASH, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_HASH, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_HASH, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_HASH, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_HASH, ACVP_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_HASH, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_HASH, ACVP_SHA3_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_HASH, ACVP_SHA3_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_HASH, ACVP_SHA3_384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_HASH, ACVP_SHA3_512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_L, 1024);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_parm(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_NULL_ASSOC_DATA, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kts_ifc_set_scheme_string(ctx, ACVP_KTS_IFC, ACVP_KTS_IFC_KAS1_BASIC, ACVP_KTS_IFC_ENCODING, concatenation);
+     CHECK_ENABLE_CAP_RV(rv);
+
+ end:
+     if (expo_str) free(expo_str);
+     return rv;
+ }
+
+ #if !defined OPENSSL_NO_DSA
+ static int enable_kas_ffc(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     rv = acvp_cap_kas_ffc_enable(ctx, ACVP_KAS_FFC_SSC, &app_kas_ffc_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_SAFE_PRIMES, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_DSA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_prereq(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kas_ffc_set_scheme(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_DH_EPHEMERAL, ACVP_KAS_FFC_ROLE, ACVP_KAS_FFC_ROLE_INITIATOR);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_scheme(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_DH_EPHEMERAL, ACVP_KAS_FFC_ROLE, ACVP_KAS_FFC_ROLE_RESPONDER);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_FC);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_FB);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_MODP2048);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_MODP3072);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_MODP4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_MODP6144);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_MODP8192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_FFDHE2048);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_FFDHE3072);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_FFDHE4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_FFDHE6144);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kas_ffc_set_parm(ctx, ACVP_KAS_FFC_SSC, ACVP_KAS_FFC_MODE_NONE, ACVP_KAS_FFC_GEN_METH, ACVP_KAS_FFC_FFDHE8192);
+     CHECK_ENABLE_CAP_RV(rv);
+ end:
+
+     return rv;
+ }
+ #endif
+
+ static int enable_kda(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     rv = acvp_cap_kda_enable(ctx, ACVP_KDA_HKDF, &app_kda_hkdf_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_HKDF, ACVP_PREREQ_HMAC, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_ALGID, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_L, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_UPARTYINFO, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_VPARTYINFO, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_ALG, ACVP_SHA1, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_domain(ctx, ACVP_KDA_HKDF, ACVP_KDA_Z, 224, 8192, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_ENCODING_TYPE, ACVP_KDA_ENCODING_CONCAT, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_ALG, ACVP_SHA224, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_ALG, ACVP_SHA256, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_ALG, ACVP_SHA384, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_ALG, ACVP_SHA512, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_ALG, ACVP_SHA512_224, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_ALG, ACVP_SHA512_256, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_ALG, ACVP_SHA3_224, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_ALG, ACVP_SHA3_256, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_ALG, ACVP_SHA3_384, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_ALG, ACVP_SHA3_512, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_SALT, ACVP_KDA_MAC_SALT_METHOD_DEFAULT, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_MAC_SALT, ACVP_KDA_MAC_SALT_METHOD_RANDOM, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_HKDF, ACVP_KDA_L, 2048, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     // kdf onestep
+     rv = acvp_cap_kda_enable(ctx, ACVP_KDA_ONESTEP, &app_kda_onestep_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_HMAC, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_ONESTEP, ACVP_PREREQ_KMAC, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_ALGID, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_L, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_UPARTYINFO, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_VPARTYINFO, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA512, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA2_224, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_KMAC_128, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA1, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA224, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA256, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA384, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA512_224, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA512_256, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA3_224, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA3_256, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA3_384, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HASH_SHA3_512, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA2_256, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA2_384, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA2_512, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA2_512_224, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA2_512_256, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA3_224, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA3_256, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA3_384, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_HMAC_SHA3_512, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ONESTEP_AUX_FUNCTION, ACVP_KMAC_256, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kda_set_domain(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_Z, 224, 8192, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_ENCODING_TYPE, ACVP_KDA_ENCODING_CONCAT, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_MAC_SALT, ACVP_KDA_MAC_SALT_METHOD_DEFAULT, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_MAC_SALT, ACVP_KDA_MAC_SALT_METHOD_RANDOM, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_set_parm(ctx, ACVP_KDA_ONESTEP, ACVP_KDA_L, 2048, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kda_enable(ctx, ACVP_KDA_TWOSTEP, &app_kda_twostep_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_KDA_TWOSTEP, ACVP_PREREQ_HMAC, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_L, 2048, 0, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_domain(ctx, ACVP_KDA_Z, 224, 8192, 8, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_ALGID, 0, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_L, 0, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_UPARTYINFO, 0, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_PATTERN, ACVP_KDA_PATTERN_VPARTYINFO, 0, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_ENCODING_TYPE, ACVP_KDA_ENCODING_CONCAT, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_SALT, ACVP_KDA_MAC_SALT_METHOD_DEFAULT, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_SALT, ACVP_KDA_MAC_SALT_METHOD_RANDOM, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Most parameters are set in groups based on the KDF108 mode */
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_ALG, ACVP_KDF108_MAC_MODE_HMAC_SHA1, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_ALG, ACVP_KDF108_MAC_MODE_HMAC_SHA224, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_ALG, ACVP_KDF108_MAC_MODE_HMAC_SHA256, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_ALG, ACVP_KDF108_MAC_MODE_HMAC_SHA384, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_ALG, ACVP_KDF108_MAC_MODE_HMAC_SHA512, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_ALG, ACVP_KDF108_MAC_MODE_HMAC_SHA512_224, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_ALG, ACVP_KDF108_MAC_MODE_HMAC_SHA512_256, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_ALG, ACVP_KDF108_MAC_MODE_HMAC_SHA3_224, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_ALG, ACVP_KDF108_MAC_MODE_HMAC_SHA3_256, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_ALG, ACVP_KDF108_MAC_MODE_HMAC_SHA3_384, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_MAC_ALG, ACVP_KDF108_MAC_MODE_HMAC_SHA3_512, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_TWOSTEP_FIXED_DATA_ORDER, ACVP_KDF108_FIXED_DATA_ORDER_AFTER, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_TWOSTEP_COUNTER_LEN, 8, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_TWOSTEP_SUPPORTS_EMPTY_IV, 1, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_TWOSTEP_REQUIRES_EMPTY_IV, 1, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_kda_twostep_set_parm(ctx, ACVP_KDA_TWOSTEP_SUPPORTED_LEN, 2048, ACVP_KDF108_MODE_FEEDBACK, NULL);
+     CHECK_ENABLE_CAP_RV(rv);
+
+ end:
+    return rv;
+ }
+
+ #if !defined OPENSSL_NO_DSA
+ static int enable_dsa(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_PQGVER, &app_dsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGVER, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_PQGVER, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_GENPQ, ACVP_DSA_PROBABLE);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_GENG, ACVP_DSA_CANONICAL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_GENG, ACVP_DSA_UNVERIFIABLE);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN1024_160, ACVP_SHA1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN1024_160, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN1024_160, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN1024_160, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN1024_160, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN1024_160, ACVP_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN1024_160, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN2048_224, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN2048_224, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN2048_224, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN2048_224, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN2048_256, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN2048_256, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN2048_256, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN3072_256, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN3072_256, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN3072_256, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN2048_224, ACVP_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN2048_224, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN2048_256, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_PQGVER, ACVP_DSA_MODE_PQGVER, ACVP_DSA_LN3072_256, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_dsa_enable(ctx, ACVP_DSA_SIGVER, &app_dsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGVER, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_DSA_SIGVER, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN1024_160, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN1024_160, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN1024_160, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN1024_160, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_224, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_224, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_224, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_224, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_256, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_256, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_256, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_256, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN3072_256, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN3072_256, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN3072_256, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN3072_256, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN1024_160, ACVP_SHA1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN1024_160, ACVP_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN1024_160, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_224, ACVP_SHA1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_224, ACVP_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_224, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_256, ACVP_SHA1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_256, ACVP_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN2048_256, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN3072_256, ACVP_SHA1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN3072_256, ACVP_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_dsa_set_parm(ctx, ACVP_DSA_SIGVER, ACVP_DSA_MODE_SIGVER, ACVP_DSA_LN3072_256, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+ end:
+     return rv;
+ }
+ #endif
+
+ static int enable_rsa(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+     BIGNUM *expo = NULL;
+     char *expo_str = NULL;
+
+     expo = BN_new();
+     if (!expo || !BN_set_word(expo, RSA_F4)) {
+         printf("oh no\n");
+         return 1;
+     }
+     expo_str = BN_bn2hex(expo);
+     BN_free(expo);
+
+     /* Enable RSA keygen... */
+     rv = acvp_cap_rsa_keygen_enable(ctx, ACVP_RSA_KEYGEN, &app_rsa_keygen_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_KEYGEN, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_keygen_set_mode(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 2048, ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_2POW100);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 3072, ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_2POW100);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_keygen_set_primes(ctx, ACVP_RSA_KEYGEN_PROB_W_PROB_AUX, 4096, ACVP_RSA_PRIME_TEST, ACVP_RSA_PRIME_TEST_2POW100);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_FIXED);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_keygen_set_exponent(ctx, ACVP_RSA_PARM_FIXED_PUB_EXP_VAL, expo_str);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_INFO_GEN_BY_SERVER, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_keygen_set_parm(ctx, ACVP_RSA_PARM_KEY_FORMAT, ACVP_RSA_KEY_FORMAT_STANDARD);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable siggen */
+     rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGGEN, &app_rsa_sig_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGGEN, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGGEN, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     // RSA w/ sigType: PKCS1v1.5
+     rv = acvp_cap_rsa_siggen_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA384, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA384, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA384, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     // RSA w/ sigType: PKCS1PSS -- has salt
+     rv = acvp_cap_rsa_siggen_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA224, 24);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA256, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA384, 48);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512, 64);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA224, 24);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA256, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA384, 48);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA512, 64);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA224, 24);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA256, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA384, 48);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512, 64);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512_224, 24);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512_256, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA512_224, 24);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA512_256, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_rsa_siggen_set_mod_mask(ctx, 2048, ACVP_RSA_MASK_FUNCTION_MGF1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_mask(ctx, 3072, ACVP_RSA_MASK_FUNCTION_MGF1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_siggen_set_mod_mask(ctx, 4096, ACVP_RSA_MASK_FUNCTION_MGF1);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable sigver */
+     rv = acvp_cap_rsa_sig_enable(ctx, ACVP_RSA_SIGVER, &app_rsa_sig_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGVER, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGVER, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_parm(ctx, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_RANDOM);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     // RSA w/ sigType: PKCS1v1.5
+     rv = acvp_cap_rsa_sigver_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA384, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA384, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA384, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 2048, ACVP_SHA512_256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 3072, ACVP_SHA512_256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_224, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1V15, 4096, ACVP_SHA512_256, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     // RSA w/ sigType: PKCS1PSS -- has salt
+     rv = acvp_cap_rsa_sigver_set_type(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA224, 24);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA256, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA384, 48);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512, 64);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA224, 24);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA256, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA384, 48);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA512, 64);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA224, 24);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA256, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA384, 48);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512, 64);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512_224, 24);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 2048, ACVP_SHA512_256, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA512_224, 24);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 3072, ACVP_SHA512_256, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512_224, 24);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_parm(ctx, ACVP_RSA_SIG_TYPE_PKCS1PSS, 4096, ACVP_SHA512_256, 32);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_rsa_sigver_set_mod_mask(ctx, 2048, ACVP_RSA_MASK_FUNCTION_MGF1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_mask(ctx, 3072, ACVP_RSA_MASK_FUNCTION_MGF1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_sigver_set_mod_mask(ctx, 4096, ACVP_RSA_MASK_FUNCTION_MGF1);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable Signature Primitive */
+     rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_SIGPRIM, &app_rsa_sigprim_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGPRIM, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_SIGPRIM, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_KEY_FORMAT, ACVP_RSA_KEY_FORMAT_CRT);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_KEY_FORMAT, ACVP_RSA_KEY_FORMAT_STANDARD);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_FIXED);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_MODULO, 2048);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_MODULO, 3072);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_MODULO, 4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_exponent(ctx, ACVP_RSA_SIGPRIM, ACVP_RSA_PARM_FIXED_PUB_EXP_VAL, expo_str);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable Decryption Primitive */
+     rv = acvp_cap_rsa_prim_enable(ctx, ACVP_RSA_DECPRIM, &app_rsa_decprim_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_DECPRIM, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_RSA_DECPRIM, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_KEY_FORMAT, ACVP_RSA_KEY_FORMAT_CRT);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_KEY_FORMAT, ACVP_RSA_KEY_FORMAT_STANDARD);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_PUB_EXP_MODE, ACVP_RSA_PUB_EXP_MODE_FIXED);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_MODULO, 2048);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_MODULO, 3072);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_parm(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_MODULO, 4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_rsa_prim_set_exponent(ctx, ACVP_RSA_DECPRIM, ACVP_RSA_PARM_FIXED_PUB_EXP_VAL, expo_str);
+     CHECK_ENABLE_CAP_RV(rv);
+
+ end:
+     if (expo_str) free(expo_str);
+
+     return rv;
+ }
+
+ static int enable_ecdsa(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     /* Enable ECDSA keyGen... */
+     rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYGEN, &app_ecdsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYGEN, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K571);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B571);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P521);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYGEN, ACVP_ECDSA_SECRET_GEN, ACVP_ECDSA_SECRET_GEN_TEST_CAND);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable ECDSA keyVer... */
+     rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_KEYVER, &app_ecdsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_KEYVER, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K571);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B571);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_KEYVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P521);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable ECDSA sigGen... */
+     rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGGEN, &app_ecdsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGGEN, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_COMPONENT_TEST, ACVP_ECDSA_COMPONENT_MODE_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K571);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B571);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P521);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_HASH_ALG, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_HASH_ALG, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_HASH_ALG, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_HASH_ALG, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_HASH_ALG, ACVP_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_HASH_ALG, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_HASH_ALG, ACVP_SHA3_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_HASH_ALG, ACVP_SHA3_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_HASH_ALG, ACVP_SHA3_384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGGEN, ACVP_ECDSA_HASH_ALG, ACVP_SHA3_512);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Enable ECDSA sigVer... */
+     rv = acvp_cap_ecdsa_enable(ctx, ACVP_ECDSA_SIGVER, &app_ecdsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_ECDSA_SIGVER, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_K571);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B233);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B283);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B409);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_B571);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_CURVE, ACVP_EC_CURVE_P521);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_HASH_ALG, ACVP_SHA224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_HASH_ALG, ACVP_SHA256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_HASH_ALG, ACVP_SHA384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_HASH_ALG, ACVP_SHA512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_HASH_ALG, ACVP_SHA512_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_HASH_ALG, ACVP_SHA512_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_HASH_ALG, ACVP_SHA3_224);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_HASH_ALG, ACVP_SHA3_256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_HASH_ALG, ACVP_SHA3_384);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ecdsa_set_parm(ctx, ACVP_ECDSA_SIGVER, ACVP_ECDSA_HASH_ALG, ACVP_SHA3_512);
+     CHECK_ENABLE_CAP_RV(rv);
+
+ end:
+
+     return rv;
+ }
+
+ static int enable_eddsa(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_KEYGEN, &app_eddsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_KEYVER, &app_eddsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_KEYVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_SIGGEN, &app_eddsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_SUPPORTS_PREHASH, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_SUPPORTS_PURE, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_domain(ctx, ACVP_EDDSA_SIGGEN, ACVP_EDDSA_CONTEXT_LEN, 0, 255, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_eddsa_enable(ctx, ACVP_EDDSA_SIGVER, &app_eddsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_25519);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_CURVE, ACVP_ED_CURVE_448);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_SUPPORTS_PREHASH, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_eddsa_set_parm(ctx, ACVP_EDDSA_SIGVER, ACVP_EDDSA_SUPPORTS_PURE, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+ end:
+         return rv;
+ }
+
+ static int enable_drbg(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     /* Hash DRBG */
+     rv = acvp_cap_drbg_enable(ctx, ACVP_HASHDRBG, &app_drbg_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_set_prereq(ctx, ACVP_HASHDRBG, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_RESEED_ENABLED, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_ENTROPY_LEN, 256, 64, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_PERSO_LEN, 0, 128, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_RET_BITS_LEN, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, 0, ACVP_DRBG_ENTROPY_LEN, 256, 64, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, 0, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, 0, ACVP_DRBG_PERSO_LEN, 0, 128, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, 0, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_256, 0, ACVP_DRBG_RET_BITS_LEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, 0, ACVP_DRBG_ENTROPY_LEN, 256, 64, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, 0, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, 0, ACVP_DRBG_PERSO_LEN, 0, 128, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, 0, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA_512, 0, ACVP_DRBG_RET_BITS_LEN, 512);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA3_256, 0, ACVP_DRBG_ENTROPY_LEN, 256, 64, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA3_256, 0, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA3_256, 0, ACVP_DRBG_PERSO_LEN, 0, 128, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA3_256, 0, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA3_256, 0, ACVP_DRBG_RET_BITS_LEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA3_512, 0, ACVP_DRBG_ENTROPY_LEN, 256, 64, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA3_512, 0, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA3_512, 0, ACVP_DRBG_PERSO_LEN, 0, 128, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA3_512, 0, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HASHDRBG, ACVP_DRBG_SHA3_512, 0, ACVP_DRBG_RET_BITS_LEN, 512);
+     CHECK_ENABLE_CAP_RV(rv);
+
+
+     /* HMAC DRBG */
+     rv = acvp_cap_drbg_enable(ctx, ACVP_HMACDRBG, &app_drbg_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_HMACDRBG,ACVP_PREREQ_HMAC, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_RESEED_ENABLED, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+
+
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_ENTROPY_LEN, 256, 64, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_PERSO_LEN, 0, 128, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_1, 0, ACVP_DRBG_RET_BITS_LEN, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, 0, ACVP_DRBG_ENTROPY_LEN, 256, 64, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, 0, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, 0, ACVP_DRBG_PERSO_LEN, 0, 128, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, 0, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_256, 0, ACVP_DRBG_RET_BITS_LEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, 0, ACVP_DRBG_ENTROPY_LEN, 256, 64, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, 0, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, 0, ACVP_DRBG_PERSO_LEN, 0, 128, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, 0, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA_512, 0, ACVP_DRBG_RET_BITS_LEN, 512);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA3_256, 0, ACVP_DRBG_RET_BITS_LEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA3_256, 0, ACVP_DRBG_ENTROPY_LEN, 256, 64, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA3_256, 0, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA3_256, 0, ACVP_DRBG_PERSO_LEN, 0, 128, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA3_256, 0, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA3_512, 0, ACVP_DRBG_RET_BITS_LEN, 512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA3_512, 0, ACVP_DRBG_ENTROPY_LEN, 256, 64, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA3_512, 0, ACVP_DRBG_NONCE_LEN, 128, 32, 160);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA3_512, 0, ACVP_DRBG_PERSO_LEN, 0, 128, 65536);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_HMACDRBG, ACVP_DRBG_SHA3_512, 0, ACVP_DRBG_ADD_IN_LEN, 0, 128, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* CTR DRBG */
+     rv = acvp_cap_drbg_enable(ctx, ACVP_CTRDRBG, &app_drbg_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_CTRDRBG, ACVP_PREREQ_AES, value);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Group number for these should be 0 */
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_DER_FUNC_ENABLED, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_RESEED_ENABLED, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_RET_BITS_LEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_ENTROPY_LEN, 128, 128, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_NONCE_LEN, 0, 0, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_PERSO_LEN, 0, 256, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 0, ACVP_DRBG_ADD_IN_LEN, 0, 256, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 1, ACVP_DRBG_DER_FUNC_ENABLED, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 1, ACVP_DRBG_RET_BITS_LEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 1, ACVP_DRBG_ENTROPY_LEN, 256, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 1, ACVP_DRBG_NONCE_LEN, 0, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 1, ACVP_DRBG_PERSO_LEN, 256, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_128, 1, ACVP_DRBG_ADD_IN_LEN, 256, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 0, ACVP_DRBG_DER_FUNC_ENABLED, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 0, ACVP_DRBG_RET_BITS_LEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 0, ACVP_DRBG_ENTROPY_LEN, 256, 128, 512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 0, ACVP_DRBG_NONCE_LEN, 0, 0, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 0, ACVP_DRBG_PERSO_LEN, 0, 256, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 0, ACVP_DRBG_ADD_IN_LEN, 0, 256, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 1, ACVP_DRBG_DER_FUNC_ENABLED, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 1, ACVP_DRBG_RET_BITS_LEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 1, ACVP_DRBG_ENTROPY_LEN, 320, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 1, ACVP_DRBG_NONCE_LEN, 0, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 1, ACVP_DRBG_PERSO_LEN, 320, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_192, 1, ACVP_DRBG_ADD_IN_LEN, 320, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_DER_FUNC_ENABLED, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_PRED_RESIST_ENABLED, ACVP_DRBG_PRED_RESIST_YES);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_RESEED_ENABLED, 1);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_RET_BITS_LEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_ENTROPY_LEN, 256, 128, 512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_NONCE_LEN, 0, 0, 128);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_PERSO_LEN, 0, 256, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 0, ACVP_DRBG_ADD_IN_LEN, 0, 256, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 1, ACVP_DRBG_DER_FUNC_ENABLED, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_parm(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 1, ACVP_DRBG_RET_BITS_LEN, 256);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 1, ACVP_DRBG_ENTROPY_LEN, 384, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 1, ACVP_DRBG_NONCE_LEN, 0, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 1, ACVP_DRBG_PERSO_LEN, 384, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_drbg_set_length(ctx, ACVP_CTRDRBG, ACVP_DRBG_AES_256, 1, ACVP_DRBG_ADD_IN_LEN, 384, 0, 0);
+     CHECK_ENABLE_CAP_RV(rv);
+ end:
+     return rv;
+ }
+
+ #if !defined OPENSSL_NO_DSA
+ static int enable_safe_primes(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     /* Register Safe Prime Key Generation testing */
+     rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYGEN, &app_safe_primes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_FFDHE2048);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_FFDHE3072);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_FFDHE4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_FFDHE6144);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_FFDHE8192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_MODP2048);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_MODP3072);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_MODP4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_MODP6144);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYGEN, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_MODP8192);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     /* Register Safe Prime Key Verify testing */
+     rv = acvp_cap_safe_primes_enable(ctx, ACVP_SAFE_PRIMES_KEYVER, &app_safe_primes_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_PREREQ_DRBG, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_set_prereq(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_PREREQ_SHA, value);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_FFDHE2048);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_FFDHE3072);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_FFDHE4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_FFDHE6144);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_FFDHE8192);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_MODP2048);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_MODP3072);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_MODP4096);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_MODP6144);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_safe_primes_set_parm(ctx, ACVP_SAFE_PRIMES_KEYVER, ACVP_SAFE_PRIMES_GENMETH, ACVP_SAFE_PRIMES_MODP8192);
+     CHECK_ENABLE_CAP_RV(rv);
+ end:
+     return rv;
+ }
+ #endif
+
+ static int enable_ml_kem(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     rv = acvp_cap_ml_kem_enable(ctx, ACVP_ML_KEM_KEYGEN, &app_ml_kem_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_KEYGEN, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_KEYGEN, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_768);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_KEYGEN, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_1024);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_ml_kem_enable(ctx, ACVP_ML_KEM_XCAP, &app_ml_kem_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_512);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_768);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_PARAMETER_SET, ACVP_ML_KEM_PARAM_SET_ML_KEM_1024);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_FUNCTION, ACVP_ML_KEM_FUNCTION_ENCAPSULATE);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_FUNCTION, ACVP_ML_KEM_FUNCTION_DECAPSULATE);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_FUNCTION, ACVP_ML_KEM_FUNCTION_ENC_KEYCHECK);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_kem_set_parm(ctx, ACVP_ML_KEM_XCAP, ACVP_ML_KEM_PARAM_FUNCTION, ACVP_ML_KEM_FUNCTION_DEC_KEYCHECK);
+     CHECK_ENABLE_CAP_RV(rv);
+
+ end:
+     return rv;
+ }
+
+ static int enable_ml_dsa(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_KEYGEN, &app_ml_dsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_KEYGEN, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_44);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_KEYGEN, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_65);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_KEYGEN, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_87);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_SIGGEN, &app_ml_dsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_DETERMINISTIC_MODE, ACVP_DETERMINISTIC_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_SIG_INTERFACE, ACVP_SIG_INTERFACE_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_PREHASH, ACVP_SIG_PREHASH_NO);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_MU, ACVP_ML_DSA_MU_EXTERNAL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_44);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_65);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_87);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_domain(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_MSG_LEN, 8, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_domain(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_CONTEXT_LEN, 0, 2040, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_ml_dsa_enable(ctx, ACVP_ML_DSA_SIGVER, &app_ml_dsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_SIG_INTERFACE, ACVP_SIG_INTERFACE_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_PREHASH, ACVP_SIG_PREHASH_NO);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_MU, ACVP_ML_DSA_MU_EXTERNAL);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_44);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_65);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_87);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_domain(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_MSG_LEN, 8, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_ml_dsa_set_domain(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_CONTEXT_LEN, 0, 2040, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+ end:
+     return rv;
+ }
+
+ static int enable_slh_dsa(ACVP_CTX *ctx) {
+     ACVP_RESULT rv = ACVP_SUCCESS;
+
+     rv = acvp_cap_slh_dsa_enable(ctx, ACVP_SLH_DSA_KEYGEN, &app_slh_dsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_128S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_128F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_192S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_192F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_256S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_256F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_128S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_128F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_192S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_192F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_256S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_KEYGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_256F);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_slh_dsa_enable(ctx, ACVP_SLH_DSA_SIGGEN, &app_slh_dsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_DETERMINISTIC_MODE, ACVP_DETERMINISTIC_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_SIG_INTERFACE, ACVP_SIG_INTERFACE_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PREHASH, ACVP_SIG_PREHASH_NO);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_128S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_128F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_192S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_192F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_256S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_256F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_128S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_128F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_192S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_192F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_256S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_256F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_domain(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_MSG_LEN, 8, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_domain(ctx, ACVP_SLH_DSA_SIGGEN, 0, ACVP_SLH_DSA_PARAM_CONTEXT_LEN, 0, 2040, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+     rv = acvp_cap_slh_dsa_enable(ctx, ACVP_SLH_DSA_SIGVER, &app_slh_dsa_handler);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_SIG_INTERFACE, ACVP_SIG_INTERFACE_BOTH);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PREHASH, ACVP_SIG_PREHASH_NO);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_128S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_128F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_192S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_192F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_256S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHA2_256F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_128S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_128F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_192S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_192F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_256S);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_parm(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_PARAMETER_SET, ACVP_SLH_DSA_PARAM_SET_SLH_DSA_SHAKE_256F);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_domain(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_MSG_LEN, 8, 65536, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+     rv = acvp_cap_slh_dsa_set_domain(ctx, ACVP_SLH_DSA_SIGVER, 0, ACVP_SLH_DSA_PARAM_CONTEXT_LEN, 0, 2040, 8);
+     CHECK_ENABLE_CAP_RV(rv);
+
+  end:
+     return rv;
+ }

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -158,6 +158,8 @@
 /* KMAC */
 #define ACVP_REV_KMAC_128            ACVP_REV_STR_1_0
 #define ACVP_REV_KMAC_256            ACVP_REV_STR_1_0
+#define ACVP_REV_CSHAKE_128          ACVP_REV_STR_1_0
+#define ACVP_REV_CSHAKE_256          ACVP_REV_STR_1_0
 
 /* DSA */
 #define ACVP_REV_DSA                 ACVP_REV_STR_1_0
@@ -302,6 +304,8 @@
 
 #define ACVP_ALG_KMAC_128            "KMAC-128"
 #define ACVP_ALG_KMAC_256            "KMAC-256"
+#define ACVP_ALG_CSHAKE_128          "cSHAKE-128"
+#define ACVP_ALG_CSHAKE_256          "cSHAKE-256"
 
 #define ACVP_ALG_DSA                 "DSA"
 #define ACVP_ALG_DSA_PQGGEN          "pqgGen"
@@ -833,6 +837,21 @@
 #define ACVP_KMAC_CUSTOM_HEX_BYTE_MAX (ACVP_KMAC_CUSTOM_HEX_BIT_MAX >> 3)
 #define ACVP_KMAC_CUSTOM_HEX_STR_MAX (ACVP_KMAC_CUSTOM_HEX_BIT_MAX >> 2)
 
+#define ACVP_CSHAKE_MSG_BIT_MAX 65536
+#define ACVP_CSHAKE_MSG_BYTE_MAX (ACVP_CSHAKE_MSG_BIT_MAX >> 3)
+#define ACVP_CSHAKE_MSG_STR_MAX (ACVP_CSHAKE_MSG_BIT_MAX >> 2)
+
+#define ACVP_CSHAKE_OUTPUT_BIT_MAX 65536
+#define ACVP_CSHAKE_OUTPUT_BYTE_MAX (ACVP_CSHAKE_OUTPUT_BIT_MAX >> 3)
+#define ACVP_CSHAKE_OUTPUT_STR_MAX (ACVP_CSHAKE_OUTPUT_BIT_MAX >> 2)
+
+#define ACVP_CSHAKE_CUSTOM_STR_MAX 161
+#define ACVP_CSHAKE_CUSTOM_HEX_BIT_MAX 1288
+#define ACVP_CSHAKE_CUSTOM_HEX_BYTE_MAX (ACVP_CSHAKE_CUSTOM_HEX_BIT_MAX >> 3)
+#define ACVP_CSHAKE_CUSTOM_HEX_STR_MAX (ACVP_CSHAKE_CUSTOM_HEX_BIT_MAX >> 2)
+
+#define ACVP_CSHAKE_FUNCTION_STR_MAX 161
+
 #define ACVP_DSA_PQG_MAX        3072     /**< 3072 bits, 768 characters */
 #define ACVP_DSA_PQG_MAX_BYTES  (ACVP_DSA_PQG_MAX / 2)
 #define ACVP_DSA_SEED_MAX       1024
@@ -1039,6 +1058,7 @@ struct acvp_alg_handler_t {
         ACVP_SUB_TDES     tdes;
         ACVP_SUB_CMAC     cmac;
         ACVP_SUB_KMAC     kmac;
+        ACVP_SUB_CSHAKE   cshake;
         ACVP_SUB_KDF      kdf;
         ACVP_SUB_DSA      dsa;
         ACVP_SUB_RSA      rsa;
@@ -1102,6 +1122,7 @@ typedef enum acvp_capability_type {
     ACVP_HMAC_TYPE,
     ACVP_CMAC_TYPE,
     ACVP_KMAC_TYPE,
+    ACVP_CSHAKE_TYPE,
     ACVP_RSA_KEYGEN_TYPE,
     ACVP_RSA_SIGGEN_TYPE,
     ACVP_RSA_SIGVER_TYPE,
@@ -1376,6 +1397,12 @@ typedef struct acvp_kmac_capability {
     ACVP_XOF_SUPPORT_OPTION xof;
     int hex_customization; // boolean
 } ACVP_KMAC_CAP;
+
+typedef struct acvp_cshake_capability {
+    ACVP_JSON_DOMAIN_OBJ output_len;
+    ACVP_JSON_DOMAIN_OBJ msg_len;
+    int hex_customization; // boolean
+} ACVP_CSHAKE_CAP;
 
 typedef struct acvp_drbg_cap_mode {
     int der_func_enabled;
@@ -1758,6 +1785,7 @@ typedef struct acvp_caps_list_t {
         ACVP_HMAC_CAP *hmac_cap;
         ACVP_CMAC_CAP *cmac_cap;
         ACVP_KMAC_CAP *kmac_cap;
+        ACVP_CSHAKE_CAP *cshake_cap;
         ACVP_RSA_KEYGEN_CAP *rsa_keygen_cap;
         ACVP_RSA_SIG_CAP *rsa_siggen_cap;
         ACVP_RSA_SIG_CAP *rsa_sigver_cap;
@@ -2062,6 +2090,8 @@ ACVP_RESULT acvp_hmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj);
 ACVP_RESULT acvp_cmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj);
 
 ACVP_RESULT acvp_kmac_kat_handler(ACVP_CTX *ctx, JSON_Object *obj);
+
+ACVP_RESULT acvp_cshake_kat_handler(ACVP_CTX *ctx, JSON_Object *obj);
 
 ACVP_RESULT acvp_rsa_keygen_kat_handler(ACVP_CTX *ctx, JSON_Object *obj);
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,7 @@ libacvp_la_SOURCES =  acvp.c \
                     acvp_hmac.c \
                     acvp_cmac.c \
                     acvp_kmac.c \
+                    acvp_cshake.c \
                     acvp_rsa_keygen.c \
                     acvp_rsa_sig.c \
                     acvp_rsa_prim.c \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -139,15 +139,15 @@ am_libacvp_la_OBJECTS = acvp.lo acvp_build_register.lo \
 	acvp_capabilities.lo acvp_operating_env.lo acvp_aes.lo \
 	acvp_des.lo acvp_hash.lo acvp_drbg.lo acvp_transport.lo \
 	acvp_util.lo parson.lo acvp_hmac.lo acvp_cmac.lo acvp_kmac.lo \
-	acvp_rsa_keygen.lo acvp_rsa_sig.lo acvp_rsa_prim.lo \
-	acvp_dsa.lo acvp_kdf135_snmp.lo acvp_kdf135_ssh.lo \
-	acvp_kdf135_srtp.lo acvp_kdf135_ikev2.lo acvp_kdf135_ikev1.lo \
-	acvp_kdf135_x942.lo acvp_kdf135_x963.lo acvp_kdf108.lo \
-	acvp_pbkdf.lo acvp_kdf_tls12.lo acvp_kdf_tls13.lo \
-	acvp_kas_ecc.lo acvp_kas_ffc.lo acvp_kas_ifc.lo acvp_kda.lo \
-	acvp_kts_ifc.lo acvp_safe_primes.lo acvp_ecdsa.lo \
-	acvp_eddsa.lo acvp_lms.lo acvp_ml_dsa.lo acvp_ml_kem.lo \
-	acvp_slh_dsa.lo
+	acvp_cshake.lo acvp_rsa_keygen.lo acvp_rsa_sig.lo \
+	acvp_rsa_prim.lo acvp_dsa.lo acvp_kdf135_snmp.lo \
+	acvp_kdf135_ssh.lo acvp_kdf135_srtp.lo acvp_kdf135_ikev2.lo \
+	acvp_kdf135_ikev1.lo acvp_kdf135_x942.lo acvp_kdf135_x963.lo \
+	acvp_kdf108.lo acvp_pbkdf.lo acvp_kdf_tls12.lo \
+	acvp_kdf_tls13.lo acvp_kas_ecc.lo acvp_kas_ffc.lo \
+	acvp_kas_ifc.lo acvp_kda.lo acvp_kts_ifc.lo \
+	acvp_safe_primes.lo acvp_ecdsa.lo acvp_eddsa.lo acvp_lms.lo \
+	acvp_ml_dsa.lo acvp_ml_kem.lo acvp_slh_dsa.lo
 libacvp_la_OBJECTS = $(am_libacvp_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -171,13 +171,13 @@ am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = ./$(DEPDIR)/acvp.Plo ./$(DEPDIR)/acvp_aes.Plo \
 	./$(DEPDIR)/acvp_build_register.Plo \
 	./$(DEPDIR)/acvp_capabilities.Plo ./$(DEPDIR)/acvp_cmac.Plo \
-	./$(DEPDIR)/acvp_des.Plo ./$(DEPDIR)/acvp_drbg.Plo \
-	./$(DEPDIR)/acvp_dsa.Plo ./$(DEPDIR)/acvp_ecdsa.Plo \
-	./$(DEPDIR)/acvp_eddsa.Plo ./$(DEPDIR)/acvp_hash.Plo \
-	./$(DEPDIR)/acvp_hmac.Plo ./$(DEPDIR)/acvp_kas_ecc.Plo \
-	./$(DEPDIR)/acvp_kas_ffc.Plo ./$(DEPDIR)/acvp_kas_ifc.Plo \
-	./$(DEPDIR)/acvp_kda.Plo ./$(DEPDIR)/acvp_kdf108.Plo \
-	./$(DEPDIR)/acvp_kdf135_ikev1.Plo \
+	./$(DEPDIR)/acvp_cshake.Plo ./$(DEPDIR)/acvp_des.Plo \
+	./$(DEPDIR)/acvp_drbg.Plo ./$(DEPDIR)/acvp_dsa.Plo \
+	./$(DEPDIR)/acvp_ecdsa.Plo ./$(DEPDIR)/acvp_eddsa.Plo \
+	./$(DEPDIR)/acvp_hash.Plo ./$(DEPDIR)/acvp_hmac.Plo \
+	./$(DEPDIR)/acvp_kas_ecc.Plo ./$(DEPDIR)/acvp_kas_ffc.Plo \
+	./$(DEPDIR)/acvp_kas_ifc.Plo ./$(DEPDIR)/acvp_kda.Plo \
+	./$(DEPDIR)/acvp_kdf108.Plo ./$(DEPDIR)/acvp_kdf135_ikev1.Plo \
 	./$(DEPDIR)/acvp_kdf135_ikev2.Plo \
 	./$(DEPDIR)/acvp_kdf135_snmp.Plo \
 	./$(DEPDIR)/acvp_kdf135_srtp.Plo \
@@ -391,6 +391,7 @@ libacvp_la_SOURCES = acvp.c \
                     acvp_hmac.c \
                     acvp_cmac.c \
                     acvp_kmac.c \
+                    acvp_cshake.c \
                     acvp_rsa_keygen.c \
                     acvp_rsa_sig.c \
                     acvp_rsa_prim.c \
@@ -508,6 +509,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_build_register.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_capabilities.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_cmac.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_cshake.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_des.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_drbg.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/acvp_dsa.Plo@am__quote@ # am--include-marker
@@ -735,6 +737,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/acvp_build_register.Plo
 	-rm -f ./$(DEPDIR)/acvp_capabilities.Plo
 	-rm -f ./$(DEPDIR)/acvp_cmac.Plo
+	-rm -f ./$(DEPDIR)/acvp_cshake.Plo
 	-rm -f ./$(DEPDIR)/acvp_des.Plo
 	-rm -f ./$(DEPDIR)/acvp_drbg.Plo
 	-rm -f ./$(DEPDIR)/acvp_dsa.Plo
@@ -821,6 +824,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/acvp_build_register.Plo
 	-rm -f ./$(DEPDIR)/acvp_capabilities.Plo
 	-rm -f ./$(DEPDIR)/acvp_cmac.Plo
+	-rm -f ./$(DEPDIR)/acvp_cshake.Plo
 	-rm -f ./$(DEPDIR)/acvp_des.Plo
 	-rm -f ./$(DEPDIR)/acvp_drbg.Plo
 	-rm -f ./$(DEPDIR)/acvp_dsa.Plo

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -60,7 +60,7 @@ static ACVP_RESULT acvp_put_data_from_ctx(ACVP_CTX *ctx);
  * ACVP operation.
  *
  * WARNING:
- * This table is not sparse, it must contain ACVP_OP_MAX entries.
+ * This table is not sparse, it must contain ACVP_ALG_MAX entries.
  */
 ACVP_ALG_HANDLER alg_tbl[ACVP_ALG_MAX] = {
     { ACVP_AES_GCM,           &acvp_aes_kat_handler,              ACVP_ALG_AES_GCM,           NULL, ACVP_REV_AES_GCM, {ACVP_SUB_AES_GCM}},
@@ -127,6 +127,8 @@ ACVP_ALG_HANDLER alg_tbl[ACVP_ALG_MAX] = {
     { ACVP_CMAC_TDES,         &acvp_cmac_kat_handler,             ACVP_ALG_CMAC_TDES,         NULL, ACVP_REV_CMAC_TDES, {ACVP_SUB_CMAC_TDES}},
     { ACVP_KMAC_128,          &acvp_kmac_kat_handler,             ACVP_ALG_KMAC_128,          NULL, ACVP_REV_KMAC_128, {ACVP_SUB_KMAC_128}},
     { ACVP_KMAC_256,          &acvp_kmac_kat_handler,             ACVP_ALG_KMAC_256,          NULL, ACVP_REV_KMAC_256, {ACVP_SUB_KMAC_256}},
+    { ACVP_CSHAKE_128,        &acvp_cshake_kat_handler,           ACVP_ALG_CSHAKE_128,        NULL, ACVP_REV_CSHAKE_128, {ACVP_SUB_CSHAKE_128}},
+    { ACVP_CSHAKE_256,        &acvp_cshake_kat_handler,           ACVP_ALG_CSHAKE_256,        NULL, ACVP_REV_CSHAKE_256, {ACVP_SUB_CSHAKE_256}},
     { ACVP_DSA_KEYGEN,        &acvp_dsa_kat_handler,              ACVP_ALG_DSA,               ACVP_ALG_DSA_KEYGEN, ACVP_REV_DSA, {ACVP_SUB_DSA_KEYGEN}},
     { ACVP_DSA_PQGGEN,        &acvp_dsa_kat_handler,              ACVP_ALG_DSA,               ACVP_ALG_DSA_PQGGEN, ACVP_REV_DSA, {ACVP_SUB_DSA_PQGGEN}},
     { ACVP_DSA_PQGVER,        &acvp_dsa_kat_handler,              ACVP_ALG_DSA,               ACVP_ALG_DSA_PQGVER, ACVP_REV_DSA, {ACVP_SUB_DSA_PQGVER}},
@@ -752,6 +754,11 @@ ACVP_RESULT acvp_free_test_session(ACVP_CTX *ctx) {
                 acvp_cap_free_domain(&cap_entry->cap.kmac_cap->msg_len);
                 acvp_cap_free_domain(&cap_entry->cap.kmac_cap->mac_len);
                 free(cap_entry->cap.kmac_cap);
+                break;
+            case ACVP_CSHAKE_TYPE:
+                acvp_cap_free_domain(&cap_entry->cap.cshake_cap->output_len);
+                acvp_cap_free_domain(&cap_entry->cap.cshake_cap->msg_len);
+                free(cap_entry->cap.cshake_cap);
                 break;
             case ACVP_DSA_TYPE:
                 acvp_cap_free_dsa_attrs(cap_entry);
@@ -4195,6 +4202,13 @@ ACVP_SUB_KMAC acvp_get_kmac_alg(ACVP_CIPHER cipher)
     return (alg_tbl[cipher-1].alg.kmac);
 }
 
+ACVP_SUB_CSHAKE acvp_get_cshake_alg(ACVP_CIPHER cipher)
+{
+    if ((cipher == ACVP_CIPHER_START) || (cipher >= ACVP_CIPHER_END)) {
+        return 0;
+    }
+    return (alg_tbl[cipher-1].alg.cshake);
+}
 
 ACVP_SUB_RSA acvp_get_rsa_alg(ACVP_CIPHER cipher)
 {

--- a/src/acvp_capabilities.c
+++ b/src/acvp_capabilities.c
@@ -187,6 +187,14 @@ static ACVP_RESULT acvp_cap_list_append(ACVP_CTX *ctx,
         }
         break;
 
+    case ACVP_CSHAKE_TYPE:
+        cap_entry->cap.cshake_cap = calloc(1, sizeof(ACVP_CSHAKE_CAP));
+        if (!cap_entry->cap.cshake_cap) {
+            rv = ACVP_MALLOC_FAIL;
+            goto err;
+        }
+        break;
+
     case ACVP_DRBG_TYPE:
         cap_entry->cap.drbg_cap = calloc(1, sizeof(ACVP_DRBG_CAP));
         if (!cap_entry->cap.drbg_cap) {
@@ -1133,6 +1141,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_CMAC_TDES:
         case ACVP_KMAC_128:
         case ACVP_KMAC_256:
+        case ACVP_CSHAKE_128:
+        case ACVP_CSHAKE_256:
         case ACVP_DSA_KEYGEN:
         case ACVP_DSA_PQGGEN:
         case ACVP_DSA_PQGVER:
@@ -1268,6 +1278,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_CMAC_TDES:
         case ACVP_KMAC_128:
         case ACVP_KMAC_256:
+        case ACVP_CSHAKE_128:
+        case ACVP_CSHAKE_256:
         case ACVP_DSA_KEYGEN:
         case ACVP_DSA_PQGGEN:
         case ACVP_DSA_PQGVER:
@@ -1399,6 +1411,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_CMAC_TDES:
         case ACVP_KMAC_128:
         case ACVP_KMAC_256:
+        case ACVP_CSHAKE_128:
+        case ACVP_CSHAKE_256:
         case ACVP_DSA_KEYGEN:
         case ACVP_DSA_PQGGEN:
         case ACVP_DSA_PQGVER:
@@ -1530,6 +1544,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_CMAC_TDES:
         case ACVP_KMAC_128:
         case ACVP_KMAC_256:
+        case ACVP_CSHAKE_128:
+        case ACVP_CSHAKE_256:
         case ACVP_DSA_KEYGEN:
         case ACVP_DSA_PQGGEN:
         case ACVP_DSA_PQGVER:
@@ -1671,6 +1687,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_CMAC_TDES:
         case ACVP_KMAC_128:
         case ACVP_KMAC_256:
+        case ACVP_CSHAKE_128:
+        case ACVP_CSHAKE_256:
         case ACVP_DSA_KEYGEN:
         case ACVP_DSA_PQGGEN:
         case ACVP_DSA_PQGVER:
@@ -1799,6 +1817,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_parm_value(ACVP_CIPHER cipher, ACVP_
         case ACVP_CMAC_TDES:
         case ACVP_KMAC_128:
         case ACVP_KMAC_256:
+        case ACVP_CSHAKE_128:
+        case ACVP_CSHAKE_256:
         case ACVP_DSA_KEYGEN:
         case ACVP_DSA_PQGGEN:
         case ACVP_DSA_PQGVER:
@@ -2230,6 +2250,8 @@ static ACVP_RESULT acvp_validate_sym_cipher_domain_value(ACVP_CIPHER cipher, ACV
     case ACVP_CMAC_TDES:
     case ACVP_KMAC_128:
     case ACVP_KMAC_256:
+    case ACVP_CSHAKE_128:
+    case ACVP_CSHAKE_256:
     case ACVP_DSA_KEYGEN:
     case ACVP_DSA_PQGGEN:
     case ACVP_DSA_PQGVER:
@@ -2344,6 +2366,8 @@ static ACVP_RESULT acvp_validate_prereq_val(ACVP_CIPHER cipher, ACVP_PREREQ_ALG 
     case ACVP_HASH_SHA3_512:
     case ACVP_HASH_SHAKE_128:
     case ACVP_HASH_SHAKE_256:
+    case ACVP_CSHAKE_128:
+    case ACVP_CSHAKE_256:
         return ACVP_INVALID_ARG;
 
         break;
@@ -2756,6 +2780,8 @@ ACVP_RESULT acvp_cap_sym_cipher_set_domain(ACVP_CTX *ctx,
     case ACVP_CMAC_TDES:
     case ACVP_KMAC_128:
     case ACVP_KMAC_256:
+    case ACVP_CSHAKE_128:
+    case ACVP_CSHAKE_256:
     case ACVP_DSA_KEYGEN:
     case ACVP_DSA_PQGGEN:
     case ACVP_DSA_PQGVER:
@@ -3026,6 +3052,8 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm(ACVP_CTX *ctx,
     case ACVP_CMAC_TDES:
     case ACVP_KMAC_128:
     case ACVP_KMAC_256:
+    case ACVP_CSHAKE_128:
+    case ACVP_CSHAKE_256:
     case ACVP_DSA_KEYGEN:
     case ACVP_DSA_PQGGEN:
     case ACVP_DSA_PQGVER:
@@ -3383,6 +3411,8 @@ ACVP_RESULT acvp_cap_sym_cipher_set_parm_string(ACVP_CTX *ctx,
     case ACVP_CMAC_TDES:
     case ACVP_KMAC_128:
     case ACVP_KMAC_256:
+    case ACVP_CSHAKE_128:
+    case ACVP_CSHAKE_256:
     case ACVP_DSA_KEYGEN:
     case ACVP_DSA_PQGGEN:
     case ACVP_DSA_PQGVER:
@@ -3575,6 +3605,8 @@ ACVP_RESULT acvp_cap_sym_cipher_set_iv_modes(ACVP_CTX *ctx,
     case ACVP_CMAC_TDES:
     case ACVP_KMAC_128:
     case ACVP_KMAC_256:
+    case ACVP_CSHAKE_128:
+    case ACVP_CSHAKE_256:
     case ACVP_DSA_KEYGEN:
     case ACVP_DSA_PQGGEN:
     case ACVP_DSA_PQGVER:
@@ -3759,6 +3791,8 @@ ACVP_RESULT acvp_cap_sym_cipher_enable(ACVP_CTX *ctx,
     case ACVP_CMAC_TDES:
     case ACVP_KMAC_128:
     case ACVP_KMAC_256:
+    case ACVP_CSHAKE_128:
+    case ACVP_CSHAKE_256:
     case ACVP_DSA_KEYGEN:
     case ACVP_DSA_PQGGEN:
     case ACVP_DSA_PQGVER:
@@ -4667,7 +4701,151 @@ ACVP_RESULT acvp_cap_kmac_set_domain(ACVP_CTX *ctx,
     }
 
     return ACVP_SUCCESS;
+}
 
+ACVP_RESULT acvp_cap_cshake_enable(ACVP_CTX *ctx,
+                                   ACVP_CIPHER cipher,
+                                   int (*crypto_handler)(ACVP_TEST_CASE *test_case)) {
+    ACVP_RESULT result = ACVP_SUCCESS;
+    ACVP_SUB_CSHAKE alg;
+
+    if (!ctx) {
+        return ACVP_NO_CTX;
+    }
+    if (!crypto_handler) {
+        ACVP_LOG_ERR("NULL parameter 'crypto_handler'");
+        return ACVP_INVALID_ARG;
+    }
+
+    alg = acvp_get_cshake_alg(cipher);
+    if (alg == 0) {
+        ACVP_LOG_ERR("Invalid cipher value");
+        return ACVP_INVALID_ARG;
+    }
+    switch (alg) {
+    case ACVP_SUB_CSHAKE_128:
+    case ACVP_SUB_CSHAKE_256:
+        break;
+    default:
+        return ACVP_INVALID_ARG;
+    }
+
+    result = acvp_cap_list_append(ctx, ACVP_CSHAKE_TYPE, cipher, crypto_handler);
+
+    if (result == ACVP_DUP_CIPHER) {
+        ACVP_LOG_ERR("Capability previously enabled. Duplicate not allowed.");
+    } else if (result == ACVP_MALLOC_FAIL) {
+        ACVP_LOG_ERR("Failed to allocate capability object");
+    }
+
+    return result;
+}
+
+ACVP_RESULT acvp_cap_cshake_set_parm(ACVP_CTX *ctx,
+                                     ACVP_CIPHER cipher,
+                                     ACVP_CSHAKE_PARM parm,
+                                     int value) {
+    ACVP_CAPS_LIST *cap = NULL;
+    ACVP_CSHAKE_CAP *cshake_cap = NULL;
+
+    /*
+     * Locate this cipher in the caps array
+     */
+    cap = acvp_locate_cap_entry(ctx, cipher);
+    if (!cap) {
+        ACVP_LOG_ERR("Cap entry not found, use acvp_cap_cshake_enable() first.");
+        return ACVP_NO_CAP;
+    }
+    cshake_cap = cap->cap.cshake_cap;
+
+    switch (parm) {
+    case ACVP_CSHAKE_HEX_CUSTOM_SUPPORT:
+        if (is_valid_tf_param(value) == ACVP_SUCCESS) {
+            cshake_cap->hex_customization = value;
+        } else {
+            ACVP_LOG_ERR("Invalid param 'value' for ACVP_CSHAKE_HEX_CUSTOM_SUPPORT. "
+                         "Must be 1 or 0");
+            return ACVP_INVALID_ARG;
+        }
+        break;
+    case ACVP_CSHAKE_OUTLEN:
+        if (value < 16 || value > 65536 || (value % 8) != 0) {
+            ACVP_LOG_ERR("Invalid output length value for cSHAKE. Must be 16-65536 bits and multiple of 8");
+            return ACVP_INVALID_ARG;
+        }
+        if (acvp_append_sl_list(&cshake_cap->output_len.values, value) != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("Error adding output length value to cSHAKE capability");
+            return ACVP_MALLOC_FAIL;
+        }
+        break;
+    case ACVP_CSHAKE_MSGLEN:
+        if (value < 0 || value > 65536 || (value % 8) != 0) {
+            ACVP_LOG_ERR("Invalid message length value for cSHAKE. Must be 0-65536 bits and multiple of 8");
+            return ACVP_INVALID_ARG;
+        }
+        if (acvp_append_sl_list(&cshake_cap->msg_len.values, value) != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("Error adding message length value to cSHAKE capability");
+            return ACVP_MALLOC_FAIL;
+        }
+        break;
+    default:
+        ACVP_LOG_ERR("Invalid cSHAKE parameter given");
+        return ACVP_INVALID_ARG;
+    }
+
+    return ACVP_SUCCESS;
+}
+
+ACVP_RESULT acvp_cap_cshake_set_domain(ACVP_CTX *ctx,
+                                       ACVP_CIPHER cipher,
+                                       ACVP_CSHAKE_PARM parm,
+                                       int min,
+                                       int max,
+                                       int increment) {
+    ACVP_CAPS_LIST *cap = NULL;
+    ACVP_CSHAKE_CAP *cshake_cap = NULL;
+
+    /*
+     * Locate this cipher in the caps array
+     */
+    cap = acvp_locate_cap_entry(ctx, cipher);
+    if (!cap) {
+        ACVP_LOG_ERR("Cap entry not found, use acvp_cap_cshake_enable() first.");
+        return ACVP_NO_CAP;
+    }
+    cshake_cap = cap->cap.cshake_cap;
+
+    if (validate_domain_range(min, max, increment) != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Invalid domain given for cSHAKE");
+        return ACVP_INVALID_ARG;
+    }
+
+    switch (parm) {
+    case ACVP_CSHAKE_OUTLEN:
+        if (max > 65536 || min < 16 || increment != 8) {
+            ACVP_LOG_ERR("Out of bounds output length given for cSHAKE");
+            return ACVP_INVALID_ARG;
+        }
+        cshake_cap->output_len.min = min;
+        cshake_cap->output_len.max = max;
+        cshake_cap->output_len.increment = increment;
+        break;
+    case ACVP_CSHAKE_MSGLEN:
+        if (max > 65536) {
+            ACVP_LOG_ERR("Out of bounds msglen given for cSHAKE");
+            return ACVP_INVALID_ARG;
+        }
+        cshake_cap->msg_len.min = min;
+        cshake_cap->msg_len.max = max;
+        cshake_cap->msg_len.increment = increment;
+        break;
+    case ACVP_CSHAKE_HEX_CUSTOM_SUPPORT:
+    default:
+        ACVP_LOG_ERR("Invalid cSHAKE parameter given");
+        return ACVP_INVALID_ARG;
+    }
+
+    return ACVP_SUCCESS;
 }
 
 /*

--- a/src/acvp_cshake.c
+++ b/src/acvp_cshake.c
@@ -1,0 +1,661 @@
+/** @file */
+/*
+ * Copyright (c) 2025, Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/cisco/libacvp/LICENSE
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "acvp.h"
+#include "acvp_lcl.h"
+#include "parson.h"
+#include "safe_lib.h"
+
+static ACVP_RESULT acvp_cshake_init_tc(ACVP_CTX *ctx,
+                                       ACVP_CSHAKE_TC *stc,
+                                       ACVP_CIPHER alg_id,
+                                       int tc_id,
+                                       ACVP_CSHAKE_TESTTYPE type,
+                                       int hex_customization,
+                                       const char *msg,
+                                       int md_len,
+                                       const char *function_name,
+                                       const char *custom) {
+
+    ACVP_RESULT rv;
+    int len = 0;
+    memzero_s(stc, sizeof(ACVP_CSHAKE_TC));
+    stc->tc_id = tc_id;
+    stc->cipher = alg_id;
+    stc->test_type = type;
+    stc->hex_customization = hex_customization;
+    stc->md_len = md_len / 8;
+
+    stc->msg = calloc(1, ACVP_CSHAKE_MSG_BYTE_MAX);
+    if (!stc->msg) { return ACVP_MALLOC_FAIL; }
+    stc->md = calloc(1, ACVP_CSHAKE_OUTPUT_BYTE_MAX);
+    if (!stc->md) { return ACVP_MALLOC_FAIL; }
+
+    if (hex_customization) {
+        stc->custom_hex = calloc(1, ACVP_CSHAKE_CUSTOM_HEX_BYTE_MAX);
+        if (!stc->custom_hex) { return ACVP_MALLOC_FAIL; }
+    } else {
+        stc->custom = calloc(1, ACVP_CSHAKE_CUSTOM_STR_MAX + 1);
+        if (!stc->custom) { return ACVP_MALLOC_FAIL; }
+    }
+
+    stc->function_name = calloc(1, ACVP_CSHAKE_FUNCTION_STR_MAX + 1);
+    if (!stc->function_name) { return ACVP_MALLOC_FAIL; }
+
+
+    if (msg) {
+        len = strnlen_s(msg, ACVP_CSHAKE_MSG_STR_MAX + 1);
+        if (len > ACVP_CSHAKE_MSG_STR_MAX) {
+            ACVP_LOG_ERR("msg too long");
+            return ACVP_INVALID_ARG;
+        }
+        rv = acvp_hexstr_to_bin(msg, stc->msg, ACVP_CSHAKE_MSG_BYTE_MAX, &(stc->msg_len));
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("Hex conversion failure (msg)");
+            return rv;
+        }
+    }
+
+    if (function_name) {
+        len = strnlen_s(function_name, ACVP_CSHAKE_FUNCTION_STR_MAX + 1);
+        if (len > ACVP_CSHAKE_FUNCTION_STR_MAX) {
+            ACVP_LOG_ERR("function name too long");
+            return ACVP_INVALID_ARG;
+        }
+        strcpy_s(stc->function_name, ACVP_CSHAKE_FUNCTION_STR_MAX + 1, function_name);
+        stc->function_name_len = len;
+    }
+
+    if (custom) {
+        if (hex_customization) {
+            len = strnlen_s(custom, ACVP_CSHAKE_CUSTOM_HEX_STR_MAX + 1);
+            if (len > ACVP_CSHAKE_CUSTOM_HEX_STR_MAX) {
+                ACVP_LOG_ERR("custom hex too long");
+                return ACVP_INVALID_ARG;
+            }
+            rv = acvp_hexstr_to_bin(custom, stc->custom_hex, ACVP_CSHAKE_CUSTOM_HEX_BYTE_MAX, &(stc->custom_len));
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("Hex conversion failure (custom_hex)");
+                return rv;
+            }
+        } else {
+            len = strnlen_s(custom, ACVP_CSHAKE_CUSTOM_STR_MAX + 1);
+            if (len > ACVP_CSHAKE_CUSTOM_STR_MAX) {
+                ACVP_LOG_ERR("custom string too long");
+                return ACVP_INVALID_ARG;
+            }
+            strcpy_s(stc->custom, ACVP_CSHAKE_CUSTOM_STR_MAX + 1, custom);
+            stc->custom_len = len;
+        }
+    }
+
+    return ACVP_SUCCESS;
+}
+
+static ACVP_RESULT acvp_cshake_output_tc(ACVP_CTX *ctx, ACVP_CSHAKE_TC *stc, JSON_Object *tc_rsp) {
+    ACVP_RESULT rv = ACVP_SUCCESS;
+    char *tmp = NULL;
+
+    tmp = calloc(ACVP_CSHAKE_OUTPUT_STR_MAX + 1, sizeof(char));
+    if (!tmp) {
+        ACVP_LOG_ERR("Unable to malloc");
+        return ACVP_MALLOC_FAIL;
+    }
+
+    if (stc->test_type == ACVP_CSHAKE_TEST_TYPE_AFT) {
+        rv = acvp_bin_to_hexstr(stc->md, stc->md_len, tmp, ACVP_CSHAKE_OUTPUT_STR_MAX);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("hex conversion failure (md)");
+            goto end;
+        }
+        json_object_set_string(tc_rsp, "md", tmp);
+        json_object_set_number(tc_rsp, "outLen", stc->md_len * 8);
+    }
+
+end:
+    if (tmp) free(tmp);
+    return rv;
+}
+
+/*
+ * This function simply releases the data associated with
+ * a test case.
+ */
+static ACVP_RESULT acvp_cshake_release_tc(ACVP_CSHAKE_TC *stc) {
+    if (stc->msg) free(stc->msg);
+    if (stc->md) free(stc->md);
+    if (stc->custom) free(stc->custom);
+    if (stc->custom_hex) free(stc->custom_hex);
+    if (stc->function_name) free(stc->function_name);
+    memzero_s(stc, sizeof(ACVP_CSHAKE_TC));
+
+    return ACVP_SUCCESS;
+}
+
+static ACVP_CSHAKE_TESTTYPE read_test_type(const char *str) {
+    int diff = 1;
+
+    strcmp_s("AFT", 3, str, &diff);
+    if (!diff) return ACVP_CSHAKE_TEST_TYPE_AFT;
+
+    strcmp_s("MCT", 3, str, &diff);
+    if (!diff) return ACVP_CSHAKE_TEST_TYPE_MCT;
+
+    return 0;
+}
+
+/*
+ * Helper function to convert bits to ASCII string as specified in XOF draft
+ * BitsToString(bits) converts each byte to ASCII character ((byte % 26) + 65)
+ */
+static ACVP_RESULT acvp_cshake_bits_to_string(const unsigned char *bits, int bits_len,
+                                               char *str, int str_max_len) {
+    int i;
+
+    if (!bits || !str || bits_len < 0 || str_max_len <= 0) {
+        return ACVP_INVALID_ARG;
+    }
+
+    if (bits_len >= str_max_len) {
+        return ACVP_DATA_TOO_LARGE;
+    }
+
+    for (i = 0; i < bits_len; i++) {
+        str[i] = (char)((bits[i] % 26) + 65); /* Convert to uppercase ASCII letters A-Z */
+    }
+    str[bits_len] = '\0'; /* Null terminate */
+
+    return ACVP_SUCCESS;
+}
+
+/*
+ * MCT-specific output function to handle the resultsArray format
+ */
+static ACVP_RESULT acvp_cshake_output_mct_tc(ACVP_CTX *ctx, ACVP_CSHAKE_TC *stc,
+                                              JSON_Object *tc_rsp) {
+    ACVP_RESULT rv = ACVP_SUCCESS;
+    char *tmp = NULL;
+
+    tmp = calloc(ACVP_CSHAKE_OUTPUT_STR_MAX + 1, sizeof(char));
+    if (!tmp) {
+        ACVP_LOG_ERR("Unable to malloc");
+        return ACVP_MALLOC_FAIL;
+    }
+
+    rv = acvp_bin_to_hexstr(stc->md, stc->md_len, tmp, ACVP_CSHAKE_OUTPUT_STR_MAX);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("hex conversion failure (md)");
+        goto end;
+    }
+    json_object_set_string(tc_rsp, "md", tmp);
+    json_object_set_number(tc_rsp, "outLen", stc->md_len * 8);
+
+end:
+    if (tmp) free(tmp);
+    return rv;
+}
+
+/*
+ * cSHAKE Monte Carlo Test implementation
+ * Based on the algorithm specified in draft-celi-acvp-xof.txt Section 6.2.1
+ */
+static ACVP_RESULT acvp_cshake_mct(ACVP_CTX *ctx,
+                                   ACVP_CAPS_LIST *cap,
+                                   ACVP_TEST_CASE *tc,
+                                   ACVP_CSHAKE_TC *stc,
+                                   JSON_Array *res_array,
+                                   int min_out_len,
+                                   int max_out_len,
+                                   int out_len_increment) {
+    int i = 0, j = 0;
+    ACVP_RESULT rv = ACVP_SUCCESS;
+    JSON_Value *r_tval = NULL;  /* Response testval */
+    JSON_Object *r_tobj = NULL; /* Response testobj */
+
+    /* MCT working variables */
+    unsigned char *output = NULL;
+    unsigned char *inner_msg = NULL;
+    unsigned char *rightmost_bits = NULL;
+    unsigned char *custom_bits = NULL;
+    char *custom_string = NULL;
+    int output_len = 0;
+    int range = 0;
+    uint16_t rightmost_val = 0;
+    int leftmost_bytes = 0;
+
+    /* Set leftmost_bytes as per specification (always 128 bits for cSHAKE MCT) */
+    leftmost_bytes = 16; /* 128 bits = 16 bytes as per specification */
+
+    /* Allocate working buffers */
+    output = calloc(1, ACVP_CSHAKE_OUTPUT_BYTE_MAX);
+    inner_msg = calloc(1, leftmost_bytes + 16); /* leftmost_bytes + padding */
+    rightmost_bits = calloc(1, 2); /* 16 bits = 2 bytes */
+    custom_bits = calloc(1, leftmost_bytes + 2); /* InnerMsg + RightmostBits */
+    custom_string = calloc(1, ACVP_CSHAKE_CUSTOM_STR_MAX + 1);
+
+    if (!output || !inner_msg || !rightmost_bits || !custom_bits || !custom_string) {
+        rv = ACVP_MALLOC_FAIL;
+        goto err;
+    }
+
+    /* MCT algorithm implementation */
+    range = (max_out_len - min_out_len + 1);
+    output_len = max_out_len;
+
+    /* Copy initial message to output[0] */
+    memcpy_s(output, ACVP_CSHAKE_OUTPUT_BYTE_MAX, stc->msg, stc->msg_len);
+    int current_output_len = stc->msg_len; /* Track current output length */
+
+    /* Outer loop: j = 0 to 99 */
+    for (j = 0; j < 100; j++) {
+        /* Inner loop: i = 1 to 1000 */
+        for (i = 1; i <= 1000; i++) {
+            /* InnerMsg = Left(Output[i-1] || ZeroBits(leftmost_bytes*8), leftmost_bytes*8) */
+            memzero_s(inner_msg, leftmost_bytes + 16);
+            if (current_output_len >= leftmost_bytes) {
+                memcpy_s(inner_msg, leftmost_bytes, output, leftmost_bytes);
+            } else {
+                memcpy_s(inner_msg, leftmost_bytes, output, current_output_len);
+                /* Remaining bytes are already zeroed */
+            }
+
+            /* Set up test case for crypto handler */
+            memcpy_s(stc->msg, ACVP_CSHAKE_MSG_BYTE_MAX, inner_msg, leftmost_bytes);
+            stc->msg_len = leftmost_bytes;
+            stc->md_len = (output_len + 7) / 8; /* Convert bits to bytes */
+
+            /* Clear md buffer */
+            memzero_s(stc->md, ACVP_CSHAKE_OUTPUT_BYTE_MAX);
+
+            /* Call crypto module: Output[i] = CSHAKE(InnerMsg, OutputLen, FunctionName, Customization) */
+            rv = (cap->crypto_handler)(tc);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("Crypto module failed the operation");
+                goto err;
+            }
+
+            /* Copy result to output buffer for next iteration */
+            memcpy_s(output, ACVP_CSHAKE_OUTPUT_BYTE_MAX, stc->md, stc->md_len);
+            current_output_len = stc->md_len;
+
+            /* Rightmost_Output_bits = Right(Output[i], 16) */
+            if (stc->md_len >= 2) {
+                memcpy_s(rightmost_bits, 2, &stc->md[stc->md_len - 2], 2);
+            } else {
+                memzero_s(rightmost_bits, 2);
+                if (stc->md_len == 1) {
+                    rightmost_bits[0] = stc->md[0];  /* Rightmost byte goes in index 0 */
+                }
+            }
+
+            /* Convert rightmost bits to integer (little-endian where first 8-bits are MSB) */
+            rightmost_val = (uint16_t)(rightmost_bits[1] | (rightmost_bits[0] << 8));
+
+            /* OutputLen = MinOutLen + (floor((Rightmost_Output_bits % Range) / OutLenIncrement) * OutLenIncrement) */
+            output_len = min_out_len + ((rightmost_val % range) / out_len_increment) * out_len_increment;
+
+            /* Customization = BitsToString(InnerMsg || Rightmost_Output_bits) */
+            memcpy_s(custom_bits, leftmost_bytes + 2, inner_msg, leftmost_bytes);
+            memcpy_s(&custom_bits[leftmost_bytes], 2, rightmost_bits, 2);
+
+            rv = acvp_cshake_bits_to_string(custom_bits, leftmost_bytes + 2,
+                                            custom_string, ACVP_CSHAKE_CUSTOM_STR_MAX);
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("BitsToString conversion failed");
+                goto err;
+            }
+
+            /* Update customization in test case */
+            strcpy_s(stc->custom, ACVP_CSHAKE_CUSTOM_STR_MAX + 1, custom_string);
+            stc->custom_len = strnlen_s(custom_string, ACVP_CSHAKE_CUSTOM_STR_MAX);
+        }
+
+        /* Create response object for this iteration */
+        r_tval = json_value_init_object();
+        r_tobj = json_value_get_object(r_tval);
+
+        /* Output the result for this outer loop iteration */
+        rv = acvp_cshake_output_mct_tc(ctx, stc, r_tobj);
+        if (rv != ACVP_SUCCESS) {
+            ACVP_LOG_ERR("JSON output failure recording MCT test response");
+            json_value_free(r_tval);
+            goto err;
+        }
+
+        json_array_append_value(res_array, r_tval);
+
+        /* Output[0] = Output[1000] for next iteration (as per spec line 307) */
+        /* The output buffer already contains Output[1000] from the last inner loop iteration */
+    }
+
+err:
+    if (output) free(output);
+    if (inner_msg) free(inner_msg);
+    if (rightmost_bits) free(rightmost_bits);
+    if (custom_bits) free(custom_bits);
+    if (custom_string) free(custom_string);
+
+    return rv;
+}
+
+ACVP_RESULT acvp_cshake_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
+    int tc_id = 0, msglen = 0, outlen = 0;
+    const char *msg = NULL, *type_str = NULL, *custom = NULL, *function_name = NULL;
+    int hex_customization = 0;
+    int min_out_len = 0, max_out_len = 0, out_len_increment = 0; /* MCT parameters */
+    ACVP_CSHAKE_TESTTYPE type;
+    JSON_Value *groupval = NULL;
+    JSON_Object *groupobj = NULL;
+    JSON_Value *testval = NULL;
+    JSON_Object *testobj = NULL;
+    JSON_Array *groups = NULL;
+    JSON_Array *tests = NULL;
+
+    JSON_Value *reg_arry_val = NULL;
+    JSON_Object *reg_obj = NULL;
+    JSON_Array *reg_arry = NULL;
+
+    int i, g_cnt;
+    int j, t_cnt;
+
+    JSON_Value *r_vs_val = NULL;
+    JSON_Object *r_vs = NULL;
+    JSON_Array *r_tarr = NULL, *r_garr = NULL;  /* Response testarray, grouparray */
+    JSON_Value *r_tval = NULL, *r_gval = NULL;  /* Response testval, groupval */
+    JSON_Object *r_tobj = NULL, *r_gobj = NULL; /* Response testobj, groupobj */
+    ACVP_CAPS_LIST *cap = NULL;
+    ACVP_CSHAKE_TC stc;
+    ACVP_TEST_CASE tc;
+    ACVP_RESULT rv;
+    const char *alg_str = json_object_get_string(obj, "algorithm");
+    ACVP_CIPHER alg_id;
+    char *json_result = NULL;
+
+    if (!ctx) {
+        ACVP_LOG_ERR("No ctx for handler operation");
+        return ACVP_NO_CTX;
+    }
+
+    if (!obj) {
+        ACVP_LOG_ERR("No obj for handler operation");
+        return ACVP_MALFORMED_JSON;
+    }
+
+    if (!alg_str) {
+        ACVP_LOG_ERR("unable to parse 'algorithm' from JSON");
+        return ACVP_MALFORMED_JSON;
+    }
+
+    /*
+     * Get a reference to the abstracted test case
+     */
+    tc.tc.cshake = &stc;
+
+    /*
+     * Get the crypto module handler for cSHAKE
+     */
+    alg_id = acvp_lookup_cipher_index(alg_str);
+    if (alg_id < ACVP_CIPHER_START) {
+        ACVP_LOG_ERR("unsupported algorithm (%s)", alg_str);
+        return ACVP_UNSUPPORTED_OP;
+    }
+    cap = acvp_locate_cap_entry(ctx, alg_id);
+    if (!cap) {
+        ACVP_LOG_ERR("ACVP server requesting unsupported capability %s : %d.", alg_str, alg_id);
+        return ACVP_UNSUPPORTED_OP;
+    }
+
+    /*
+     * Create ACVP array for response
+     */
+    rv = acvp_create_array(&reg_obj, &reg_arry_val, &reg_arry);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Failed to create JSON response struct. ");
+        return rv;
+    }
+
+    /*
+     * Start to build the JSON response
+     */
+    rv = acvp_setup_json_rsp_group(&ctx, &reg_arry_val, &r_vs_val, &r_vs, alg_str, &r_garr);
+    if (rv != ACVP_SUCCESS) {
+        ACVP_LOG_ERR("Failed to setup json response");
+        return rv;
+    }
+
+    groups = json_object_get_array(obj, "testGroups");
+    g_cnt = json_array_get_count(groups);
+
+    for (i = 0; i < g_cnt; i++) {
+        int tgId = 0;
+        groupval = json_array_get_value(groups, i);
+        groupobj = json_value_get_object(groupval);
+
+        /*
+         * Create a new group in the response with the tgid
+         * and an array of tests
+         */
+        r_gval = json_value_init_object();
+        r_gobj = json_value_get_object(r_gval);
+        tgId = json_object_get_number(groupobj, "tgId");
+        if (!tgId) {
+            ACVP_LOG_ERR("Missing tgid from server JSON groub obj");
+            rv = ACVP_MALFORMED_JSON;
+            goto err;
+        }
+        json_object_set_number(r_gobj, "tgId", tgId);
+        json_object_set_value(r_gobj, "tests", json_value_init_array());
+        r_tarr = json_object_get_array(r_gobj, "tests");
+
+        type_str = json_object_get_string(groupobj, "testType");
+        if (!type_str) {
+            ACVP_LOG_ERR("Server JSON missing 'testType'");
+            rv = ACVP_MISSING_ARG;
+            goto err;
+        }
+
+        type = read_test_type(type_str);
+        if (!type) {
+            ACVP_LOG_ERR("Server JSON invalid 'testType'");
+            rv = ACVP_INVALID_ARG;
+            goto err;
+        }
+
+        hex_customization = json_object_get_boolean(groupobj, "hexCustomization");
+
+        /* Parse MCT-specific parameters if this is an MCT test */
+        if (type == ACVP_CSHAKE_TEST_TYPE_MCT) {
+            min_out_len = json_object_get_number(groupobj, "minOutLen");
+            max_out_len = json_object_get_number(groupobj, "maxOutLen");
+            out_len_increment = json_object_get_number(groupobj, "outLenIncrement");
+
+            if (min_out_len <= 0 || max_out_len <= 0 || out_len_increment <= 0) {
+                ACVP_LOG_ERR("Invalid MCT parameters in test group");
+                rv = ACVP_MISSING_ARG;
+                goto err;
+            }
+        }
+
+        ACVP_LOG_VERBOSE("    Test group: %d", i);
+        ACVP_LOG_VERBOSE("      test type: %s", type_str);
+        ACVP_LOG_VERBOSE("   hex customization: %s", hex_customization ? "true" : "false");
+        if (type == ACVP_CSHAKE_TEST_TYPE_MCT) {
+            ACVP_LOG_VERBOSE("      min out len: %d", min_out_len);
+            ACVP_LOG_VERBOSE("      max out len: %d", max_out_len);
+            ACVP_LOG_VERBOSE("  out len increment: %d", out_len_increment);
+        }
+
+        tests = json_object_get_array(groupobj, "tests");
+        t_cnt = json_array_get_count(tests);
+
+        for (j = 0; j < t_cnt; j++) {
+            ACVP_LOG_VERBOSE("Found new cSHAKE test vector...");
+            testval = json_array_get_value(tests, j);
+            testobj = json_value_get_object(testval);
+
+            tc_id = json_object_get_number(testobj, "tcId");
+
+            msg = json_object_get_string(testobj, "msg");
+            msglen = json_object_get_number(testobj, "len");
+            outlen = json_object_get_number(testobj, "outLen");
+            function_name = json_object_get_string(testobj, "functionName");
+
+            if (hex_customization) {
+                custom = json_object_get_string(testobj, "customizationHex");
+                if (custom && strnlen_s(custom, ACVP_CSHAKE_CUSTOM_HEX_STR_MAX + 1) > ACVP_CSHAKE_CUSTOM_HEX_STR_MAX) {
+                    ACVP_LOG_ERR("customization hex too long in tcid %d", tc_id);
+                    rv = ACVP_INVALID_ARG;
+                    goto err;
+                }
+            } else {
+                custom = json_object_get_string(testobj, "customization");
+                if (custom && strnlen_s(custom, ACVP_CSHAKE_CUSTOM_STR_MAX + 1) > ACVP_CSHAKE_CUSTOM_STR_MAX) {
+                    ACVP_LOG_ERR("customization string too long in tcid %d", tc_id);
+                    rv = ACVP_INVALID_ARG;
+                    goto err;
+                }
+            }
+
+            if (!msg) {
+                ACVP_LOG_ERR("Server JSON missing 'msg'");
+                rv = ACVP_MISSING_ARG;
+                goto err;
+            }
+
+            if (msglen < 0) {
+                ACVP_LOG_ERR("Server JSON missing or invalid 'len'");
+                rv = ACVP_MISSING_ARG;
+                goto err;
+            }
+
+            if (type != ACVP_CSHAKE_TEST_TYPE_MCT && outlen <= 0) {
+                ACVP_LOG_ERR("Server JSON missing or invalid 'outLen'");
+                rv = ACVP_MISSING_ARG;
+                goto err;
+            }
+
+            ACVP_LOG_VERBOSE("        Test case: %d", j);
+            ACVP_LOG_VERBOSE("             tcId: %d", tc_id);
+            ACVP_LOG_VERBOSE("           msgLen: %d", msglen);
+            ACVP_LOG_VERBOSE("           outLen: %d", outlen);
+            ACVP_LOG_VERBOSE("              msg: %s", msg);
+            ACVP_LOG_VERBOSE("     functionName: %s", function_name ? function_name : "");
+            ACVP_LOG_VERBOSE("    customization: %s", custom ? custom : "");
+
+            /*
+             * Create a new test case in the response
+             */
+            r_tval = json_value_init_object();
+            r_tobj = json_value_get_object(r_tval);
+
+            json_object_set_number(r_tobj, "tcId", tc_id);
+
+            /*
+             * Setup the test case data that will be passed down to
+             * the crypto module.
+             */
+            if (msg) {
+                int actual_msg_len = strnlen_s(msg, ACVP_CSHAKE_MSG_STR_MAX + 1) / 2;
+                if (msglen != actual_msg_len * 8) {
+                    ACVP_LOG_ERR("Message length mismatch: JSON says %d bits, actual string is %d bytes (%d bits)",
+                                 msglen, actual_msg_len, actual_msg_len * 8);
+                    rv = ACVP_TC_INVALID_DATA;
+                    goto err;
+                }
+            }
+
+            if (type == ACVP_CSHAKE_TEST_TYPE_MCT) {
+                /* MCT tests don't have outLen, md_len will be set during MCT execution */
+                rv = acvp_cshake_init_tc(ctx, &stc, alg_id, tc_id, type, hex_customization,
+                                         msg, 0, function_name, custom);
+            } else {
+                /* AFT tests use outLen from JSON */
+                rv = acvp_cshake_init_tc(ctx, &stc, alg_id, tc_id, type, hex_customization,
+                                         msg, outlen, function_name, custom);
+            }
+            if (rv != ACVP_SUCCESS) {
+                ACVP_LOG_ERR("Error initializing cSHAKE test case");
+                acvp_cshake_release_tc(&stc);
+                json_value_free(r_tval);
+                goto err;
+            }
+
+            /* Handle MCT or AFT test types */
+            if (type == ACVP_CSHAKE_TEST_TYPE_MCT) {
+                /* For MCT, create resultsArray and call MCT handler */
+                json_object_set_value(r_tobj, "resultsArray", json_value_init_array());
+                JSON_Array *results_array = json_object_get_array(r_tobj, "resultsArray");
+
+                rv = acvp_cshake_mct(ctx, cap, &tc, &stc, results_array,
+                                     min_out_len, max_out_len, out_len_increment);
+                if (rv != ACVP_SUCCESS) {
+                    ACVP_LOG_ERR("cSHAKE MCT processing failed");
+                    acvp_cshake_release_tc(&stc);
+                    json_value_free(r_tval);
+                    goto err;
+                }
+
+                /*
+                 * Release all the memory associated with the test case
+                 */
+                acvp_cshake_release_tc(&stc);
+
+                /* Append the MCT test case to the main test array */
+                json_array_append_value(r_tarr, r_tval);
+            } else {
+                /* AFT processing */
+                if ((cap->crypto_handler)(&tc)) {
+                    ACVP_LOG_ERR("Crypto module failed the operation");
+                    acvp_cshake_release_tc(&stc);
+                    json_value_free(r_tval);
+                    rv = ACVP_CRYPTO_MODULE_FAIL;
+                    goto err;
+                }
+
+                /*
+                 * Output the test case results using JSON
+                 */
+                rv = acvp_cshake_output_tc(ctx, &stc, r_tobj);
+                if (rv != ACVP_SUCCESS) {
+                    ACVP_LOG_ERR("JSON output failure recording test response");
+                    json_value_free(r_tval);
+                    acvp_cshake_release_tc(&stc);
+                    goto err;
+                }
+
+                /*
+                 * Release all the memory associated with the test case
+                 */
+                acvp_cshake_release_tc(&stc);
+
+                /* Append the AFT test response value to array */
+                json_array_append_value(r_tarr, r_tval);
+            }
+        }
+        json_array_append_value(r_garr, r_gval);
+    }
+
+    json_array_append_value(reg_arry, r_vs_val);
+
+    json_result = json_serialize_to_string_pretty(ctx->kat_resp, NULL);
+    ACVP_LOG_VERBOSE("\n\n%s\n\n", json_result);
+    json_free_serialized_string(json_result);
+    rv = ACVP_SUCCESS;
+
+err:
+    if (rv != ACVP_SUCCESS) {
+        acvp_release_json(r_vs_val, r_gval);
+    }
+    return rv;
+}


### PR DESCRIPTION
First commit for 2.3.0. 

- Library support for cSHAKE
- Added initial registration for OpenSSL 4 (copied 3.5 and added cSHAKE)
- Added testing harness for cSHAKE and OpenSSL 4