### PR TITLE
Fixes for some strict build warnings

### DIFF
--- a/app/implementations/openssl/3/iut_dsa.c
+++ b/app/implementations/openssl/3/iut_dsa.c
@@ -81,7 +81,8 @@ int app_dsa_handler(ACVP_TEST_CASE *test_case) {
     int rv = 1;
     size_t seed_len = 0, sig_len = 0;
     const char *md = NULL;
-    unsigned char *sig = NULL, *sig_iter = NULL;
+    unsigned char *sig = NULL;
+    const unsigned char *sig_iter = NULL;
     ACVP_DSA_TC *tc;
     BIGNUM *x = NULL, *y = NULL;
     BIGNUM *q = NULL, *p = NULL, *g = NULL, *r = NULL, *s = NULL, *pub_key = NULL;
@@ -363,7 +364,7 @@ int app_dsa_handler(ACVP_TEST_CASE *test_case) {
 
         /* Need to extract R and S from signature */
         sig_iter = sig; /* d2i functions alter pointer */
-        sig_obj = d2i_DSA_SIG(NULL, (const unsigned char **)&sig_iter, (long)sig_len);
+        sig_obj = d2i_DSA_SIG(NULL, &sig_iter, (long)sig_len);
         if (!sig_obj) {
             printf("Error creating signature object needed to retrieve output in ECDSA siggen\n");
             goto err;

--- a/app/implementations/openssl/3/iut_ecdsa.c
+++ b/app/implementations/openssl/3/iut_ecdsa.c
@@ -39,7 +39,8 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
     size_t sig_len = 0;
     const char *curve = NULL, *md = NULL;
     char *pub_key = NULL;
-    unsigned char *sig = NULL, *sig_iter = NULL;
+    unsigned char *sig = NULL;
+    const unsigned char *sig_iter = NULL;
     ACVP_CIPHER mode;
     ACVP_SUB_ECDSA alg;
     ACVP_ECDSA_TC *tc = NULL;
@@ -275,7 +276,7 @@ int app_ecdsa_handler(ACVP_TEST_CASE *test_case) {
             }
         }
         /* Finally, extract R and S from signature */
-        sig_obj = d2i_ECDSA_SIG(NULL, (const unsigned char **)&sig_iter, (long)sig_len);
+        sig_obj = d2i_ECDSA_SIG(NULL, &sig_iter, (long)sig_len);
         if (!sig_obj) {
             printf("Error creating signature object needed to retrieve output in ECDSA siggen\n");
             goto err;

--- a/safe_c_stub/include/safe_lib_errno.h
+++ b/safe_c_stub/include/safe_lib_errno.h
@@ -3,8 +3,8 @@
  *
  * Octobber 2008, Bo Berry
  *
- * Copyright (c) 2008-2011 by Cisco Systems, Inc
- * All rights reserved. 
+ * Copyright (c) 2008-2025 by Cisco Systems, Inc
+ * All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -32,60 +32,64 @@
 #ifndef __SAFE_LIB_ERRNO_H__
 #define __SAFE_LIB_ERRNO_H__
 #include <stddef.h>
+#include <errno.h>
 
 /*
- * CONFIGURE: If these errno codes are added to errno.h, then 
- * enable this macro
- */ 
-/* #define USING_ERRNO_H  */ 
-
-#ifdef USING_ERRNO_H
-
-#include "errno.h"
-
-#else
-
-/* 
- * Safe Lib specific errno codes.  These can be added to the errno.h file
- * if desired. 
+ * Update 2025: Previously, users could build with USING_ERRNO_H defined,
+ * and it would exclude the safeC error codes in the assumption that they
+ * were already defined in errno.h. EINVAL is always needed though, and we
+ * don't want the user to have to include headers themselves, or redefine
+ * EINVAL, so lets include errno.h and use ifndef for the error codes.
  */
-#undef  ESNULLP 
-#define ESNULLP         ( 400 )       /* null ptr                    */  
 
-#undef  ESZEROL
-#define ESZEROL         ( 401 )       /* length is zero              */  
+/*
+ * Safe Lib specific errno codes
+ */
+#ifndef  ESNULLP
+#define ESNULLP         ( 400 )       /* null ptr                    */
+#endif
 
-#undef  ESLEMIN  
-#define ESLEMIN         ( 402 )       /* length is below min         */  
+#ifndef  ESZEROL
+#define ESZEROL         ( 401 )       /* length is zero              */
+#endif
 
-#undef  ESLEMAX 
-#define ESLEMAX         ( 403 )       /* length exceeds max          */  
+#ifndef  ESLEMIN
+#define ESLEMIN         ( 402 )       /* length is below min         */
+#endif
 
-#undef  ESOVRLP 
-#define ESOVRLP         ( 404 )       /* overlap undefined           */ 
+#ifndef  ESLEMAX
+#define ESLEMAX         ( 403 )       /* length exceeds max          */
+#endif
 
-#undef  ESEMPTY 
-#define ESEMPTY         ( 405 )       /* empty string                */ 
+#ifndef  ESOVRLP
+#define ESOVRLP         ( 404 )       /* overlap ifndefined           */
+#endif
 
-#undef  ESNOSPC 
-#define ESNOSPC         ( 406 )       /* not enough space for s2     */  
+#ifndef  ESEMPTY
+#define ESEMPTY         ( 405 )       /* empty string                */
+#endif
 
-#undef  ESUNTERM 
-#define ESUNTERM        ( 407 )       /* unterminated string         */  
+#ifndef  ESNOSPC
+#define ESNOSPC         ( 406 )       /* not enough space for s2     */
+#endif
 
-#undef  ESNODIFF 
-#define ESNODIFF        ( 408 )       /* no difference               */ 
+#ifndef  ESUNTERM
+#define ESUNTERM        ( 407 )       /* unterminated string         */
+#endif
 
-#undef  ESNOTFND
-#define ESNOTFND        ( 409 )       /* not found                   */ 
+#ifndef  ESNODIFF
+#define ESNODIFF        ( 408 )       /* no difference               */
+#endif
 
-#undef  EINVAL
-#define EINVAL          ( 422 )       /* invalid                     */ 
+#ifndef  ESNOTFND
+#define ESNOTFND        ( 409 )       /* not found                   */
+#endif
 
-#endif 
+#ifndef EINVAL
+#define EINVAL          ( 422 )       /* invalid                     */
+#endif
 
-
-/* errno_t may or may not be defined in errno.h */ 
+/* errno_t may or may not be defined in errno.h */
 #ifndef errno_t
 typedef int errno_t;
 #endif
@@ -94,8 +98,8 @@ typedef int errno_t;
 typedef size_t rsize_t;
 #endif
 
-/* EOK may or may not be defined in errno.h */ 
-#ifndef EOK 
+/* EOK may or may not be defined in errno.h */
+#ifndef EOK
 #define EOK   0
 #endif
 


### PR DESCRIPTION
- Fix safeC stub headers. Currently, safeC either uses its own errno definitions, OR can be built to use errno.h, assuming that all of safeC's values had been added to errno.h. EINVAL is always going to be defined as part of errno.h, which can cause redefine issues/warnings downstream. Instead of choosing errno.h OR safeC errno codes, lets use errno.h and use ifndef to define any which are not included in errno.h.
- Fix some casting warnings in DSA and ECDSA harnesses for OpenSSL