### PR TITLE
Allow online builds without providing curl dir

### DIFF
--- a/configure
+++ b/configure
@@ -12853,13 +12853,6 @@ else $as_nop
   with_libcurldir=no
 fi
 
-
-    if test "x$libcurldir" = "x" && test "x$offline" = "x" ; then
-        { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "libcurl or libmurl directory must be set if building library for online use
-See \`config.log' for more details" "$LINENO" 5; }
-    fi
 fi
 
 # Use much more strict compile flags

--- a/configure.ac
+++ b/configure.ac
@@ -115,10 +115,6 @@ if test "x$enable_offline" = "xfalse" && test "x$disable_lib" != "xyes" ; then
         [enable support for client proxy using libcurl])],
         [libcurldir="$withval"],
         [with_libcurldir=no])
-
-    if test "x$libcurldir" = "x" && test "x$offline" = "x" ; then
-        AC_MSG_FAILURE([libcurl or libmurl directory must be set if building library for online use])
-    fi
 fi
 
 # Use much more strict compile flags


### PR DESCRIPTION
When building non-SSL harnesses, this allows use of the Distro's libcurl packages for transport code. This was enabled by the last release, but this check prevented it from working entirely.