### PR TITLE
Correct FIPS disable option in help text

### DIFF
--- a/app/app_cli.c
+++ b/app/app_cli.c
@@ -164,7 +164,7 @@ static void print_usage(int code) {
     printf("      -s <file>\n");
     printf("\n");
     printf("To request disabling FIPS for this run (may not apply to all supported modules):\n");
-    printf("      -disable_fips\n");
+    printf("      --disable_fips\n");
     printf("\n");
     printf("In addition some options are passed to acvp_app using\n");
     printf("environment variables.  The following variables can be set:\n\n");


### PR DESCRIPTION
The actual flag is `--disable_fips` instead of `-disable_fips` as described in the help text

```console
$ ./acvp_app --aes -disable_fips
unknown option: -disable_fips
Use acvp_app --help for more information.

$ ./acvp_app --aes --disable_fips

***********************************************************************************
* WARNING: You have chosen to not fetch the FIPS provider for this run. Any tests *
* created or performed during this run MUST NOT have any validation requested     *
* on it. Proceed at your own risk. Continuing in 5 seconds...                     *
***********************************************************************************
```