### PR TITLE
Fix ML-DSA internal MU tests

### DIFF
--- a/app/implementations/openssl/3/iut_ml_dsa.c
+++ b/app/implementations/openssl/3/iut_ml_dsa.c
@@ -172,6 +172,11 @@ int app_ml_dsa_handler(ACVP_TEST_CASE *test_case) {
             msg_ptr = tc->mu;
             msg_len = (size_t)tc->mu_len;
             OSSL_PARAM_BLD_push_int(pbld, OSSL_SIGNATURE_PARAM_MU, 1);
+        } else if (tc->sig_interface == ACVP_SIG_INTERFACE_INTERNAL) {
+            // M' is passed as-is; disable pure encoding so OpenSSL computes mu = SHAKE-256(tr || M', 64)
+            msg_ptr = tc->msg;
+            msg_len = (size_t)tc->msg_len;
+            OSSL_PARAM_BLD_push_int(pbld, OSSL_SIGNATURE_PARAM_MESSAGE_ENCODING, 0);
         } else {
             msg_ptr = tc->msg;
             msg_len = (size_t)tc->msg_len;
@@ -257,6 +262,11 @@ int app_ml_dsa_handler(ACVP_TEST_CASE *test_case) {
             msg_ptr = tc->mu;
             msg_len = (size_t)tc->mu_len;
             OSSL_PARAM_BLD_push_int(pbld, OSSL_SIGNATURE_PARAM_MU, 1);
+        } else if (tc->sig_interface == ACVP_SIG_INTERFACE_INTERNAL) {
+            // M' is passed as-is; disable pure encoding so OpenSSL computes mu = SHAKE-256(tr || M', 64)
+            msg_ptr = tc->msg;
+            msg_len = (size_t)tc->msg_len;
+            OSSL_PARAM_BLD_push_int(pbld, OSSL_SIGNATURE_PARAM_MESSAGE_ENCODING, 0);
         } else {
             msg_ptr = tc->msg;
             msg_len = (size_t)tc->msg_len;

--- a/app/implementations/openssl/3/registrations/fp_350.c
+++ b/app/implementations/openssl/3/registrations/fp_350.c
@@ -2467,7 +2467,7 @@ static int enable_ml_dsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_PREHASH, ACVP_SIG_PREHASH_NO);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_MU, ACVP_ML_DSA_MU_EXTERNAL);
+    rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_MU, ACVP_ML_DSA_MU_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGGEN, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_44);
     CHECK_ENABLE_CAP_RV(rv);
@@ -2486,7 +2486,7 @@ static int enable_ml_dsa(ACVP_CTX *ctx) {
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_PREHASH, ACVP_SIG_PREHASH_NO);
     CHECK_ENABLE_CAP_RV(rv);
-    rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_MU, ACVP_ML_DSA_MU_EXTERNAL);
+    rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_MU, ACVP_ML_DSA_MU_BOTH);
     CHECK_ENABLE_CAP_RV(rv);
     rv = acvp_cap_ml_dsa_set_parm(ctx, ACVP_ML_DSA_SIGVER, 0, ACVP_ML_DSA_PARAM_PARAMETER_SET, ACVP_ML_DSA_PARAM_SET_ML_DSA_44);
     CHECK_ENABLE_CAP_RV(rv);

--- a/src/acvp_ml_dsa.c
+++ b/src/acvp_ml_dsa.c
@@ -557,7 +557,9 @@ ACVP_RESULT acvp_ml_dsa_kat_handler(ACVP_CTX *ctx, JSON_Object *obj) {
                     goto err;
                 }
 
-                if (!is_deterministic) {
+            if (is_deterministic) {
+                    rnd_str = NULL;
+            } else {
                     rv = acvp_tc_json_get_string(ctx, alg_id, testobj, "rnd", &rnd_str);
                     if (rv != ACVP_SUCCESS) {
                         goto err;


### PR DESCRIPTION
This PR fixes a couple of issues with ML-DSA vectors.

The first, as described in https://github.com/cisco/libacvp/issues/963, happens when we try to use internal MU for ML-DSA. This was caused because OpenSSL was encoding the message, which it shouldn't.

The second problem was caused by the order in which test groups were executed. When reading the request JSON, setting one of the variables could be skipped, which caused it to keep the value from the previous iteration, thus producing the wrong result.

With these two fixes, we can switch mu testing from EXTERNAL to BOTH.

It was tested with:

```
acvp_app --ml_dsa
```

using OpenSSL 3.5.0.

Resolves: #963